### PR TITLE
Add link to package website in startup message

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,17 +1,21 @@
 .onAttach <- function(...) {
     # startup message
-    packageStartupMessage("quanteda version ", as.character(utils::packageVersion("quanteda")))
+    packageStartupMessage("Initializing package: ‘quanteda‘")
+    packageStartupMessage("Package version: ", as.character(utils::packageVersion("quanteda")))
     
     # initialize options
     quanteda_options(initialize = TRUE)
     
     # threads message
     if (qatd_cpp_tbb_enabled()) {
-        packageStartupMessage("Using ", quanteda_options("threads"), " of ", 
-                              RcppParallel::defaultNumThreads(), " threads for parallel computing")
+        packageStartupMessage("Parallel computing: ", quanteda_options("threads"), " of ", 
+                              RcppParallel::defaultNumThreads(), " threads")
     } else {
-        packageStartupMessage("Parallel computing is disabled") 
+        packageStartupMessage("Parallel computing: disabled") 
     }
+    
+    # wesite link
+    packageStartupMessage('To learn how to use ‘quanteda‘ through examples and tutorials, go to https://quanteda.io')
 }
 
 .onUnload <- function (libpath) {

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -9,14 +9,13 @@
     # threads message
     if (qatd_cpp_tbb_enabled()) {
         packageStartupMessage("Parallel computing: ", quanteda_options("threads"), " of ", 
-                              RcppParallel::defaultNumThreads(), " threads")
+                              RcppParallel::defaultNumThreads(), " threads used.")
     } else {
         packageStartupMessage("Parallel computing: disabled") 
     }
     
     # wesite link
-    packageStartupMessage('To learn how to use ', sQuote('quanteda'), 
-                          ' through examples and tutorials, go to https://quanteda.io')
+    packageStartupMessage("See https://quanteda.io for tutorials and examples.")
 }
 
 .onUnload <- function (libpath) {

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,6 +1,6 @@
 .onAttach <- function(...) {
     # startup message
-    packageStartupMessage("Initializing package: ‘quanteda‘")
+    #packageStartupMessage("Initializing package: ", sQuote('quanteda'))
     packageStartupMessage("Package version: ", as.character(utils::packageVersion("quanteda")))
     
     # initialize options
@@ -15,7 +15,8 @@
     }
     
     # wesite link
-    packageStartupMessage('To learn how to use ‘quanteda‘ through examples and tutorials, go to https://quanteda.io')
+    packageStartupMessage('To learn how to use ', sQuote('quanteda'), 
+                          ' through examples and tutorials, go to https://quanteda.io')
 }
 
 .onUnload <- function (libpath) {


### PR DESCRIPTION
Advertise our website in the start up message.
```
Initializing package: ‘quanteda‘
Package version: 1.0.5
Parallel computing: 3 of 4 threads
To learn how to use ‘quanteda‘ through examples and tutorials, go to https://quanteda.io/

Attaching package: ‘quanteda’

The following object is masked from ‘package:utils’:

    View
```