### PR TITLE
Improve consistency of selection argument for textstat_dist/simil()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: quanteda
-Version: 1.1.2
+Version: 1.1.3
 Title: Quantitative Analysis of Textual Data
 Description: A fast, flexible, and comprehensive framework for 
     quantitative text analysis in R.  Provides functionality for corpus management,

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@
 ### Behaviour changes
 
 * `dfm_trim()` now takes more options, and these are implemented more consistently.  `min_termfreq` and `max_termfreq` have replaced `min_count` and `max_count`, and these can be modified using a `termfreq_type` argument.  (Similar options are implemented for `docfreq_type`.)  Solves #1253, #1254.
-
+* `textstat_simil()` and `textstat_dist()` now take valid dfm indexes for the relevant margin for the `selection` argument.  Previously, this could also be a direct vector or matrix for comparison, but this is no longer allowed.  Solves #1266.
 
 # quanteda v1.1.1
 

--- a/R/textstat_dist.R
+++ b/R/textstat_dist.R
@@ -200,9 +200,10 @@ as.list.dist_selection <- function(x, sorted = TRUE, n = NULL, ...) {
     
     if (!is.null(attr(x, "Labels"))) label <- attr(x, "Labels")
     result <- lapply(seq_len(ncol(as.matrix(x))), function(i) as.matrix(x)[, i])
+    names(result) <- colnames(x)
     attributes(x) <- NULL
-    names(result) <- if (!is.null(label)) label[seq_len(ncol(as.matrix(x)))]
-    
+    # names(result) <- if (!is.null(label)) label[seq_len(ncol(as.matrix(x)))]
+
     # remove the element of each similarity vector equal to the item itself
     for (m in names(result)) {
         result[[m]] <- result[[m]][m != names(result[[m]])]

--- a/R/textstat_dist.R
+++ b/R/textstat_dist.R
@@ -70,42 +70,14 @@ textstat_dist.dfm <- function(x, selection = NULL,
     method <- char_tolower(method)
     
     if (!is.null(selection)) {
-        if (!is.character(selection)) {
-            if (!is.dfm(selection)) selection_dfm <- as.dfm(as.matrix(selection))
-            if (margin == "features") {
-                if (ndoc(selection_dfm) != ndoc(x))
-                    stop("The vector/matrix specified by 'selection' must be conform to the object x in rows.")
-                y <- selection_dfm
-            } else {
-                if (nfeat(selection_dfm) != nfeat(x))
-                    stop("The vector/matrix specified by 'selection' must be conform to the object x in columns.")
-                y <- selection_dfm
-            }
-        } else {    
-            if (margin == "features") {
-                selection <- intersect(selection, featnames(x))
-                if (!length(selection))
-                    stop("The features specified by 'selection' do not exist.")
-                y <- x[, selection, drop = FALSE]
-            } else {
-                selection <- intersect(selection, docnames(x))
-                if (!length(selection))
-                    stop("The documents specified by 'selection' do not exist.")
-                y <- x[selection, , drop = FALSE]
-            }
-        }
+        y <- if (margin == "documents") x[selection, ] else x[, selection]
     } else {
         y <- NULL
     }
     
     m <- if (margin == "documents") 1 else 2
-    
     methods1 <- c("euclidean", "hamming", "chisquared", "chisquared2", "kullback", "manhattan", "maximum", "canberra")
     methods2 <- c("jaccard", "binary", "ejaccard", "simple matching")
-    
-    # methods1 <- char_tolower(methods1)
-    # methods1 <- char_tolower(methods2)
-    # method <- char_tolower(method)
     
     if (method %in% methods1) {
         temp <- get(paste0(method, "_dist"))(x, y, margin = m)
@@ -116,12 +88,6 @@ textstat_dist.dfm <- function(x, selection = NULL,
         temp <- get(paste0(method, "_simil"))(x, y, margin = m)
     } else {
         stop(method, " is not implemented; consider trying proxy::dist().")
-    }
-    
-    if (is.character(selection)) {
-        name <- c(colnames(temp), setdiff(rownames(temp), colnames(temp)))
-        # NOTE dense matrix does not accept "" as rowname
-        temp <- temp[match(name, rownames(temp)), , drop = FALSE] # sort for as.dist()
     }
     
     # create a new dist object

--- a/man/textstat_simil.Rd
+++ b/man/textstat_simil.Rd
@@ -14,15 +14,12 @@ textstat_simil(x, selection = NULL, margin = c("documents", "features"),
 \arguments{
 \item{x}{a \link{dfm} object}
 
-\item{selection}{character vector of document names or feature labels from
-\code{x}; or, a numeric vector or matrix which is conforms to \code{x}. A
-\code{"dist"} object is returned if selection is \code{NULL}, otherwise, a
-matrix is returned matching distances to the documents or features identified
-in the selection.}
+\item{selection}{a valid index for document or feature names from \code{x},
+to be selected for comparison}
 
-\item{margin}{identifies the margin of the dfm on which similarity or 
+\item{margin}{identifies the margin of the dfm on which similarity or
 difference will be computed:  \code{"documents"} for documents or 
-\code{"features"} for word/term features.}
+\code{"features"} for word/term features}
 
 \item{method}{method the similarity or distance measure to be used; see
 Details}
@@ -35,7 +32,10 @@ matrix is recorded}
 \item{p}{The power of the Minkowski distance.}
 }
 \value{
-\code{textstat_simil} and \code{textstat_dist} return \code{dist} class objects.
+\code{textstat_simil} and \code{textstat_dist} return
+  \code{\link{dist}} class objects if selection is \code{NULL}, otherwise, a
+  matrix is returned matching distances to the documents or features
+  identified in the selection.
 }
 \description{
 These functions compute matrixes of distances and similarities between 

--- a/tests/testthat/test-textstat_dist.R
+++ b/tests/testthat/test-textstat_dist.R
@@ -241,11 +241,13 @@ test_that("as.list.dist works as expected",{
     )
 })
 
-test_that("as.list.dist.selection works as expected",{
+test_that("as.list.dist_selection works as expected", {
     presDfm <- dfm(corpus_subset(data_corpus_inaugural, Year > 1980), remove = stopwords("english"),
                    stem = TRUE, verbose = FALSE)
-    ddist_list <- as.list(textstat_dist(presDfm, c("2017-Trump", "2013-Obama"), margin = "documents"))
-    expect_null(ddist_list$'1985-Reagan')
+    ddist <- textstat_dist(presDfm, c("2017-Trump", "2013-Obama"), margin = "documents")
+    ddist_list <- as.list(ddist)
+    expect_equal(names(ddist_list), c("2017-Trump", "2013-Obama"))
+    expect_null(ddist_list$"1985-Reagan")
     expect_equal(names(ddist_list$`2017-Trump`)[1:3], c("1985-Reagan", "1981-Reagan", "1989-Bush"))
 })
 
@@ -256,22 +258,22 @@ test_that("textstat_dist stops as expected for methods not supported",{
                  "yule is not implemented; consider trying proxy::dist\\(\\)")
 })
 
-test_that("textstat_dist stops as expected for wrong selections",{
-    presDfm <- dfm(corpus_subset(data_corpus_inaugural, Year > 1980), remove = stopwords("english"),
-                   stem = TRUE, verbose = FALSE)
-    expect_error(textstat_dist(presDfm, 5), 
-                 "The vector/matrix specified by 'selection' must be conform to the object x in columns")
-    expect_error(textstat_dist(presDfm, 5, margin = "features"), 
-                 "The vector/matrix specified by 'selection' must be conform to the object x in rows")
-    
-    
-    
-    expect_error(textstat_dist(presDfm, margin = "documents", "2009-Obamaa"), 
-                 "The documents specified by 'selection' do not exist.")
-    expect_error(textstat_dist(presDfm, margin = "features", "Obamaa"), 
-                 "The features specified by 'selection' do not exist.")
-    
-})
+# test_that("textstat_dist stops as expected for wrong selections",{
+#     presDfm <- dfm(corpus_subset(data_corpus_inaugural, Year > 1980), remove = stopwords("english"),
+#                    stem = TRUE, verbose = FALSE)
+#     expect_error(textstat_dist(presDfm, 5), 
+#                  "The vector/matrix specified by 'selection' must be conform to the object x in columns")
+#     expect_error(textstat_dist(presDfm, 5, margin = "features"), 
+#                  "The vector/matrix specified by 'selection' must be conform to the object x in rows")
+#     
+#     
+#     
+#     expect_error(textstat_dist(presDfm, margin = "documents", "2009-Obamaa"), 
+#                  "The documents specified by 'selection' do not exist.")
+#     expect_error(textstat_dist(presDfm, margin = "features", "Obamaa"), 
+#                  "The features specified by 'selection' do not exist.")
+#     
+# })
 
 test_that("as.dist on a dist returns a dist", {
     presDfm <- dfm(corpus_subset(data_corpus_inaugural, Year > 1990), remove = stopwords("english"),
@@ -295,11 +297,11 @@ test_that("selection offers option to enable an alien vector/matrix", {
 
 test_that("selection works with dfm with padding", {
     
-    toks <- tokens(c(doc1 = 'a b c d e', doc2 = 'b c f e'), remove_punct = TRUE)
-    toks <- tokens_remove(toks, 'b', padding = TRUE)
+    toks <- tokens(c(doc1 = "a b c d e", doc2 = "b c f e"), remove_punct = TRUE)
+    toks <- tokens_remove(toks, "b", padding = TRUE)
     mt <- dfm(toks)
-    expect_silent(textstat_dist(mt, selection = c('c'), margin = 'features'))
-    expect_silent(textstat_dist(mt, selection = c(''), margin = 'features'))
-    expect_silent(textstat_dist(mt, selection = c('doc2'), margin = 'documents'))
+    expect_silent(textstat_dist(mt, selection = c("c"), margin = "features"))
+    expect_silent(textstat_dist(mt, selection = c(""), margin = "features"))
+    expect_silent(textstat_dist(mt, selection = c("doc2"), margin = "documents"))
     
 })

--- a/tests/testthat/test-textstat_simil.R
+++ b/tests/testthat/test-textstat_simil.R
@@ -309,20 +309,20 @@ test_that("textstat_simil stops as expected for methods not supported",{
     "Yule is not implemented; consider trying proxy::simil\\(\\)")
 })
 
-test_that("textstat_simil stops as expected for wrong selections",{
-    presDfm <- dfm(corpus_subset(data_corpus_inaugural, Year > 1980), remove = stopwords("english"),
-                   stem = TRUE, verbose = FALSE)
-    expect_error(textstat_simil(presDfm, 5), 
-                 "The vector/matrix specified by 'selection' must be conform to the object x in columns")
-    expect_error(textstat_simil(presDfm, 5, margin = "features"), 
-                 "The vector/matrix specified by 'selection' must be conform to the object x in rows")
-    
-    expect_error(textstat_simil(presDfm, margin = "documents", "2009-Obamaa"), 
-                 "The documents specified by 'selection' do not exist.")
-    expect_error(textstat_simil(presDfm, margin = "features", "Obamaa"), 
-                 "The features specified by 'selection' do not exist.")
-    
-})
+# test_that("textstat_simil stops as expected for wrong selections",{
+#     presDfm <- dfm(corpus_subset(data_corpus_inaugural, Year > 1980), remove = stopwords("english"),
+#                    stem = TRUE, verbose = FALSE)
+#     expect_error(textstat_simil(presDfm, selection = 5), 
+#                  "The vector/matrix specified by 'selection' must be conform to the object x in columns")
+#     expect_error(textstat_simil(presDfm, selection = 5, margin = "features"), 
+#                  "The vector/matrix specified by 'selection' must be conform to the object x in rows")
+#     
+#     expect_error(textstat_simil(presDfm, margin = "documents", selection = "2009-Obamaa"), 
+#                  "The documents specified by 'selection' do not exist.")
+#     expect_error(textstat_simil(presDfm, margin = "features", selection = "Obamaa"), 
+#                  "The features specified by 'selection' do not exist.")
+#     
+# })
 
 # test_that("test textstat_simil works as expected for 'n' is not NULL", {
 #     skip_if_not_installed("proxy")

--- a/tests/testthat/test-textstat_simil.R
+++ b/tests/testthat/test-textstat_simil.R
@@ -1,4 +1,5 @@
-context('test textstat_simil.R')
+context("test textstat_simil.R")
+
 # correlation
 test_that("test textstat_simil method = \"correlation\" against proxy simil(): documents", {
     skip_if_not_installed("proxy")


### PR DESCRIPTION
Solves #1266.

Improves the consistency of the `selection` argument by enforcing it to be a valid index on the dfm dimension defined in `margin`. 

Also fixes a bug in `as.list.dist_selection()` that caused all but the first column (of the non-symmetric matrix) to be dropped, resulting in a list of length 1.