### PR TITLE
Add original frequency to a fcm

### DIFF
--- a/R/fcm-methods.R
+++ b/R/fcm-methods.R
@@ -39,6 +39,7 @@ fcm_compress.fcm <- function(x) {
     x <- dfm_compress(x, margin = "both")
     result <- new("fcm", as(x, 'dgCMatrix'), count = attrs$count,
                   context = attrs$context, window = attrs$window,
+                  margin =  attrs$margin,
                   weights = attrs$weights, tri = attrs$tri)
     names(result@Dimnames) <- c("features", "features")
     return(result)
@@ -81,12 +82,15 @@ fcm_sort.fcm <- function(x) {
     x <- x[order(rownames(x)), order(colnames(x))]
     if (x@tri) {
         # make a triplet
-        tmp <- as(x, "dgTMatrix")
-        swap <- which(tmp@i > tmp@j)
-        i <- tmp@i[swap]
-        tmp@i[swap] <- tmp@j[swap]
-        tmp@j[swap] <- i
-        x <- new("fcm", as(tmp, "dgCMatrix")) 
+        temp <- as(x, "dgTMatrix")
+        swap <- which(temp@i > temp@j)
+        i <- temp@i[swap]
+        temp@i[swap] <- temp@j[swap]
+        temp@j[swap] <- i
+        x <- new("fcm", as(temp, "dgCMatrix"), count = attrs$count,
+                 context = attrs$context, 
+                 window = attrs$window, margin = attrs$margin,
+                 weights = attrs$weights, tri = attrs$tri) 
         slots(x) <- attrs
     }
     return(x)
@@ -131,7 +135,7 @@ fcm_select.fcm <- function(x, pattern = NULL,
                       case_insensitive, verbose = FALSE, ...))
     result <- new("fcm", as(x, 'dgCMatrix'), count = attrs$count,
                   context = attrs$context, 
-                  window = attrs$window, 
+                  window = attrs$window, margin = attrs$margin,
                   weights = attrs$weights, tri = attrs$tri)
     names(result@Dimnames) <- c("features", "features")
     return(result)

--- a/R/fcm.R
+++ b/R/fcm.R
@@ -9,6 +9,7 @@
 #' @slot window the size of the window, if \code{context = "window"}
 #' @slot count how co-occurrences are counted
 #' @slot weights context weighting for distance from target feature, equal in length to \code{window}
+#' @slot margin frequencies of features in the original \link{dfm} or \link{tokens}
 #' @slot tri whether the lower triangle of the symmetric \eqn{V \times V} matrix is recorded
 #' @slot ordered whether a term appears before or after the target feature 
 #'      are counted separately
@@ -21,7 +22,8 @@
 setClass("fcm",
          slots = c(context = "character", window = "integer", 
                    count = "character", weights = "numeric", 
-                   ordered = "logical", tri = "logical"),
+                   ordered = "logical", tri = "logical",
+                   margin = "numeric"),
          # prototype = list(Dimnames = list(contexts = NULL, features = NULL)),
          #contains = c("dfm", "dgCMatrix", "dtCMatrix"))
          contains = c("dfm", "dgCMatrix"))
