### PR TITLE
added DocumentTermMatrix and TermDocumentMatrix mathos for the generic as.dfm

### DIFF
--- a/R/dfm-methods.R
+++ b/R/dfm-methods.R
@@ -122,6 +122,39 @@ as.dfm.dfmSparse <- function(x) {
     as.dfm(as(x, 'dgCMatrix'))
 }
 
+#' @noRd
+#' @method as.dfm DocumentTermMatrix
+#' @export
+#' @importFrom Matrix spareMatrix
+as.dfm.DocumentTermMatrix <- function(x){
+
+    as.dfm(
+        Matrix::sparseMatrix(
+            i = x$i, 
+            j = x$j, 
+            x = x$v, 
+            dimnames = list(seq_len(nrow(x)), colnames(x))
+        )
+    )
+    
+}
+
+#' @noRd
+#' @method as.dfm TermDocumentMatrix
+#' @export
+as.dfm.TermDocumentMatrix <- function(x){
+
+    as.dfm(
+        Matrix::sparseMatrix(
+            i = x$j, 
+            j = x$i, 
+            x = x$v, 
+            dimnames = list(seq_len(ncol(x)), rownames(x))
+        )
+    )
+    
+}
+
 as_dfm_constructor <- function(x) {
     x <- Matrix(x, sparse = TRUE) # dimnames argument is not working
     names(dimnames(x)) <- c("docs", "features")


### PR DESCRIPTION
Per https://github.com/quanteda/quanteda/issues/1222

Could not run `devtools::document()` w/o error...and thus run CRAN checks...likely because of the C level coding which I have no experience in yet (or because of running the make command on a Windows machine that doesn't have it installed):

```
> devtools::document()
Updating quanteda documentation
Loading quanteda
Re-compiling quanteda
"C:/R/R-34~1.3/bin/x64/R" --no-site-file --no-environ --no-save --no-restore --quiet CMD INSTALL  \
  "C:\Users\Tyler\GitHub\quanteda" --library="C:\Users\Tyler\AppData\Local\Temp\RtmpgtkuNn\devtools_install_25b82acc71fe"  \
  --no-R --no-data --no-help --no-demo --no-inst --no-docs --no-exec --no-multiarch --no-test-load --preclean 

* installing *source* package 'quanteda' ...
** libs
c:/Rtools/mingw_64/bin/g++  -std=gnu++11 -I"C:/R/R-34~1.3/include" -DNDEBUG -DARMA_DONT_PRINT_OPENMP_WARNING=1 -I"C:/R/R-3.4.3/library/Rcpp/include" -I"C:/R/R-3.4.3/library/RcppParallel/include" -I"C:/R/R-3.4.3/library/RcppArmadillo/include"     -DRCPP_PARALLEL_USE_TBB=1 -DARMA_64BIT_WORD=1   -O2 -Wall  -mtune=generic -c RcppExports.cpp -o RcppExports.o
c:/Rtools/mingw_64/bin/g++: not found
make: *** [RcppExports.o] Error 127
Warning: running command 'make -f "Makevars.win" -f "C:/R/R-34~1.3/etc/x64/Makeconf" -f "C:/R/R-34~1.3/share/make/winshlib.mk" CXX='$(CXX11) $(CXX11STD)' CXXFLAGS='$(CXX11FLAGS)' CXXPICFLAGS='$(CXX11PICFLAGS)' SHLIB_LDFLAGS='$(SHLIB_CXX11LDFLAGS)' SHLIB_LD='$(SHLIB_CXX11LD)' SHLIB="quanteda.dll" WIN=64 TCLBIN=64 OBJECTS="RcppExports.o ca_mt.o collocations_mt_.o dist_mt.o fcm_mt.o kwic_mt.o tokens_compound_mt.o tokens_lookup_mt.o tokens_ngrams_mt.o tokens_recompile_mt.o tokens_segment_mt.o tokens_select_mt.o utility.o wordfish_dense.o wordfish_mt.o"' had status 2
ERROR: compilation failed for package 'quanteda'
* removing 'C:/Users/Tyler/AppData/Local/Temp/RtmpgtkuNn/devtools_install_25b82acc71fe/quanteda'
In R CMD INSTALL
```