### PR TITLE
Fix #1232 corpus() for dplyr grouped data.frame objects

### DIFF
--- a/R/corpus.R
+++ b/R/corpus.R
@@ -257,6 +257,9 @@ corpus.data.frame <- function(x, docid_field = NULL, text_field = "text",
 
     args <- list(...)
 
+    # coerce data.frame variants to data.frame - for #1232
+    x <- as.data.frame(x)
+    
     # text field
     if (length(text_field) != 1)
         stop("text_field must refer to a single column")

--- a/tests/testthat/test-corpus.R
+++ b/tests/testthat/test-corpus.R
@@ -316,3 +316,19 @@ test_that("print.summary.corpus work", {
         "^\\s+Types Tokens\\n1\\s+625\\s+1538"
     )
 })
+
+test_that("corpus works on dplyr grouped data.frames (#1232)", {
+    skip_if_not_installed("dplyr")
+    mydf_grouped <- 
+        data.frame(letter_factor = factor(rep(letters[1:3], each = 2)),
+                   some_ints = 1L:6L,
+                   text = paste0("This is text number ", 1:6, "."),
+                   stringsAsFactors = FALSE,
+                   row.names = paste0("fromDf_", 1:6)) %>%
+        dplyr::group_by(letter_factor) %>% 
+        dplyr::mutate(n_group = n())
+    expect_output(
+        quanteda::print(corpus(mydf_grouped)),
+        "^Corpus consisting of 6 documents and 3 docvars\\.$"
+    )
+})


### PR DESCRIPTION
To make corpus.data.frame() work with tibbles, grouped data.frames, etc.

Closes #1232.