### PR TITLE
Address #1254

### DIFF
--- a/man/dfm_trim.Rd
+++ b/man/dfm_trim.Rd
@@ -5,9 +5,10 @@
 \title{Trim a dfm using frequency threshold-based feature selection}
 \usage{
 dfm_trim(x, min_termfreq = NULL, max_termfreq = NULL,
-  termfreq_type = c("count", "rank", "quantile"), min_docfreq = NULL,
-  max_docfreq = NULL, docfreq_type = c("count", "rank", "quantile"),
-  sparsity = NULL, verbose = quanteda_options("verbose"), ...)
+  termfreq_type = c("count", "prop", "rank", "quantile"),
+  min_docfreq = NULL, max_docfreq = NULL, docfreq_type = c("count",
+  "prop", "rank", "quantile"), sparsity = NULL,
+  verbose = quanteda_options("verbose"), ...)
 }
 \arguments{
 \item{x}{a \link{dfm} object}
@@ -17,10 +18,11 @@ across all documents, below/above which features will
   be removed}
 
 \item{termfreq_type}{how \code{min_termfreq} and \code{max_termfreq} are
-intepreted.  \code{"count"} sums the frequencies; \code{"rank"} is matched
-against the inverted ranking of features in terms of overall frequency, so
-that 1, 2, ... are the highest and second highest frequency features, and
-so on; \code{"quantile"} sets the cutoffs according to the quantiles (see
+intepreted.  \code{"count"} sums the frequencies; \code{"prop"} devides the
+term frequences by the total sum; \code{"rank"} is matched against the inverted
+ranking of features in terms of overall frequency, so that 1, 2, ... are
+the highest and second highest frequency features, and so on;
+\code{"quantile"} sets the cutoffs according to the quantiles (see
 \code{\link{quantile}}) of term frequencies.}
 
 \item{min_docfreq, max_docfreq}{minimum/maximum values of a feature's document
@@ -28,10 +30,11 @@ frequency, below/above which features will be removed}
 
 \item{docfreq_type}{specify how \code{min_docfreq} and \code{max_docfreq} are
 intepreted.   \code{"count"} is the same as \code{\link{docfreq}(x, scheme
-= "count")}; \code{"rank"} is matched against the inverted ranking of
-document frequency, so that 1, 2, ... are the features with the highest and
-second highest document frequencies, and so on; \code{"quantile"} sets the
-cutoffs according to the quantiles (see \code{\link{quantile}}) of document
+= "count")}; \code{"prop"} devides the document frequences by the total sum;
+\code{"rank"} is matched against the inverted ranking of document
+frequency, so that 1, 2, ... are the features with the highest and second
+highest document frequencies, and so on; \code{"quantile"} sets the cutoffs
+according to the quantiles (see \code{\link{quantile}}) of document
 frequencies.}
 
 \item{sparsity}{equivalent to \code{1 - min_docfreq}, included for comparison

--- a/man/quanteda-package.Rd
+++ b/man/quanteda-package.Rd
@@ -95,7 +95,7 @@ Other contributors:
   \item Paul Nulty \email{paul.nulty@gmail.com} [contributor]
   \item Adam Obeng \email{quanteda@binaryeagle.com} [contributor]
   \item Haiyan Wang \email{h.wang52@lse.ac.uk} [contributor]
-  \item Stefan M<U+FF83><U+FF7C>ller \email{mullers@tcd.ie} [contributor]
+  \item Stefan Müller \email{mullers@tcd.ie} [contributor]
   \item Benjamin Lauderdale \email{B.E.lauderdale@lse.ac.uk} [contributor]
   \item Will Lowe \email{wlowe@princeton.edu} [contributor]
 }

--- a/tests/testthat/test-dfm_trim.R
+++ b/tests/testthat/test-dfm_trim.R
@@ -108,15 +108,36 @@ test_that("dfm_trim works on previously weighted dfms (#1237)", {
         tol = .0001
     )
     expect_warning(
-        dfm_trim(dfm2, min_docfreq = .5, docfreq_type = 'prop'),
+        dfm_trim(dfm2, min_docfreq = .5, docfreq_type = "prop"),
         "dfm has been previously weighted"
     )
     expect_warning(
-        dfm_trim(dfm2, min_termfreq = 1, min_docfreq = .5, docfreq_type = 'prop'),
+        dfm_trim(dfm2, min_termfreq = 1, min_docfreq = .5, docfreq_type = "prop"),
         "dfm has been previously weighted"
     )
+    
     expect_equal(
-        dim(dfm_trim(dfm2, min_termfreq = 1, min_docfreq = .5, docfreq_type = 'prop')),
+        dim(dfm_trim(dfm2, min_termfreq = 1, min_docfreq = .5, docfreq_type = "prop")),
         c(2, 0)
     )
+})
+
+test_that("dfm_trim warn when termfreq is termfreq_type = 'count' (#1254)", {
+    dfm1 <- dfm(c("the quick brown fox jumps over the lazy dog", 
+                  "the quick brown foxy ox jumps over the lazy god"))
+    #dfm2 <- dfm_tfidf(dfm1)
+    expect_warning(
+        dfm_trim(dfm1, min_termfreq = 0.001, termfreq_type = "count"),
+        "use termfreq_type = 'prop' for fractional term frequency"
+    )
+    #expect_silent(
+    #    dfm_trim(dfm2, min_termfreq = 0.001, termfreq_type = "count")
+    #)
+    expect_warning(
+        dfm_trim(dfm1, max_termfreq = 0.001, termfreq_type = "count"),
+        "use termfreq_type = 'prop' for fractional term frequency"
+    )
+    #expect_silent(
+    #    dfm_trim(dfm2, max_termfreq = 0.001, termfreq_type = "count")
+    #)
 })


### PR DESCRIPTION
- Add warnings of fractional termfreq
- Correct generic signiture

Note that `dfm_trim()` should warn only when x@weightTf$scheme == "count" but we cannot condition until #1274 has been solved.