### PR TITLE
Issue 1229

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 ### New Features
 
 * Added `as.dfm()` methods for **tm** `DocumentTermMatrix` and `TermDocumentMatrix` objects. (#1222)
+* `predict.textmodel_wordscores()` nows includes an `include_reftexts` argument to exclude training texts from the predicted model object (#1229).  The default behaviour is `include_reftexts = TRUE`, producing the same behaviour as existed before the introduction of this argument.  This allows rescaling based on the reference documents (since rescaling requires prediction on the reference documents) but provides an easy way to exclude the reference documents from the predicted quantities.
 
 ### Bug fixes and stability enhancements
 

--- a/R/textmodel_wordscores.R
+++ b/R/textmodel_wordscores.R
@@ -146,99 +146,104 @@ predict.textmodel_wordscores <- function(object,
                                          rescaling = c("none", "lbg", "mv"),
                                          include_reftexts = TRUE,
                                          ...) {
-  
-  if (length(list(...)) > 0) stop("Arguments:", names(list(...)), "not supported.\n")
-  
-  interval <- match.arg(interval)
-  rescaling <- match.arg(rescaling)
-  
-  if (!is.null(newdata)) {
-    data <- as.dfm(newdata)
-  } else {
-    data <- as.dfm(object$x)
-  }
-  
-  if (!include_reftexts) {
-    data <- dfm_subset(data, is.na(object$y))
-  }
-  
-  # Compute text scores as weighted mean of word scores in "virgin" document
-  sw <- coef(object)
-  data <- dfm_select(data, as.dfm(rbind(sw)))
-  # This is different from computing term weights on only the scorable words.
-  # It take rowSums() only to generates named vector.
-  sw <- sw[intersect(featnames(data), names(sw))]
-  raw <- rowSums(dfm_weight(data, "prop") %*% sw)
-  
-  # if (verbose)
-  #    catm(sprintf('%d of %d features (%.2f%%) can be scored\n\n', 
-  #         length(sw), nfeat(data), 100 * length(sw) / nfeat(data)))
-  
-  if (rescaling == "mv") {
-    if (sum(!is.na(object$y)) > 2)
-      warning("More than two reference scores found with MV rescaling; using only min, max values.")
-    fit <- mv_transform(raw, object$y, raw)
-  } else if (rescaling == "lbg") {
-    lbg_sdr <- stats::sd(object$y, na.rm = TRUE)
-    lbg_sv <- mean(raw, na.rm = TRUE)
-    lbg_sdv <- if (length(raw) < 2L) 0 else stats::sd(raw)
-    lbg_mult <- if (lbg_sdr == 0) 0 else lbg_sdr / lbg_sdv
-    fit <- (raw - lbg_sv) * lbg_mult + lbg_sv
-  } else {
-    fit <- raw
-  }
-  
-  if (!se.fit && interval == "none") {
-    class(fit) <- c("predict.textmodel_wordscores", "numeric")
-    return(fit)
-  }
-  
-  # Compute standard error
-  raw_se <- rep(NA, length(raw))
-  fwv <- dfm_weight(data, "prop")
-  for (i in seq_along(raw_se))
-    raw_se[i] <- sqrt(sum(as.numeric(fwv[i,]) * (raw[i] - sw) ^ 2)) / sqrt(rowSums(data)[[i]])
-  
-  result <- list(fit = fit)
-  if (se.fit) {
-    if (rescaling == "mv") {
-      z <- stats::qnorm(1 - (1 - level) / 2)
-      upr <- mv_transform(raw + z * raw_se, object$y, raw)
-      result$se.fit <- (upr - result$fit) / z
-    } else if (rescaling == "lbg") {
-      result$se.fit <- (raw_se - lbg_sv) * lbg_mult + lbg_sv
-    } else {
-      result$se.fit <- raw_se
-    }
-  } 
-  
-  if (interval == "confidence") {
-    # make fit into a matrix
-    result$fit <- matrix(result$fit, ncol = 3, nrow = length(result$fit),
-                         dimnames = list(names(result$fit), c("fit", "lwr", "upr")))
     
-    # Compute confidence intervals
-    z <- stats::qnorm(1 - (1 - level) / 2)
-    raw <- unname(raw)
+    if (length(list(...)) > 0) stop("Arguments: ", names(list(...)), " not supported.\n")
+    
+    interval <- match.arg(interval)
+    rescaling <- match.arg(rescaling)
+    
+    if (!is.null(newdata)) {
+        data <- as.dfm(newdata)
+    } else {
+        data <- as.dfm(object$x)
+    }
+    
+    # Compute text scores as weighted mean of word scores in "virgin" document
+    sw <- coef(object)
+    data <- dfm_select(data, as.dfm(rbind(sw)))
+    # This is different from computing term weights on only the scorable words.
+    # It take rowSums() only to generates named vector.
+    sw <- sw[intersect(featnames(data), names(sw))]
+    raw <- rowSums(dfm_weight(data, "prop") %*% sw)
+    
+    # if (verbose)
+    #    catm(sprintf('%d of %d features (%.2f%%) can be scored\n\n', 
+    #         length(sw), nfeat(data), 100 * length(sw) / nfeat(data)))
     
     if (rescaling == "mv") {
-      result$fit[, "lwr"] <- mv_transform(raw - z * raw_se, object$y, raw)
-      result$fit[, "upr"] <- mv_transform(raw + z * raw_se, object$y, raw)
+        if (sum(!is.na(object$y)) > 2)
+            warning("More than two reference scores found with MV rescaling; using only min, max values.")
+        fit <- mv_transform(raw, object$y, raw)
     } else if (rescaling == "lbg") {
-      if (lbg_mult == 0) {
-        result$fit[, "lwr"] <- raw - z * raw_se
-        result$fit[, "upr"] <- raw + z * raw_se
-      } else {
-        result$fit[, "lwr"] <- ((raw - z * raw_se) - lbg_sv) * lbg_mult + lbg_sv
-        result$fit[, "upr"] <- ((raw + z * raw_se) - lbg_sv) * lbg_mult + lbg_sv
-      }
+        lbg_sdr <- stats::sd(object$y, na.rm = TRUE)
+        lbg_sv <- mean(raw, na.rm = TRUE)
+        lbg_sdv <- if (length(raw) < 2L) 0 else stats::sd(raw)
+        lbg_mult <- if (lbg_sdr == 0) 0 else lbg_sdr / lbg_sdv
+        fit <- (raw - lbg_sv) * lbg_mult + lbg_sv
     } else {
-      result$fit[, "lwr"] <- raw - z * raw_se
-      result$fit[, "upr"] <- raw + z * raw_se
+        fit <- raw
     }
-  }
-  class(result) <- c("predict.textmodel_wordscores", class(result))
-  result
+    
+    if (!se.fit && interval == "none") {
+        if (!include_reftexts) fit <- fit[is.na(object$y)]
+        class(fit) <- c("predict.textmodel_wordscores", "numeric")
+        return(fit)
+    }
+    
+    # Compute standard error
+    raw_se <- rep(NA, length(raw))
+    fwv <- dfm_weight(data, "prop")
+    for (i in seq_along(raw_se))
+        raw_se[i] <- sqrt(sum(as.numeric(fwv[i,]) * (raw[i] - sw) ^ 2)) / sqrt(rowSums(data)[[i]])
+    
+    result <- list(fit = fit)
+    if (se.fit) {
+        if (rescaling == "mv") {
+            z <- stats::qnorm(1 - (1 - level) / 2)
+            upr <- mv_transform(raw + z * raw_se, object$y, raw)
+            result$se.fit <- (upr - result$fit) / z
+        } else if (rescaling == "lbg") {
+            result$se.fit <- (raw_se - lbg_sv) * lbg_mult + lbg_sv
+        } else {
+            result$se.fit <- raw_se
+        }
+        
+        if (!include_reftexts) result$se.fit <- result$se.fit[is.na(object$y)]
+    } 
+    
+    if (interval == "confidence") {
+        # make fit into a matrix
+        result$fit <- matrix(result$fit, ncol = 3, nrow = length(result$fit),
+                             dimnames = list(names(result$fit), c("fit", "lwr", "upr")))
+        
+        # Compute confidence intervals
+        z <- stats::qnorm(1 - (1 - level) / 2)
+        raw <- unname(raw)
+        
+        if (rescaling == "mv") {
+            result$fit[, "lwr"] <- mv_transform(raw - z * raw_se, object$y, raw)
+            result$fit[, "upr"] <- mv_transform(raw + z * raw_se, object$y, raw)
+        } else if (rescaling == "lbg") {
+            if (lbg_mult == 0) {
+                result$fit[, "lwr"] <- raw - z * raw_se
+                result$fit[, "upr"] <- raw + z * raw_se
+            } else {
+                result$fit[, "lwr"] <- ((raw - z * raw_se) - lbg_sv) * lbg_mult + lbg_sv
+                result$fit[, "upr"] <- ((raw + z * raw_se) - lbg_sv) * lbg_mult + lbg_sv
+            }
+        } else {
+            result$fit[, "lwr"] <- raw - z * raw_se
+            result$fit[, "upr"] <- raw + z * raw_se
+        }
+    } 
+    
+    # drop the reference texts if needed - handles both vector and matrix case 
+    if (!include_reftexts) {
+        result$fit <- as.matrix(result$fit)[is.na(object$y), , drop = interval == "none"]
+    }
+    
+    class(result) <- c("predict.textmodel_wordscores", class(result))
+    result
 }
 
 # internal methods -----------

--- a/man/predict.textmodel_wordscores.Rd
+++ b/man/predict.textmodel_wordscores.Rd
@@ -6,7 +6,7 @@
 \usage{
 \method{predict}{textmodel_wordscores}(object, newdata = NULL,
   se.fit = FALSE, interval = c("none", "confidence"), level = 0.95,
-  rescaling = c("none", "lbg", "mv"), ...)
+  rescaling = c("none", "lbg", "mv"), include_reftexts = TRUE, ...)
 }
 \arguments{
 \item{object}{a fitted Wordscores textmodel}
@@ -22,6 +22,8 @@
 \item{rescaling}{\code{"none"} for "raw" scores; \code{"lbg"} for LBG (2003) 
 rescaling; or \code{"mv"} for the rescaling proposed by Martin and Vanberg 
 (2007).  See References.}
+
+\item{include_reftexts}{if \code{FALSE}, reference texts are removed from the prediction}
 
 \item{...}{not used}
 }

--- a/man/textmodel_wordscores.Rd
+++ b/man/textmodel_wordscores.Rd
@@ -40,6 +40,7 @@ The \code{textmodel_wordscores()} function and the associated
 summary(ws)
 coef(ws)
 predict(ws)
+predict(ws, include_reftexts = FALSE)
 predict(ws, rescaling = "mv")
 predict(ws, rescaling = "lbg")
 predict(ws, se.fit = TRUE)

--- a/tests/testthat/test-textmodel_wordscores.R
+++ b/tests/testthat/test-textmodel_wordscores.R
@@ -48,11 +48,34 @@ test_that("coef works for wordscores fitted", {
     expect_equal(coef(ws), coefficients(ws))
 })
 
-test_that("test wordscores prediction when reference texts are excluded", {
+test_that("test wordscores prediction without reftexts", {
     y <- c(seq(-1.5, 1.5, .75), NA)
     ws <- textmodel_wordscores(data_dfm_lbgexample, y)
     ws_predict <- predict(ws, include_reftexts = FALSE)
     expect_equal(length(ws_predict), 1)
+})
+
+test_that("test wordscores predict output without reftexts, standard errors and intervals", {
+    y <- c(seq(-1.5, 1.5, .75), NA)
+    ws <- textmodel_wordscores(data_dfm_lbgexample, y)
+    ws_predict <- predict(ws, include_reftexts = FALSE, se.fit = FALSE, interval = "none")
+    expect_equal(length(ws_predict), 1)
+})
+
+test_that("test wordscores predict output without reftexts and interval, but with standard error", {
+    y <- c(seq(-1.5, 1.5, .75), NA)
+    ws <- textmodel_wordscores(data_dfm_lbgexample, y)
+    ws_predict <- predict(ws, include_reftexts = FALSE, se.fit = TRUE, interval = "none")
+    expect_equal(length(ws_predict), 2)
+    expect_true(!is.null(ws_predict$se.fit))
+})
+
+test_that("test wordscores predict output without reftexts, but with standard error and confidence interval", {
+    y <- c(seq(-1.5, 1.5, .75), NA)
+    ws <- textmodel_wordscores(data_dfm_lbgexample, y)
+    ws_predict <- predict(ws, include_reftexts = FALSE, se.fit = TRUE, interval = "confidence")
+    expect_equal(length(ws_predict$fit), 3)
+    expect_true(!is.null(ws_predict$se.fit))
 })
 
 # test_that("coef works for wordscores predicted, rescaling = none", {

--- a/tests/testthat/test-textmodel_wordscores.R
+++ b/tests/testthat/test-textmodel_wordscores.R
@@ -48,6 +48,13 @@ test_that("coef works for wordscores fitted", {
     expect_equal(coef(ws), coefficients(ws))
 })
 
+test_that("test wordscores prediction when reference texts are excluded", {
+  y <- c(seq(-1.5, 1.5, .75), NA)
+  ws <- textmodel_wordscores(data_dfm_lbgexample, y)
+  ws_predict <- predict(ws, include_reftexts = FALSE)
+  expect_equal(length(ws_predict), 1)
+})
+
 # test_that("coef works for wordscores predicted, rescaling = none", {
 #     ws <- textmodel_wordscores(data_dfm_lbgexample, c(seq(-1.5, 1.5, .75), NA))
 #     pr <- predict(ws, rescaling = "none")

--- a/tests/testthat/test-textmodel_wordscores.R
+++ b/tests/testthat/test-textmodel_wordscores.R
@@ -78,6 +78,46 @@ test_that("test wordscores predict output without reftexts, but with standard er
     expect_true(!is.null(ws_predict$se.fit))
 })
 
+test_that("test wordscores predict is same for virgin texts with and without ref texts", {
+    y <- c(seq(-1.5, 1.5, .75), NA)
+    ws <- textmodel_wordscores(data_dfm_lbgexample, y)
+    
+    expect_equal(
+        predict(ws, include_reftexts = FALSE)["V1"],
+        predict(ws, include_reftexts = TRUE)["V1"]
+    )
+    expect_equal(
+        suppressWarnings(predict(ws, include_reftexts = FALSE, rescaling = "mv")["V1"]),
+        suppressWarnings(predict(ws, include_reftexts = TRUE, rescaling = "mv")["V1"])
+    )
+    expect_equal(
+        suppressWarnings(predict(ws, include_reftexts = FALSE, rescaling = "lbg")["V1"]),
+        suppressWarnings(predict(ws, include_reftexts = TRUE, rescaling = "lbg")["V1"])
+    )
+    
+    expect_equal(
+        predict(ws, include_reftexts = FALSE, se.fit = TRUE)["V1"],
+        predict(ws, include_reftexts = TRUE, se.fit = TRUE)["V1"]
+    )
+    expect_equal(
+        predict(ws, include_reftexts = FALSE, interval = "confidence", se.fit = TRUE)$fit["V1", , drop = FALSE],
+        predict(ws, include_reftexts = TRUE, interval = "confidence", se.fit = TRUE)$fit["V1", , drop = FALSE]
+    )
+    expect_equal(
+        predict(ws, include_reftexts = FALSE, interval = "confidence", 
+                se.fit = TRUE)$se.fit,
+        predict(ws, include_reftexts = TRUE, interval = "confidence", 
+                se.fit = TRUE)$se.fit[which(docnames(ws) == "V1")]
+    )
+    expect_equal(
+        predict(ws, include_reftexts = FALSE, interval = "confidence", 
+                rescaling = "lbg", se.fit = TRUE)$se.fit,
+        predict(ws, include_reftexts = TRUE, interval = "confidence", 
+                rescaling = "lbg", se.fit = TRUE)$se.fit[which(docnames(ws) == "V1")]
+    )
+})
+
+
 # test_that("coef works for wordscores predicted, rescaling = none", {
 #     ws <- textmodel_wordscores(data_dfm_lbgexample, c(seq(-1.5, 1.5, .75), NA))
 #     pr <- predict(ws, rescaling = "none")

--- a/tests/testthat/test-textmodel_wordscores.R
+++ b/tests/testthat/test-textmodel_wordscores.R
@@ -49,10 +49,10 @@ test_that("coef works for wordscores fitted", {
 })
 
 test_that("test wordscores prediction when reference texts are excluded", {
-  y <- c(seq(-1.5, 1.5, .75), NA)
-  ws <- textmodel_wordscores(data_dfm_lbgexample, y)
-  ws_predict <- predict(ws, include_reftexts = FALSE)
-  expect_equal(length(ws_predict), 1)
+    y <- c(seq(-1.5, 1.5, .75), NA)
+    ws <- textmodel_wordscores(data_dfm_lbgexample, y)
+    ws_predict <- predict(ws, include_reftexts = FALSE)
+    expect_equal(length(ws_predict), 1)
 })
 
 # test_that("coef works for wordscores predicted, rescaling = none", {


### PR DESCRIPTION
Following the discussion in #1229, I added the option `include_reftexts` to `predict.textmodel_wordscores()` which has `TRUE` as the default.