### PR TITLE
Fix #1320

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: quanteda
-Version: 1.2.0
+Version: 1.2.1
 Title: Quantitative Analysis of Textual Data
 Description: A fast, flexible, and comprehensive framework for 
     quantitative text analysis in R.  Provides functionality for corpus management,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# Since quanteda v1.2.0
+
+### Bug fixes and stability enhancements
+
+* `dfm_remove(x, selection = anydfm)` is now equivalent to `dfm_remove(x, selection = featnames(anydfm))`.  (#1320)
+
+
+
 # quanteda v1.2.0
 
 ### New Features

--- a/R/casechange-functions.R
+++ b/R/casechange-functions.R
@@ -101,14 +101,7 @@ char_tolower.character <- function(x, keep_acronyms = FALSE, ...) {
             x[i] <- stri_replace_all_regex(x[i], paste0('\\b', m, '\\b'), 
                                                  paste0('\uE000', m, '\uE001'), 
                                            vectorize_all = FALSE)
-            x[i] <- stri_trans_tolower(x[i]
-                                       
-                                       
-                                       
-                                       
-                                       
-                                       
-                                       )
+            x[i] <- stri_trans_tolower(x[i])
             x[i] <- stri_replace_all_regex(x[i], paste0('\uE000', stri_trans_tolower(m), '\uE001'), 
                                                  m, vectorize_all = FALSE)
         }

--- a/R/dfm_select.R
+++ b/R/dfm_select.R
@@ -117,15 +117,14 @@ dfm_select.dfm <-  function(x, pattern = NULL,
     feature_keep <- seq_len(nfeat(x))
     if (!is.null(pattern)) {
         # special handling if pattern is a dfm
-        if (is.dfm(pattern) && selection == "remove") {
-            pattern <- featnames(pattern)
-        }
-        if (is.dfm(pattern) && selection == "keep") {
-            is_dfm <- TRUE
+        if (is.dfm(pattern)) {
             pattern <- featnames(pattern)
             valuetype <- "fixed"
-            padding <- TRUE
             case_insensitive <- FALSE
+            if (selection == "keep") {
+                is_dfm <- TRUE
+                padding <- TRUE
+            }
         } else if (is.dictionary(pattern)) {
             pattern <- 
                 stri_replace_all_fixed(unlist(pattern, use.names = FALSE), 

--- a/R/dfm_select.R
+++ b/R/dfm_select.R
@@ -36,7 +36,7 @@
 #' @return A \link{dfm} or \link{fcm} object, after the feature selection has
 #'   been applied.
 #'
-#'   When \code{pattern} is a \link{dfm} object, then the returned object will
+#'   When \code{pattern} is a \link{dfm} object and \code{selection = "keep"}, then the returned object will
 #'   be identical in its feature set to the dfm supplied as the \code{pattern}
 #'   argument. This means that any features in \code{x} not in the dfm provided
 #'   as \code{pattern} will be discarded, and that any features in found in the
@@ -45,10 +45,14 @@
 #'   selected dfm with an exact feature match, when \code{pattern} is a
 #'   \link{dfm} object, then the following settings are always used:
 #'   \code{case_insensitive = FALSE}, and \code{valuetype = "fixed"}.
-#'
+#'   
 #'   Selecting on a \link{dfm} is useful when you have trained a model on one
 #'   dfm, and need to project this onto a test set whose features must be
 #'   identical.  It is also used in \code{\link{bootstrap_dfm}}.  See examples.
+#'
+#'   When \code{pattern} is a \link{dfm} object and \code{selection = "keep"},
+#'   the returned object will simply be the dfm without the featnames matching
+#'   those of the selection dfm.
 #' @export
 #' @keywords dfm
 #' @examples
@@ -113,7 +117,10 @@ dfm_select.dfm <-  function(x, pattern = NULL,
     feature_keep <- seq_len(nfeat(x))
     if (!is.null(pattern)) {
         # special handling if pattern is a dfm
-        if (is.dfm(pattern)) {
+        if (is.dfm(pattern) && selection == "remove") {
+            pattern <- featnames(pattern)
+        }
+        if (is.dfm(pattern) && selection == "keep") {
             is_dfm <- TRUE
             pattern <- featnames(pattern)
             valuetype <- "fixed"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,3 +40,6 @@ artifacts:
 
   - path: '\*_*.zip'
     name: Bits
+
+environment:
+  R_VERSION: 3.4

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,4 +42,4 @@ artifacts:
     name: Bits
 
 environment:
-  R_VERSION: 3.4
+  R_VERSION: 3.4.4

--- a/man/dfm_select.Rd
+++ b/man/dfm_select.Rd
@@ -60,7 +60,7 @@ removed}
 A \link{dfm} or \link{fcm} object, after the feature selection has
   been applied.
 
-  When \code{pattern} is a \link{dfm} object, then the returned object will
+  When \code{pattern} is a \link{dfm} object and \code{selection = "keep"}, then the returned object will
   be identical in its feature set to the dfm supplied as the \code{pattern}
   argument. This means that any features in \code{x} not in the dfm provided
   as \code{pattern} will be discarded, and that any features in found in the
@@ -69,10 +69,14 @@ A \link{dfm} or \link{fcm} object, after the feature selection has
   selected dfm with an exact feature match, when \code{pattern} is a
   \link{dfm} object, then the following settings are always used:
   \code{case_insensitive = FALSE}, and \code{valuetype = "fixed"}.
-
+  
   Selecting on a \link{dfm} is useful when you have trained a model on one
   dfm, and need to project this onto a test set whose features must be
   identical.  It is also used in \code{\link{bootstrap_dfm}}.  See examples.
+
+  When \code{pattern} is a \link{dfm} object and \code{selection = "keep"},
+  the returned object will simply be the dfm without the featnames matching
+  those of the selection dfm.
 }
 \description{
 This function selects or removes features from a \link{dfm} or \link{fcm},

--- a/tests/testthat/test-dfm_select.R
+++ b/tests/testthat/test-dfm_select.R
@@ -323,3 +323,16 @@ test_that("dfm_remove/keep fail if selection argument is used", {
         "dfm_keep cannot include selection argument"
     )
 })
+
+test_that("dfm_remove works when selection is a dfm (#1320)", {
+    d1 <- dfm("a b b c c c d d d d")
+    d2 <- dfm("d d d a a")
+    expect_identical(
+        featnames(dfm_remove(d1, d2)),
+        c("b", "c")
+    )
+    expect_identical(
+        featnames(dfm_select(d1, pattern = d2, selection = "remove")),
+        c("b", "c")
+    )
+})

--- a/tests/testthat/test-fcm_methods.R
+++ b/tests/testthat/test-fcm_methods.R
@@ -173,7 +173,7 @@ test_that("test fcm_select with features from a dfm,  fixed", {
     )
     expect_equal(
         featnames(fcm_select(testfcm, mx, selection = "remove", valuetype = "fixed", verbose = FALSE)),
-        featnames(mx)
+        setdiff(featnames(testfcm), featnames(mx))
     )
 })
 


### PR DESCRIPTION
`dfm_remove(x, selection = anydfm)` is now equivalent to `dfm_remove(x, selection = featnames(anydfm))`.

Updates documentation for `dfm_select()` to reflect this change.

Fixes #1320.