### PR TITLE
correct minor error in documentation

### DIFF
--- a/R/textstat_frequency.R
+++ b/R/textstat_frequency.R
@@ -44,6 +44,7 @@
 #' dfm_weight_pres <- data_corpus_inaugural %>% 
 #'     corpus_subset(Year > 2000) %>% 
 #'     dfm(remove = stopwords("english"), remove_punct = TRUE) %>% 
+#'     dfm_group(groups = "President") %>%
 #'     dfm_weight(scheme = "prop")
 #' 
 #' # calculate relative frequency by president


### PR DESCRIPTION
the dfm needs to be grouped before weighting, otherwise textstat_frequency() sums up the weights (here: proportions) for the 2 obama and 2 bush speeches.

current help file:

```r
> # plot relative frequencies by group
> dfm_weight_pres <- data_corpus_inaugural %>%
+     corpus_subset(Year > 2000) %>%
+     dfm(remove = stopwords("english"), remove_punct = TRUE) %>%
+     dfm_weight(scheme = "prop")
> 
> # calculate relative frequency by president
> freq_weight <- textstat_frequency(dfm_weight_pres, n = 10,
+                                   groups = "President")
> freq_weight
     feature   frequency rank docfreq group
1    freedom 0.030392921    1       2  Bush
2    america 0.021731459    2       2  Bush
3    country 0.019164510    3       2  Bush
4     nation 0.018849615    4       2  Bush
5      every 0.017259209    5       2  Bush
6   citizens 0.017243281    6       2  Bush
7         us 0.016912457    7       2  Bush
8    liberty 0.015684732    8       2  Bush
9        can 0.014377365    9       2  Bush
10 americans 0.014062469   10       2  Bush
11        us 0.039878113    1       2 Obama
12      must 0.023229386    2       2 Obama
13       can 0.017839451    3       2 Obama
14    people 0.016585365    4       2 Obama
15    nation 0.016021685    5       2 Obama
16       new 0.015169170    6       2 Obama
17      time 0.014767599    7       2 Obama
18     every 0.013576876    8       2 Obama
19   america 0.012611625    9       2 Obama
20       now 0.009941344   10       2 Obama
21   america 0.025174825    1       1 Trump
22  american 0.015384615    2       1 Trump
23    people 0.013986014    3       1 Trump
24   country 0.012587413    4       1 Trump
25       one 0.011188811    5       1 Trump
26     every 0.009790210    6       1 Trump
27       new 0.008391608    7       1 Trump
28    nation 0.008391608    8       1 Trump
29     world 0.008391608    9       1 Trump
30       now 0.008391608   10       1 Trump
```

## Expected behavior

how it should be:

```r
> dfm_weight_pres <- data_corpus_inaugural %>% 
+   corpus_subset(Year > 2000) %>% 
+   dfm(remove = stopwords("english"), remove_punct = TRUE) %>% 
+   dfm_group(groups = "President") %>%
+   dfm_weight(scheme = "prop")
> # calculate relative frequency by president
> freq_weight <- textstat_frequency(dfm_weight_pres, n = 10,
+                                   groups = "President")
> freq_weight
     feature   frequency rank docfreq group
1    freedom 0.016438356    1       1  Bush
2    america 0.010958904    2       1  Bush
3    country 0.009315068    3       1  Bush
4     nation 0.009315068    4       1  Bush
5      every 0.008767123    5       1  Bush
6    liberty 0.008767123    6       1  Bush
7   citizens 0.008219178    7       1  Bush
8         us 0.007671233    8       1  Bush
9  americans 0.007123288    9       1  Bush
10       can 0.007123288   10       1  Bush
11        us 0.019918515    1       1 Obama
12      must 0.011317338    2       1 Obama
13       can 0.009053871    3       1 Obama
14    nation 0.008148483    4       1 Obama
15    people 0.008148483    5       1 Obama
16       new 0.007695790    6       1 Obama
17      time 0.007243096    7       1 Obama
18     every 0.006790403    8       1 Obama
19   america 0.006337709    9       1 Obama
20       now 0.004979629   10       1 Obama
21   america 0.025174825    1       1 Trump
22  american 0.015384615    2       1 Trump
23    people 0.013986014    3       1 Trump
24   country 0.012587413    4       1 Trump
25       one 0.011188811    5       1 Trump
26     every 0.009790210    6       1 Trump
27       new 0.008391608    7       1 Trump
28    nation 0.008391608    8       1 Trump
29     world 0.008391608    9       1 Trump
30       now 0.008391608   10       1 Trump
```