@@ -169,10 +171,11 @@ fcm.dfm <- function(x, context = c("document", "window"),
     count <- match.arg(count)
     window <- as.integer(window)
     x <- as.dfm(x)
+    margin <- colSums(x)
     
     if (!nfeat(x)) {
         result <- new("fcm", as(make_null_dfm(), "dgCMatrix"), count = count,
-                      context = context, window = window, 
+                      context = context, window = window, margin = numeric(),
                       weights = weights, tri = tri)
         return(result)
     }
@@ -212,7 +215,7 @@ fcm.dfm <- function(x, context = c("document", "window"),
 
     # create a new feature context matrix
     result <- new("fcm", as(result, "dgCMatrix"), count = count,
-                  context = context, window = window, 
+                  context = context, window = window, margin = margin,
                   weights = weights, tri = tri)
     # set the names 
     names(result@Dimnames) <- c("features", "features")
@@ -262,7 +265,7 @@ fcm.tokens <- function(x, context = c("document", "window"),
     
     # create a new feature context matrix
     result <- new("fcm", as(result, "dgCMatrix"), count = count,
-                  context = context, window = window, 
+                  context = context, window = window, margin = colSums(dfm(x)),
                   weights = weights, tri = tri)
     # set the names 
     names(result@Dimnames) <- c("features", "features")

--- a/man/fcm-class.Rd
+++ b/man/fcm-class.Rd
@@ -19,6 +19,8 @@ The fcm class of object is a special type of \link{dfm}
 
 \item{\code{weights}}{context weighting for distance from target feature, equal in length to \code{window}}
 
+\item{\code{margin}}{frequencies of features in the original \link{dfm} or \link{tokens}}
+
 \item{\code{tri}}{whether the lower triangle of the symmetric \eqn{V \times V} matrix is recorded}
 
 \item{\code{ordered}}{whether a term appears before or after the target feature 

--- a/tests/testthat/test-fcm.R
+++ b/tests/testthat/test-fcm.R
@@ -179,8 +179,8 @@ test_that("ordered setting: boolean",{
 
 # Testing "count" with multiple documents
 test_that("counting the frequency of the co-occurrences",{
-    txts <- c("a a a b b c", "a a c e", "a c e f g")
-    fcm <- fcm(txts, context = "document", count = "frequency", tri = TRUE)           
+    txt <- c("a a a b b c", "a a c e", "a c e f g")
+    fcm <- fcm(txt, context = "document", count = "frequency", tri = TRUE)           
     fcm <- fcm_sort(fcm)
     aMat <- matrix(c(4, 6, 6, 3, 1, 1,
                      0, 1, 2, 0, 0, 0,
@@ -190,21 +190,23 @@ test_that("counting the frequency of the co-occurrences",{
                      0, 0, 0, 0, 0, 0),
                    nrow = 6, ncol = 6, byrow = TRUE)
     expect_true(all(round(fcm, 2) == round(aMat, 2)))
+    expect_equal(fcm@margin, colSums(dfm(txt)))
 })
 
 test_that("counting the co-occurrences in 'boolean' way",{
-    txts <- c("a a a b b c", "a a c e", "a c e f g")
-    fcm <- fcm(txts, context = "document", count = "boolean")           
+    txt <- c("a a a b b c", "a a c e", "a c e f g")
+    fcm <- fcm(txt, context = "document", count = "boolean")           
     fcm <- fcm_sort(fcm)
     
-    aMat <- matrix(c(2, 1, 3, 2, 1, 1,
+    mt <- matrix(c(2, 1, 3, 2, 1, 1,
                      0, 1, 1, 0, 0, 0,
                      0, 0, 0, 2, 1, 1,
                      0, 0, 0, 0, 1, 1,
                      0, 0, 0, 0, 0, 1,
                      0, 0, 0, 0, 0, 0),
                    nrow = 6, ncol = 6, byrow = TRUE)
-    expect_true(all(round(fcm, 2) == round(aMat, 2)))
+    expect_true(all(round(fcm, 2) == round(mt, 2)))
+    expect_equal(fcm@margin, colSums(dfm(txt)))
 })
 
 # Testing the setting of window size
@@ -217,7 +219,7 @@ test_that("window = 2",{
     fcmTexts <- fcm(toks, context = "window", count = "boolean", window = 2) 
     expect_equivalent(as.matrix(fcm), as.matrix(fcmTexts))
     
-    aMat <- matrix(c(2, 1, 2, 2, 0, 0,
+    mt <- matrix(c(2, 1, 2, 2, 0, 0,
                      0, 1, 1, 0, 0, 0,
                      0, 0, 0, 2, 1, 0,
                      0, 0, 0, 0, 1, 1,
@@ -225,7 +227,8 @@ test_that("window = 2",{
                      0, 0, 0, 0, 0, 0),
                    nrow = 6, ncol = 6, byrow = TRUE)
     fcm <- fcm_sort(fcm)
-    expect_equivalent(aMat, as.matrix(fcm))
+    expect_equivalent(mt, as.matrix(fcm))
+    expect_equal(fcm@margin, colSums(dfm(toks)))
 })
 
 test_that("window = 3",{

--- a/tests/testthat/test-fcm_methods.R
+++ b/tests/testthat/test-fcm_methods.R
@@ -9,30 +9,33 @@ test_that("fcm_compress works as expected, not working for 'window' context",{
 })
 
 myfcm <- fcm(tokens(c("b A A d", "C C a b B e")), context = "document")
+
 test_that("fcm_tolower and fcm_compress work as expected",{
     lc_fcm <- fcm_tolower(myfcm)
     expect_equivalent(rownames(lc_fcm), 
                       c("b", "a", "d", "c", "e"))
-    aMat <- matrix(c(1, 3, 1, 2, 2, 
+    mt <- matrix(c(1, 3, 1, 2, 2, 
                      0, 1, 2, 0, 1, 
                      0, 0, 0, 0, 0, 
                      0, 0, 0, 1, 2, 
                      0, 0, 0, 0, 0),
                    nrow = 5, ncol = 5, byrow = TRUE)
-    expect_true(all(as.vector(Matrix::triu(lc_fcm)) == as.vector(aMat)))
+    expect_true(all(as.vector(Matrix::triu(lc_fcm)) == as.vector(mt)))
+    expect_equal(lc_fcm@margin, myfcm@margin)
 })
 
 test_that("fcm_toupper and fcm_compress work as expected",{
     uc_fcm <- fcm_toupper(myfcm)
     expect_equivalent(rownames(uc_fcm), 
                       c("B", "A", "D", "C", "E"))
-    aMat <- matrix(c(1, 3, 1, 2, 2, 
+    mt <- matrix(c(1, 3, 1, 2, 2, 
                      0, 1, 2, 0, 1, 
                      0, 0, 0, 0, 0, 
                      0, 0, 0, 1, 2, 
                      0, 0, 0, 0, 0),
                    nrow = 5, ncol = 5, byrow = TRUE)
-    expect_true(all(as.vector(Matrix::triu(uc_fcm)) == as.vector(aMat)))
+    expect_true(all(as.vector(Matrix::triu(uc_fcm)) == as.vector(mt)))
+    expect_equal(uc_fcm@margin, myfcm@margin)
 })
 
 


### PR DESCRIPTION
Adds extra `margin` slot to record original frequency for #1262. I though fcm methods should change its value, but no longer think so, because names in the vector can be matched with features of the fcm when it is used in upcoming `fcm_weight()` etc. I was not sure what should happen when `fcm_lower()` is applied to the fcm, so made it to do nothing.