### PR TITLE
Solves #1245

### DIFF
--- a/R/dfm-classes.R
+++ b/R/dfm-classes.R
@@ -133,6 +133,7 @@ as.matrix.dfm <- function(x, ...) {
 #' @param document optional first column of mode \code{character} in the
 #'   data.frame, defaults \code{docnames(x)}.  Set to \code{NULL} to exclude.
 #' @inheritParams base::as.data.frame
+#' @inheritParams base::data.frame
 #' @param ... unused
 #' @method as.data.frame dfm
 #' @export
@@ -142,10 +143,12 @@ as.matrix.dfm <- function(x, ...) {
 #' as.data.frame(data_dfm_lbgexample[, 1:15], document = NULL)
 #' as.data.frame(data_dfm_lbgexample[, 1:15], document = NULL, 
 #'               row.names = docnames(data_dfm_lbgexample))
-as.data.frame.dfm <- function(x, row.names = NULL, ..., document = docnames(x)) {
+as.data.frame.dfm <- function(x, row.names = NULL, ..., document = docnames(x),
+                              check.names = FALSE) {
     if (!(is.character(document) || is.null(document)))
         stop("document must be character or NULL")
-    df <- data.frame(as.matrix(x), row.names = row.names)
+    df <- data.frame(as.matrix(x), row.names = row.names, 
+                     check.names = check.names)
     if (!is.null(document)) df <- cbind(document, df, stringsAsFactors = FALSE)
     df
 }

--- a/man/as.matrix.dfm.Rd
+++ b/man/as.matrix.dfm.Rd
@@ -8,7 +8,7 @@
 \method{as.matrix}{dfm}(x, ...)
 
 \method{as.data.frame}{dfm}(x, row.names = NULL, ...,
-  document = docnames(x))
+  document = docnames(x), check.names = FALSE)
 }
 \arguments{
 \item{x}{dfm to be coerced}
@@ -20,6 +20,12 @@
 
 \item{document}{optional first column of mode \code{character} in the
 data.frame, defaults \code{docnames(x)}.  Set to \code{NULL} to exclude.}
+
+\item{check.names}{logical.  If \code{TRUE} then the names of the
+    variables in the data frame are checked to ensure that they are
+    syntactically valid variable names and are not duplicated.
+    If necessary they are adjusted (by \code{\link{make.names}})
+    so that they are.}
 }
 \description{
 Methods for coercing a \link{dfm} object to a matrix or data.frame object.

--- a/tests/testthat/test-as.dfm.R
+++ b/tests/testthat/test-as.dfm.R
@@ -117,6 +117,20 @@ test_that("as.data.frame for dfm objects", {
     )
 })
 
+test_that("as.data.frame.dfm handles irregular feature names correctly", {
+    mydfm <- dfm(data_char_sampletext, 
+                 dictionary = dictionary(list("字" = "a", "spe cial" = "the", 
+                                              "飛機" = "if", "spec+ial" = "of")))
+    expect_equal(
+        names(as.data.frame(mydfm)),
+        c("document", "字", "spe cial", "飛機", "spec+ial")
+    )
+    expect_equal(
+        names(as.data.frame(mydfm, check.names = TRUE)),
+        c("document", "字", "spe.cial", "飛機", "spec.ial")
+    )
+})
+
 test_that("as.matrix for dfm objects", {
     d <- data_dfm_lbgexample[1:2, 1:5]
     expect_equal(

--- a/tests/testthat/test-as.dfm.R
+++ b/tests/testthat/test-as.dfm.R
@@ -118,6 +118,8 @@ test_that("as.data.frame for dfm objects", {
 })
 
 test_that("as.data.frame.dfm handles irregular feature names correctly", {
+    skip_on_os("windows")
+    skip_on_appveyor()
     mydfm <- dfm(data_char_sampletext, 
                  dictionary = dictionary(list("字" = "a", "spe cial" = "the", 
                                               "飛機" = "if", "spec+ial" = "of")))


### PR DESCRIPTION
Default handling of featnames in as.data.frame.dfm() is now to set `check.names = FALSE` to prevent adjustment of syntactically invalid variable names.