### PR TITLE
Fix and extend documentation of data_dictionary_LSD2015

### DIFF
--- a/R/data-documentation.R
+++ b/R/data-documentation.R
@@ -137,7 +137,7 @@ NULL
 #' \item{\code{negative}}{2,858 word patterns indicating negative sentiment}
 #' \item{\code{positive}}{1,709 word patterns indicating positive sentiment}
 #' \item{\code{neg_positive}}{1,721 word patterns indicating a positive word preceded by a negation (used to convey negative sentiment)}
-#' \item{\code{negative}}{2,860 word patterns indicating a negative word preceded by a negation (used to convey positive sentiment)}
+#' \item{\code{neg_negative}}{2,860 word patterns indicating a negative word preceded by a negation (used to convey positive sentiment)}
 #' }
 #' @references 
 #'   The objectives, development and reliability of the dictionary are discussed
@@ -162,6 +162,11 @@ NULL
 #' # on larger examples - notice that few negations are used
 #' dfm(data_char_ukimmig2010, dictionary = data_dictionary_LSD2015)
 #' kwic(data_char_ukimmig2010, "not")
+#' 
+#' # compound neg_negative and neg_positive tokens before creating a dfm object
+#' toks <- tokens_compound(tokens(txt), data_dictionary_LSD2015)
+#' 
+#' dfm_lookup(dfm(toks), data_dictionary_LSD2015)
 "data_dictionary_LSD2015"
 
 #' Confidence debate from 1991 Irish Parliament
@@ -201,5 +206,4 @@ NULL
 #' text(c(0.9, 0.9), c(8.5, 6.5), c("Goverment", "Opposition"))
 #' }
 "data_corpus_dailnoconf1991"
-
 

--- a/man/data_dictionary_LSD2015.Rd
+++ b/man/data_dictionary_LSD2015.Rd
@@ -9,7 +9,7 @@
 \item{\code{negative}}{2,858 word patterns indicating negative sentiment}
 \item{\code{positive}}{1,709 word patterns indicating positive sentiment}
 \item{\code{neg_positive}}{1,721 word patterns indicating a positive word preceded by a negation (used to convey negative sentiment)}
-\item{\code{negative}}{2,860 word patterns indicating a negative word preceded by a negation (used to convey positive sentiment)}
+\item{\code{neg_negative}}{2,860 word patterns indicating a negative word preceded by a negation (used to convey positive sentiment)}
 }}
 \usage{
 data_dictionary_LSD2015
@@ -53,6 +53,11 @@ tokens_lookup(tokens(txt), dictionary = data_dictionary_LSD2015, exclusive = FAL
 # on larger examples - notice that few negations are used
 dfm(data_char_ukimmig2010, dictionary = data_dictionary_LSD2015)
 kwic(data_char_ukimmig2010, "not")
+
+# compound neg_negative and neg_positive tokens before creating a dfm object
+toks <- tokens_compound(tokens(txt), data_dictionary_LSD2015)
+
+dfm_lookup(dfm(toks), data_dictionary_LSD2015)
 }
 \references{
 The objectives, development and reliability of the dictionary are discussed


### PR DESCRIPTION
- Fix mistake: "neg_negative" was called "negative" in the documentation
- Add example on how to use tokens_compound() before creating a dfm object to take into consideration the neg_negative/neg_positive tokens combinations
- Rebuild man