### PR TITLE
Improve as.data.frame.dfm() method

### DIFF
--- a/R/dfm-classes.R
+++ b/R/dfm-classes.R
@@ -121,8 +121,7 @@ setMethod("+", signature(e1 = "numeric", e2 = "dfm"),
 #' @method as.matrix dfm
 #' @examples
 #' # coercion to matrix
-#' mydfm <- dfm(data_corpus_inaugural)
-#' str(as.matrix(mydfm))
+#' as.matrix(data_dfm_lbgexample[, 1:10])
 #' 
 as.matrix.dfm <- function(x, ...) {
     as(x, "matrix")
@@ -131,19 +130,23 @@ as.matrix.dfm <- function(x, ...) {
 #           function(x) as(x, "matrix"))
 
 #' @rdname as.matrix.dfm
-#' @param row.names if \code{FALSE}, do not set the row names of the data.frame
-#'   to the docnames of the dfm (default); or a vector of values to which the
-#'   row names will be set.
+#' @param document optional first column of mode \code{character} in the
+#'   data.frame, defaults \code{docnames(x)}.  Set to \code{NULL} to exclude.
+#' @inheritParams base::as.data.frame row.names
 #' @param ... unused
 #' @method as.data.frame dfm
 #' @export
 #' @examples
 #' # coercion to a data.frame
-#' inaugDfm <- dfm(data_corpus_inaugural[1:5])
-#' as.data.frame(inaugDfm[, 1:10])
-#' as.data.frame(inaugDfm[, 1:10], row.names = FALSE)
-as.data.frame.dfm <- function(x, row.names = NULL, ...) {
-    as.data.frame(as.matrix(x), row.names = row.names, ...)
+#' as.data.frame(data_dfm_lbgexample[, 1:15])
+#' as.data.frame(data_dfm_lbgexample[, 1:15], document = NULL)
+#' as.data.frame(data_dfm_lbgexample[, 1:15], document = NULL, row.names = docnames(x))
+as.data.frame.dfm <- function(x, document = docnames(x), row.names = NULL, ...) {
+    if (!(is.character(document) || is.null(document)))
+        stop("document must be character or NULL")
+    df <- data.frame(as.matrix(x), row.names = row.names)
+    if (!is.null(document)) df <- cbind(document, df, stringsAsFactors = FALSE)
+    df
 }
 
 

--- a/R/dfm-classes.R
+++ b/R/dfm-classes.R
@@ -132,7 +132,7 @@ as.matrix.dfm <- function(x, ...) {
 #' @rdname as.matrix.dfm
 #' @param document optional first column of mode \code{character} in the
 #'   data.frame, defaults \code{docnames(x)}.  Set to \code{NULL} to exclude.
-#' @inheritParams base::as.data.frame row.names
+#' @inheritParams base::as.data.frame
 #' @param ... unused
 #' @method as.data.frame dfm
 #' @export
@@ -140,8 +140,9 @@ as.matrix.dfm <- function(x, ...) {
 #' # coercion to a data.frame
 #' as.data.frame(data_dfm_lbgexample[, 1:15])
 #' as.data.frame(data_dfm_lbgexample[, 1:15], document = NULL)
-#' as.data.frame(data_dfm_lbgexample[, 1:15], document = NULL, row.names = docnames(x))
-as.data.frame.dfm <- function(x, document = docnames(x), row.names = NULL, ...) {
+#' as.data.frame(data_dfm_lbgexample[, 1:15], document = NULL, 
+#'               row.names = docnames(data_dfm_lbgexample))
+as.data.frame.dfm <- function(x, row.names = NULL, ..., document = docnames(x)) {
     if (!(is.character(document) || is.null(document)))
         stop("document must be character or NULL")
     df <- data.frame(as.matrix(x), row.names = row.names)

--- a/man/as.matrix.dfm.Rd
+++ b/man/as.matrix.dfm.Rd
@@ -7,13 +7,16 @@
 \usage{
 \method{as.matrix}{dfm}(x, ...)
 
-\method{as.data.frame}{dfm}(x, document = docnames(x), row.names = NULL,
-  ...)
+\method{as.data.frame}{dfm}(x, row.names = NULL, ...,
+  document = docnames(x))
 }
 \arguments{
 \item{x}{dfm to be coerced}
 
 \item{...}{unused}
+
+\item{row.names}{\code{NULL} or a character vector giving the row
+    names for the data frame.  Missing values are not allowed.}
 
 \item{document}{optional first column of mode \code{character} in the
 data.frame, defaults \code{docnames(x)}.  Set to \code{NULL} to exclude.}
@@ -28,6 +31,7 @@ as.matrix(data_dfm_lbgexample[, 1:10])
 # coercion to a data.frame
 as.data.frame(data_dfm_lbgexample[, 1:15])
 as.data.frame(data_dfm_lbgexample[, 1:15], document = NULL)
-as.data.frame(data_dfm_lbgexample[, 1:15], document = NULL, row.names = docnames(x))
+as.data.frame(data_dfm_lbgexample[, 1:15], document = NULL, 
+              row.names = docnames(data_dfm_lbgexample))
 }
 \keyword{dfm}

--- a/man/as.matrix.dfm.Rd
+++ b/man/as.matrix.dfm.Rd
@@ -7,28 +7,27 @@
 \usage{
 \method{as.matrix}{dfm}(x, ...)
 
-\method{as.data.frame}{dfm}(x, row.names = NULL, ...)
+\method{as.data.frame}{dfm}(x, document = docnames(x), row.names = NULL,
+  ...)
 }
 \arguments{
 \item{x}{dfm to be coerced}
 
 \item{...}{unused}
 
-\item{row.names}{if \code{FALSE}, do not set the row names of the data.frame
-to the docnames of the dfm (default); or a vector of values to which the
-row names will be set.}
+\item{document}{optional first column of mode \code{character} in the
+data.frame, defaults \code{docnames(x)}.  Set to \code{NULL} to exclude.}
 }
 \description{
 Methods for coercing a \link{dfm} object to a matrix or data.frame object.
 }
 \examples{
 # coercion to matrix
-mydfm <- dfm(data_corpus_inaugural)
-str(as.matrix(mydfm))
+as.matrix(data_dfm_lbgexample[, 1:10])
 
 # coercion to a data.frame
-inaugDfm <- dfm(data_corpus_inaugural[1:5])
-as.data.frame(inaugDfm[, 1:10])
-as.data.frame(inaugDfm[, 1:10], row.names = FALSE)
+as.data.frame(data_dfm_lbgexample[, 1:15])
+as.data.frame(data_dfm_lbgexample[, 1:15], document = NULL)
+as.data.frame(data_dfm_lbgexample[, 1:15], document = NULL, row.names = docnames(x))
 }
 \keyword{dfm}

--- a/tests/testthat/test-as.dfm.R
+++ b/tests/testthat/test-as.dfm.R
@@ -97,3 +97,36 @@ test_that("as.dfm for tm matrix objects", {
     )
 })
 
+test_that("as.data.frame for dfm objects", {
+    d <- data_dfm_lbgexample[, 1:5]
+    expect_equal(
+        as.data.frame(d),
+        data.frame(document = docnames(d), as.matrix(d), stringsAsFactors = FALSE, row.names = NULL)
+    )
+    expect_equal(
+        as.data.frame(d, document = NULL),
+        data.frame(as.matrix(d), stringsAsFactors = FALSE, row.names = NULL)
+    )
+    expect_equal(
+        as.data.frame(d, row.names = docnames(d)),
+        data.frame(document = docnames(d), as.matrix(d), stringsAsFactors = FALSE, row.names = docnames(d))
+    )
+    expect_error(
+        as.data.frame(d, document = TRUE),
+        "document must be character or NULL"
+    )
+})
+
+test_that("as.matrix for dfm objects", {
+    d <- data_dfm_lbgexample[1:2, 1:5]
+    expect_equal(
+        as.matrix(d),
+        matrix(c(2, 0, 3, 0, 10, 0, 22, 0, 45, 0), nrow = ndoc(d), 
+               dimnames = list(docs = c("R1", "R2"), features = LETTERS[1:5]))
+    )
+    expect_equal(
+        as.matrix(d[1, ]),
+        matrix(c(2, 3, 10, 22, 45), nrow = 1,
+               dimnames = list(docs = c("R1"), features = LETTERS[1:5]))
+    )
+})

--- a/tests/testthat/test-textstat_keyness.R
+++ b/tests/testthat/test-textstat_keyness.R
@@ -231,13 +231,13 @@ test_that("textstat_keyness returns raw frequency counts", {
                    d2 = "a a b c c d d d d e f h"))
     
     expect_equivalent(textstat_keyness(mydfm, measure = "chi2", sort = FALSE)[,c(4,5)], 
-                      as.data.frame(t(mydfm)))
+                      as.data.frame(t(mydfm), document = NULL))
     
     expect_equivalent(textstat_keyness(mydfm, measure = "exact", sort = FALSE)[,c(4,5)], 
-                      as.data.frame(t(mydfm)))
+                      as.data.frame(t(mydfm), document = NULL))
     
     expect_equivalent(textstat_keyness(mydfm, measure = "lr", sort = FALSE)[,c(4,5)], 
-                      as.data.frame(t(mydfm)))
+                      as.data.frame(t(mydfm), document = NULL))
     
 })
 


### PR DESCRIPTION
Makes default the creation of a column called "document" and drops the rownames.

Solves #1212.

From `devtools::revdep_check()`:
```r
Checked politeness    : 1 error  | 0 warnings | 0 notes
```

Needs to be investigated.

New behaviour:
```r
as.data.frame(data_dfm_lbgexample[, 1:15])
#   document A B  C  D  E  F   G   H   I   J   K   L   M   N   O
# 1       R1 2 3 10 22 45 78 115 146 158 146 115  78  45  22  10
# 2       R2 0 0  0  0  0  2   3  10  22  45  78 115 146 158 146
# 3       R3 0 0  0  0  0  0   0   0   0   0   2   3  10  22  45
# 4       R4 0 0  0  0  0  0   0   0   0   0   0   0   0   0   0
# 5       R5 0 0  0  0  0  0   0   0   0   0   0   0   0   0   0
# 6       V1 0 0  0  0  0  0   0   2   3  10  22  45  78 115 146
```
