### PR TITLE
Check ubsan

### DIFF
--- a/src/quanteda.h
+++ b/src/quanteda.h
@@ -130,29 +130,12 @@ namespace quanteda{
             unsigned int add = 0;
             unsigned int seed = 0;
             for (std::size_t i = 0; i < vec.size(); i++) {
-                add = vec[i] << (8 * i);
-                if (seed <= UINT_MAX - add) { // check if addition will overflow seed
-                    seed += add;
-                } else {
-                    return std::hash<unsigned int>()(seed);
-                }
+                seed += vec[i] * (256 ^ i);
             }
             return std::hash<unsigned int>()(seed);
         }
     };
     
-    /*
-    struct hash_ngram {
-        std::size_t operator() (const Ngram &vec) const {
-            unsigned int hash = 0;
-            hash ^= std::hash<unsigned int>()(vec[1]) + 0x9e3779b9;
-            for (std::size_t i = 1; i < vec.size(); i++) {
-                hash ^= std::hash<unsigned int>()(vec[i]) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
-            }
-            return hash;
-        }
-    };
-    */
     struct equal_ngram {
         bool operator() (const Ngram &vec1, const Ngram &vec2) const { 
             return (vec1 == vec2);

--- a/tests/testthat/test-phrases.R
+++ b/tests/testthat/test-phrases.R
@@ -36,7 +36,7 @@ test_that("test phrase for collocations", {
     colls <- textstat_collocations(toks, min_count = 1, tolower = FALSE)
     expect_equivalent(
         phrase(colls),
-        list(c("federal", "government"), c("United", "States"))
+        list(c("United", "States"), c("federal", "government"))
     )
     
     # seqs <- sequences(toks, min_count = 1)

--- a/tests/testthat/test-textmodel_wordfish.R
+++ b/tests/testthat/test-textmodel_wordfish.R
@@ -24,19 +24,19 @@ test_that("textmodel-wordfish works as expected: dense vs sparse vs sparse+mt", 
 
 test_that("print/show/summary method works as expected", {
     expect_output(
-        quanteda::print(wfm), 
+        print(wfm), 
         "^\\nCall:\\ntextmodel_wordfish\\.dfm\\(.*Dispersion.*14 documents; 5140 features\\.$"
     )
     expect_output(
-        quanteda:::print.summary.textmodel(wfs),
+        print.summary.textmodel(wfs),
         "^\\nCall:\\ntextmodel_wordfish\\.dfm\\("
     )
     expect_output(
-        quanteda:::print.summary.textmodel(wfs),
+        print.summary.textmodel(wfs),
         "Estimated Document Positions:"
     )
     expect_output(
-        quanteda:::print.summary.textmodel(wfs),
+        print.summary.textmodel(wfs),
         "Estimated Feature Scores:"        
     )
 })

--- a/tests/testthat/test-textstat_collocations.R
+++ b/tests/testthat/test-textstat_collocations.R
@@ -278,17 +278,17 @@ test_that("textstat_collocations.tokens works ok with zero-length documents (#94
 
     expect_equal(
         textstat_collocations(txt, size = 2, min_count = 2, tolower = TRUE)$collocation,
-        c("ice cream", "like good", "i like", "good ice")
+        c("good ice", "i like", "ice cream", "like good")
     )
-    ##   collocation count length   lambda        z
-    ## 1   ice cream     2      2 4.317488 2.027787
-    ## 2   like good     2      2 4.317488 2.027787
-    ## 3      i like     2      2 4.317488 2.027787
-    ## 4    good ice     2      2 4.317488 2.027787
+    ##   collocation count count_nested length   lambda        z
+    ## 1    good ice     2            0      2 4.317488 2.027787
+    ## 2      i like     2            0      2 4.317488 2.027787
+    ## 3   ice cream     2            0      2 4.317488 2.027787
+    ## 4   like good     2            0      2 4.317488 2.027787
 
     expect_equal(
         textstat_collocations(toks, size = 2, min_count = 2)$collocation,
-        c("ice cream", "like good", "i like", "good ice")
+        c("good ice", "i like", "ice cream", "like good")
     )
 })
 
@@ -351,7 +351,7 @@ test_that("textstat_collocations counts sequences correctly when recursive = FAL
     toks4 <- tokens_keep(tokens(txt4), c("a", "b", "c", "d"), padding = TRUE)
     
     col4 <- textstat_collocations(toks4, size = c(2:4), min_count = 1)
-    expect_equal(col4$collocation, c('b c', 'a b', 'c d', 'a b c d', 'a b c', 'b c d'))
+    expect_equal(col4$collocation, c('a b', 'b c', 'c d', 'a b c d', 'a b c', 'b c d'))
     expect_equal(col4$count, c(2, 2, 1, 1, 2, 1))
     expect_equal(col4$count_nested, c(2, 2, 1, 0, 1, 1))
 


### PR DESCRIPTION
I was investigating #1003 and #1200. `rhub::check_with_sanitizers()` indicated the bit shift in our hash function is causing an error. See line 6221 (or search for 'runtime error') in https://builder.r-hub.io/status/original/quanteda_1.0.0.tar.gz-9672f200479b4108a6308a4d54edcc09. The log looks very different but the location of the error is very close to the TBB error in the [CRAN UBSAN check](https://www.stats.ox.ac.uk/pub/bdr/memtests/clang-UBSAN/quanteda/quanteda-Ex.Rout). 

After modifying the hash function, the runtime error has disappeared from check. I hope the same thing to happen in CRAN check.
