### PR TITLE
Improve stability of dfm_trim()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: quanteda
-Version: 1.0.4
+Version: 1.0.5
 Title: Quantitative Analysis of Textual Data
 Description: A fast, flexible, and comprehensive framework for 
     quantitative text analysis in R.  Provides functionality for corpus management,

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@
 
 * Eliminated unnecessary dependency on the **digest** package.
 * Updated the vignette title to be less generic.
+* Improved the robustness of `dfm_trim()` and `dfm_weight()` for previously weighted dfm objects and when supplied thresholds are proportions instead of counts.  (#1237)
 
 ### Performance improvements
 

--- a/R/dfm_weight.R
+++ b/R/dfm_weight.R
@@ -325,8 +325,8 @@ docfreq.dfm <- function(x, scheme = c("count", "inverse", "inversemax",
         warning("smoothing not used for this scheme")
     if (k < 0)
         stop("k must be >= 0")
-    if (x@weightDf[["scheme"]] != "unary")
-        stop("this dfm has already been term weighted as:", x@weightDf)
+    # if (x@weightDf[["scheme"]] != "unary")
+    #     stop("this dfm has already been term weighted as: ", x@weightDf[[1]])
     
     if (scheme == "unary") {
         result <- rep(1, nfeat(x))

--- a/tests/testthat/test-dfm_trim.R
+++ b/tests/testthat/test-dfm_trim.R
@@ -85,4 +85,24 @@ test_that("dfm_trim works with min_count larger than total number (#1181)", {
 
 })
 
-
+test_that("dfm_trim works on previously weighted dfms (#1237)", {
+    dfm1 <- dfm(c("the quick brown fox jumps over the lazy dog", 
+                  "the quick brown foxy ox jumps over the lazy god"))
+    dfm2 <- dfm_tfidf(dfm1)
+    expect_equal(
+        dfm_trim(dfm2, min_count = 0, min_docfreq = .5) %>% as.matrix(),
+        matrix(c(.30103, 0, .30103, 0, 0, .30103, 0, .30103, 0, .30103), nrow = 2,
+               dimnames = list(docs = c("text1", "text2"), 
+                               features = c("fox", "dog", "foxy", "ox", "god"))),
+        tol = .0001
+    )
+    expect_warning(
+        dfm_trim(dfm2, min_docfreq = .5),
+        "dfm has been previously weighted; consider changing default min_count"
+    )    
+    expect_silent(dfm_trim(dfm2, min_count = 1, min_docfreq = .5))
+    expect_equal(
+        dim(dfm_trim(dfm2, min_count = 1, min_docfreq = .5)),
+        c(2, 0)
+    )
+})

--- a/tests/testthat/test-dfm_weight.R
+++ b/tests/testthat/test-dfm_weight.R
@@ -273,3 +273,12 @@ test_that("deprecated dfm_weight argument values still work", {
     
 })
 
+test_that("docfreq works previously a weighted dfm (#1237)", {
+    df1 <- dfm(data_dfm_lbgexample) %>% dfm_tfidf(scheme_tf = "prop")
+    computed <- c(rep(1, 5), 2, 2, 3, 3, 3, 4)
+    names(computed) <- letters[1:11]
+    expect_equal(
+        docfreq(df1)[1:11],
+        computed
+    )
+})


### PR DESCRIPTION
- fixes docfreq() to work even for weighted dfm objects.
- adds warning for leaving min_count default at 1 when using fractional docfreq values
- improves stability.

Addresses #1237.

Still leaves some behaviours that may be unexpected by some users, when trimming a weighted dfm with fractional values, or supplying partially fractional values as arguments. Related to #1181.