### PR TITLE
use data.table functions for corpus addition

### DIFF
--- a/R/corpus-methods-base.R
+++ b/R/corpus-methods-base.R
@@ -209,7 +209,7 @@ tail.corpus <- function(x, n = 6L, ...) {
     }
     
     #rowname <- c(rownames(c1$documents), rownames(c2$documents))
-    c1$documents <- rbind(c1$documents, c2$documents)
+    c1$documents <- data.table::setDF(data.table::rbindlist(list(c1$documents, c2$documents), fill = TRUE))
 
     #  Put rownames back in because the hadleyverse discards them
     #rownames(c1$documents) <- make.unique(rowname, sep='')

--- a/R/corpus-methods-base.R
+++ b/R/corpus-methods-base.R
@@ -208,9 +208,10 @@ tail.corpus <- function(x, n = 6L, ...) {
                 paste(metacorpus(c1, field), metacorpus(c2, field))
     }
     
-    #rowname <- c(rownames(c1$documents), rownames(c2$documents))
+    r_names <-  make.unique(c(rownames(c1$documents), rownames(c2$documents)), sep='')
     c1$documents <- data.table::setDF(data.table::rbindlist(list(c1$documents, c2$documents), fill = TRUE))
-
+    rownames(c1$documents) <- r_names
+    
     #  Put rownames back in because the hadleyverse discards them
     #rownames(c1$documents) <- make.unique(rowname, sep='')
     

--- a/tests/testthat/test-corpus.R
+++ b/tests/testthat/test-corpus.R
@@ -305,3 +305,16 @@ test_that("corpus works on dplyr grouped data.frames (#1232)", {
         "^Corpus consisting of 6 documents and 3 docvars\\.$"
     )
 })
+
+test_that("corpus + operator works", {
+    corp1 <- corpus(LETTERS[1:3], docvars = data.frame(one = 1:3, two = 4:6))
+    corp2 <- corpus(LETTERS[1:3], docvars = data.frame(one = 7:9, three = 10:12))
+    sm <- summary(corp1 + corp2)
+    expect_identical(sm$one, c(1:3, 7:9))
+    expect_identical(sm$two, c(4:6, NA, NA, NA))
+    expect_identical(sm$three, c(NA, NA, NA, 10:12))
+    expect_identical(
+        texts(corpus(LETTERS[1:3]) + corpus(LETTERS[3:5])),
+        c(text1 = "A", text2 = "B", text3 = "C", text11 = "C", text21= "D", text31 = "E")
+    )
+})


### PR DESCRIPTION
This is a very minor edit of `+.corpus`. Originally it used `rbind` in base-R and I changed it to `data.table::rbindlist` so that it can combine two corpus objects with different lists of docvars. As it uses data.table function, this supposedly combines faster. I tested with both normal (i.e. not compressed) corpus objects and compressed corpus objects, and it worked fine.
