### PR TITLE
Make error message more friendly

### DIFF
--- a/R/tokens.R
+++ b/R/tokens.R
@@ -436,7 +436,7 @@ print.tokens <- function(x, ...) {
 #' str(toks)
 #' toks[c(1,3)]
 "[.tokens" <- function(x, i, ...) {
-    attrs <- attributes(x)
+    
     if (length(x) == 1 && is.null(x[[1]])) return(x)
     
     error <- FALSE
@@ -444,6 +444,7 @@ print.tokens <- function(x, ...) {
     if (is.numeric(i) && any(i > length(x))) error <- TRUE
     if (error) stop("Subscript out of bounds")
     
+    attrs <- attributes(x)
     x <- unclass(x)[i]
     if (is.data.frame(attrs$docvars)) {
         attrs$docvars <- attrs$docvars[i,,drop = FALSE]

--- a/R/tokens.R
+++ b/R/tokens.R
@@ -436,13 +436,20 @@ print.tokens <- function(x, ...) {
 #' str(toks)
 #' toks[c(1,3)]
 "[.tokens" <- function(x, i, ...) {
-    tokens <- unclass(x)[i]
-    if (is.data.frame(attr(x, "docvars"))) {
-        attr(tokens, "docvars") <- attr(x, "docvars")[i,,drop = FALSE]
+    attrs <- attributes(x)
+    if (length(x) == 1 && is.null(x[[1]])) return(x)
+    
+    error <- FALSE
+    if (is.character(i) && any(!i %in% names(x))) error <- TRUE
+    if (is.numeric(i) && any(i > length(x))) error <- TRUE
+    if (error) stop("Subscript out of bounds")
+    
+    x <- unclass(x)[i]
+    if (is.data.frame(attrs$docvars)) {
+        attrs$docvars <- attrs$docvars[i,,drop = FALSE]
     }
-    if (length(tokens) == 1 && is.null(tokens[[1]])) return(tokens)
-    attributes(tokens, FALSE) <- attributes(x)
-    tokens_recompile(tokens)
+    attributes(x, FALSE) <- attrs
+    tokens_recompile(x)
 }
 
 #' @method "[[" tokens

--- a/tests/testthat/test-tokens.R
+++ b/tests/testthat/test-tokens.R
@@ -21,6 +21,12 @@ test_that("tokens indexing works as expected", {
     # issue #370
     expect_equal(attr(toks[1], "types"), c("one", "two", "three"))
     expect_equal(attr(toks[2], "types"), c("four", "five", "six"))
+    
+    # issue #1308
+    expect_error(toks[4], "Subscript out of bounds")
+    expect_error(toks[1:4], "Subscript out of bounds")
+    expect_error(toks["d4"], "Subscript out of bounds")
+    expect_error(toks[c("d1", "d4")], "Subscript out of bounds")
 })
 
 test_that("tokens_recompile combine duplicates is working", {


### PR DESCRIPTION
Indexing error message is nicer and the same as for `dfm()`.