### PR TITLE
Improve `corpus.data.frame()`

### DIFF
--- a/man/corpus.Rd
+++ b/man/corpus.Rd
@@ -18,7 +18,7 @@ corpus(x, ...)
 \method{corpus}{character}(x, docnames = NULL, docvars = NULL,
   metacorpus = NULL, compress = FALSE, ...)
 
-\method{corpus}{data.frame}(x, docid_field = NULL, text_field = "text",
+\method{corpus}{data.frame}(x, docid_field = "doc_id", text_field = "text",
   metacorpus = NULL, compress = FALSE, ...)
 
 \method{corpus}{kwic}(x, ...)
@@ -54,9 +54,10 @@ gzip compression. This significantly reduces the size of the corpus in
 memory, but will slow down operations that require the texts to be
 extracted.}
 
-\item{docid_field}{optional column index of a document identifier; if
-\code{NULL}, the constructor will use the row.names of the data.frame (if
-found)}
+\item{docid_field}{optional column index of a document identifier; defaults
+to "doc_id", but if this is not found, then will use the rownames of the
+data.frame; if the rownames are not set, it will use the default sequence
+based on \code{(\link{quanteda_options}("base_docname")}.}
 
 \item{text_field}{the character name or numeric index of the source
 \code{data.frame} indicating the variable to be read in as text, which must

--- a/man/quanteda-package.Rd
+++ b/man/quanteda-package.Rd
@@ -95,7 +95,7 @@ Other contributors:
   \item Paul Nulty \email{paul.nulty@gmail.com} [contributor]
   \item Adam Obeng \email{quanteda@binaryeagle.com} [contributor]
   \item Haiyan Wang \email{h.wang52@lse.ac.uk} [contributor]
-  \item Stefan M<U+FF83><U+FF7C>ller \email{mullers@tcd.ie} [contributor]
+  \item Stefan Müller \email{mullers@tcd.ie} [contributor]
   \item Benjamin Lauderdale \email{B.E.lauderdale@lse.ac.uk} [contributor]
   \item Will Lowe \email{wlowe@princeton.edu} [contributor]
 }

--- a/tests/testthat/test-summary.R
+++ b/tests/testthat/test-summary.R
@@ -65,9 +65,9 @@ test_that("summary.character works with data.frames containing character (#1285)
     skip_on_travis()
     skip_on_cran()
     txt <- c("Testing this text. Second sentence.", "And this one.")
-    df <- data.frame(txt, other = 1:2, stringsAsFactors = FALSE)
+    dframe <- data.frame(txt, other = 1:2, stringsAsFactors = FALSE)
     expect_equal(
-        stringi::stri_trim_right(as.character(summary(df))[1:3]),
+        stringi::stri_trim_right(as.character(summary(dframe))[1:3]),
         c("Length:2", "Class :character", "Mode  :character")
     )
 })


### PR DESCRIPTION
- Simplify code in `corpus.data.frame()`
- Make `"doc_id"` the default `docfield_id`
- Use `row.names(x)` if `docfield_id` not found
- Use quanteda default if `docfield_id` not found and rownames are not set
- Solves #1293