### PR TITLE
Fix incorrect key ID given for no-match #1347

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: quanteda
-Version: 1.2.2
+Version: 1.2.3
 Title: Quantitative Analysis of Textual Data
 Description: A fast, flexible, and comprehensive framework for 
     quantitative text analysis in R.  Provides functionality for corpus management,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,11 +1,5 @@
 # quanteda v1.2.3
 
-### Bug fixes
-
-* Fixed a bug affecting `tokens_lookup()` and `dfm_lookup()` when `nomatch` is used. (#1347)
-
-# quanteda v1.2.2
-
 ### New Features
 
 * Added `to = "tripletlist"` output type for `convert()`, to convert a dfm into a simple triplet list. (#1321) 
@@ -20,6 +14,7 @@
 ### Bug fixes
 
 * Fixed a bug in `textmodel_affinity()` that caused failure when the input dfm had been compiled with `tolower = FALSE`.  (#1338)
+* Fixed a bug affecting `tokens_lookup()` and `dfm_lookup()` when `nomatch` is used. (#1347)
 
 # quanteda v1.2.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# quanteda v1.2.3
+
+### Bug fixes
+
+* Fixed a bug affecting `tokens_lookup()` and `dfm_lookup()` when `nomatch` is used. (#1347)
+
 # quanteda v1.2.2
 
 ### New Features

--- a/R/dfm_lookup.R
+++ b/R/dfm_lookup.R
@@ -122,7 +122,7 @@ dfm_lookup.dfm <- function(x, dictionary, levels = 1:5,
             if (!is.null(nomatch)) {
                 values_id_nomatch <- setdiff(seq_len(nfeat(x)), values_id)
                 values_id <- c(values_id, values_id_nomatch)
-                keys_id <- c(keys_id, rep(max(keys_id) + 1, 
+                keys_id <- c(keys_id, rep(length(dictionary) + 1, 
                                           length(values_id_nomatch)))
                 keys <- c(keys, nomatch[1])
             }

--- a/src/tokens_lookup_mt.cpp
+++ b/src/tokens_lookup_mt.cpp
@@ -60,8 +60,8 @@ Text lookup(Text tokens,
             // return empty vector
             return {}; 
         } else if (nomatch == 1) {
-            // return tokens with no-match ID
-            Text keys_flat(tokens.size(), id_max + 1); 
+            // return tokens with no-match
+            Text keys_flat(tokens.size(), id_max); 
             return keys_flat;
         } else if (nomatch == 2) {
             // return shifted tokens in exclusive mode
@@ -89,7 +89,7 @@ Text lookup(Text tokens,
             keys_flat.insert(keys_flat.end(), key_sub.begin(), key_sub.end());
         } else {
             if (nomatch == 1) {
-                keys_flat.push_back(id_max + 1); // pad with a new ID
+                keys_flat.push_back(id_max); // pad with no-match
             } else if (nomatch == 2) {
                 keys_flat.push_back(id_max + tokens[i]); // keep original token
             }
@@ -133,7 +133,7 @@ struct lookup_mt : public Worker{
 * @param words_ list of patterns to find
 * @param ids_ IDs of patterns
 * @param overlap count overlapped words if true
-* @param nomatch determine how to treat unmached words: 0=remove, 1=keep; 2=pad
+* @param nomatch determine how to treat unmached words: 0=remove, 1=pad; 2=keep
 */
 
 
@@ -148,8 +148,12 @@ List qatd_cpp_tokens_lookup(const List &texts_,
     Texts texts = Rcpp::as<Texts>(texts_);
     Types types = Rcpp::as<Types>(types_);
     unsigned int id_max(0);
-    if (ids_.size() > 0) id_max = Rcpp::max(ids_);
-    // Rcout << id_max << "\n";
+    if (nomatch == 2) {
+        id_max = ids_.size() > 0 ? Rcpp::max(ids_) : 0;
+    } else {
+        id_max = types_.size();
+    }
+    //Rcout << id_max << "\n";
     
     //dev::Timer timer;
     

--- a/tests/testthat/test-dfm_lookup.R
+++ b/tests/testthat/test-dfm_lookup.R
@@ -231,9 +231,8 @@ test_that("dfm_lookup with nomatch works with key that do not appear in the text
                             CB = c("street", "feet"), 
                             CA = c("parl", "dark"))) # CA does not appear at all
     dfm_dict <- dfm_lookup(dfm(toks), dict, nomatch = "NONE")
-    expect_equivalent(as.matrix(dfm_dict),
+    expect_identical(as.matrix(dfm_dict),
                       matrix(c(2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 3, 5, 3, 3), 
-                             nrow = 4, dimnames = list(c("text1", "text2", "text3", "text4"),
-                                                       c("CR", "CB", "CA", "NONE"))))
-    
+                             nrow = 4, dimnames = list(docs = c("text1", "text2", "text3", "text4"),
+                                                       features = c("CR", "CB", "CA", "NONE"))))
 })

--- a/tests/testthat/test-dfm_lookup.R
+++ b/tests/testthat/test-dfm_lookup.R
@@ -219,3 +219,21 @@ test_that("dfm_lookup works on a weighted dfm", {
         tol = .001
     )
 })
+
+test_that("dfm_lookup with nomatch works with key that do not appear in the text, #1347", {
+    
+    txt <- c("12032 Musgrave rd red hill", 
+             "13 rad street windermore park queensland",
+             "130 right road", 
+             "130 rtn road")
+    toks <- tokens(txt)
+    dict <- dictionary(list(CR = c("rd", "red"), 
+                            CB = c("street", "feet"), 
+                            CA = c("parl", "dark"))) # CA does not appear at all
+    dfm_dict <- dfm_lookup(dfm(toks), dict, nomatch = "NONE")
+    expect_equivalent(as.matrix(dfm_dict),
+                      matrix(c(2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 3, 5, 3, 3), 
+                             nrow = 4, dimnames = list(c("text1", "text2", "text3", "text4"),
+                                                       c("CR", "CB", "CA", "NONE"))))
+    
+})

--- a/tests/testthat/test-tokens_lookup.R
+++ b/tests/testthat/test-tokens_lookup.R
@@ -417,3 +417,21 @@ test_that("tokens_lookup works when there is a key with non-existent values and 
     )
     
 })
+
+test_that("tokens_lookup with nomatch works with key that do not appear in the text, #1347", {
+    
+    # text
+    txt <- c("12032 Musgrave rd red hill", 
+             "13 rad street windermore park queensland",
+             "130 right road", 
+             "130 rtn road")
+    toks <- tokens(txt)
+    dict <- dictionary(list(CR = c("rd", "red"), 
+                            CB = c("street", "feet"), 
+                            CA = c("parl", "dark"))) # CA does not appear at all
+    toks_dict <- quanteda::tokens_lookup(toks, dict, nomatch = "NONE")
+    expect_equivalent(unclass(toks_dict), 
+                      list(c(4, 4, 1, 1, 4), c(4, 4, 2, 4, 4, 4), c(4, 4, 4), c(4, 4, 4)))
+    expect_identical(types(toks_dict), c("CR", "CB", "CA", "NONE"))
+    
+})

--- a/tests/testthat/test-tokens_lookup.R
+++ b/tests/testthat/test-tokens_lookup.R
@@ -420,7 +420,6 @@ test_that("tokens_lookup works when there is a key with non-existent values and 
 
 test_that("tokens_lookup with nomatch works with key that do not appear in the text, #1347", {
     
-    # text
     txt <- c("12032 Musgrave rd red hill", 
              "13 rad street windermore park queensland",
              "130 right road", 
@@ -429,7 +428,7 @@ test_that("tokens_lookup with nomatch works with key that do not appear in the t
     dict <- dictionary(list(CR = c("rd", "red"), 
                             CB = c("street", "feet"), 
                             CA = c("parl", "dark"))) # CA does not appear at all
-    toks_dict <- quanteda::tokens_lookup(toks, dict, nomatch = "NONE")
+    toks_dict <- tokens_lookup(toks, dict, nomatch = "NONE")
     expect_equivalent(unclass(toks_dict), 
                       list(c(4, 4, 1, 1, 4), c(4, 4, 2, 4, 4, 4), c(4, 4, 4), c(4, 4, 4)))
     expect_identical(types(toks_dict), c("CR", "CB", "CA", "NONE"))

--- a/tests/testthat/test-tokens_lookup.R
+++ b/tests/testthat/test-tokens_lookup.R
@@ -419,7 +419,6 @@ test_that("tokens_lookup works when there is a key with non-existent values and 
 })
 
 test_that("tokens_lookup with nomatch works with key that do not appear in the text, #1347", {
-    
     txt <- c("12032 Musgrave rd red hill", 
              "13 rad street windermore park queensland",
              "130 right road", 
@@ -429,8 +428,12 @@ test_that("tokens_lookup with nomatch works with key that do not appear in the t
                             CB = c("street", "feet"), 
                             CA = c("parl", "dark"))) # CA does not appear at all
     toks_dict <- tokens_lookup(toks, dict, nomatch = "NONE")
+    expect_identical(as.list(toks_dict), 
+                      list(text1 = c("NONE", "NONE", "CR", "CR", "NONE"), 
+                           text2 = c("NONE", "NONE", "CB", "NONE", "NONE", "NONE"), 
+                           text3 = c("NONE", "NONE", "NONE"),
+                           text4 = c("NONE", "NONE", "NONE")))
     expect_equivalent(unclass(toks_dict), 
                       list(c(4, 4, 1, 1, 4), c(4, 4, 2, 4, 4, 4), c(4, 4, 4), c(4, 4, 4)))
     expect_identical(types(toks_dict), c("CR", "CB", "CA", "NONE"))
-    
 })


### PR DESCRIPTION
- It happens when there are keys that does not appear in dictionary and nomatch is used
- Solve by changing how to obtain a new key ID
- Probably a regression induced when #1278 was solved