### PR TITLE
Integrate sophistication

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,9 @@
 * Add error checking for functions taking dfm inputs in case a dfm has empty features (#1419).
 * For `textstat_readability()`, fixed a bug in Dale-Chall-based measures and in the Spache word list measure.  These were caused by an incorrect lookup mechanism but also by limited implementation of the wordlists.  The new wordlists include all of the variations called for in the original measures, but using fast fixed matching. (#1410)
 
+### New Features
+
+* Added new argument `intermediate` to `textstat_readability(x, measure, intermediate = FALSE)`, which if `TRUE` returns intermediate quantities used in the computation of readability statistics.  Useful for verification or direct use of the intermediate quantities.
 
 # quanteda v1.3.4
 

--- a/R/textstat_readability.R
+++ b/R/textstat_readability.R
@@ -17,6 +17,7 @@
 #'   
 #'   For finer-grained control, consider filtering sentences prior first, 
 #'   including through pattern-matching, using \code{\link{corpus_trim}}.
+#' @param intermediate if \code{TRUE}, include intermediate quantities in the output
 #' @param ... not used
 #' @author Kenneth Benoit, re-engineered from Meik Michalke's \pkg{koRpus}
 #'   package.
@@ -50,7 +51,8 @@ textstat_readability <- function(x,
                                     "Wheeler.Smith", "meanSentenceLength", "meanWordSyllables"),
                         remove_hyphens = TRUE,
                         min_sentence_length = 1, 
-                        max_sentence_length = 10000, ...) {
+                        max_sentence_length = 10000, 
+                        intermediate = FALSE, ...) {
     UseMethod("textstat_readability")
 }
 
@@ -72,7 +74,8 @@ textstat_readability.default <- function(x,
                                                     "Wheeler.Smith", "meanSentenceLength", "meanWordSyllables"),
                                         remove_hyphens = TRUE,
                                         min_sentence_length = 1, 
-                                        max_sentence_length = 10000, ...) {
+                                        max_sentence_length = 10000, 
+                                        intermediate = FALSE, ...) {
     stop(friendly_class_undefined_message(class(x), "textstat_readability"))
 }    
 
@@ -95,7 +98,8 @@ textstat_readability.corpus <- function(x,
                                            "Wheeler.Smith", "meanSentenceLength", "meanWordSyllables"),
                                remove_hyphens = TRUE,
                                min_sentence_length = 1, 
-                               max_sentence_length = 10000, ...) {
+                               max_sentence_length = 10000, 
+                               intermediate = FALSE, ...) {
     
     unused_dots(...)
     
@@ -382,11 +386,17 @@ textstat_readability.corpus <- function(x,
         temp[, Scrabble := nscrabble(x, mean)]
     
     result <- data.frame(document = names(x), stringsAsFactors = FALSE)
-    result <- cbind(result, as.data.frame(temp[,measure, with = FALSE]))
-    class(result) <- c('readability', 'textstat', 'data.frame')
+    
+    # if intermediate is desired, add intermediate quantities to output
+    if (intermediate)
+        measure <- c(measure, names(temp)[names(temp) %in% 
+                                              c(c("W", "St", "C", "Sy", "W3Sy", "W2Sy", "W_1Sy", 
+                                                  "W6C", "W7C", "Wlt3Sy", "W_wl.Dale.Chall", "W_wl.Spache"))])
+
+    result <- cbind(result, as.data.frame(temp[, measure, with = FALSE]))
+    class(result) <- c("readability", "textstat", "data.frame")
     rownames(result) <- as.character(seq_len(nrow(result)))
     return(result)
-
 }
 
 

--- a/docs/reference/textstat_readability.html
+++ b/docs/reference/textstat_readability.html
@@ -217,7 +217,8 @@ indexes.</p>
   <span class='st'>"SMOG.C"</span>, <span class='st'>"SMOG.simple"</span>,      <span class='st'>"SMOG.de"</span>, <span class='st'>"Spache"</span>, <span class='st'>"Spache.old"</span>,
   <span class='st'>"Strain"</span>, <span class='st'>"Traenkle.Bailer"</span>, <span class='st'>"Traenkle.Bailer.2"</span>, <span class='st'>"Wheeler.Smith"</span>,
   <span class='st'>"meanSentenceLength"</span>, <span class='st'>"meanWordSyllables"</span>), <span class='kw'>remove_hyphens</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>,
-  <span class='kw'>min_sentence_length</span> <span class='kw'>=</span> <span class='fl'>1</span>, <span class='kw'>max_sentence_length</span> <span class='kw'>=</span> <span class='fl'>10000</span>, <span class='no'>...</span>)</pre>
+  <span class='kw'>min_sentence_length</span> <span class='kw'>=</span> <span class='fl'>1</span>, <span class='kw'>max_sentence_length</span> <span class='kw'>=</span> <span class='fl'>10000</span>,
+  <span class='kw'>intermediate</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>, <span class='no'>...</span>)</pre>
     
     <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a>Arguments</h2>
     <table class="ref-arguments">
@@ -247,6 +248,10 @@ may not really be sentences, such as section titles, table elements, and
 other cruft that might be in the texts following conversion.</p>
 <p>For finer-grained control, consider filtering sentences prior first, 
 including through pattern-matching, using <code><a href='corpus_trim.html'>corpus_trim</a></code>.</p></td>
+    </tr>
+    <tr>
+      <th>intermediate</th>
+      <td><p>if <code>TRUE</code>, include intermediate quantities in the output</p></td>
     </tr>
     <tr>
       <th>...</th>

--- a/man/textstat_readability.Rd
+++ b/man/textstat_readability.Rd
@@ -15,7 +15,8 @@ textstat_readability(x, measure = c("all", "ARI", "ARI.simple",
   "SMOG.C", "SMOG.simple",      "SMOG.de", "Spache", "Spache.old",
   "Strain", "Traenkle.Bailer", "Traenkle.Bailer.2", "Wheeler.Smith",
   "meanSentenceLength", "meanWordSyllables"), remove_hyphens = TRUE,
-  min_sentence_length = 1, max_sentence_length = 10000, ...)
+  min_sentence_length = 1, max_sentence_length = 10000,
+  intermediate = FALSE, ...)
 }
 \arguments{
 \item{x}{a character or \link{corpus} object containing the texts}
@@ -36,6 +37,8 @@ other cruft that might be in the texts following conversion.
 
 For finer-grained control, consider filtering sentences prior first, 
 including through pattern-matching, using \code{\link{corpus_trim}}.}
+
+\item{intermediate}{if \code{TRUE}, include intermediate quantities in the output}
 
 \item{...}{not used}
 }

--- a/tests/data_creation/create_wordlists.R
+++ b/tests/data_creation/create_wordlists.R
@@ -1,3 +1,5 @@
+library("quanteda")
+
 makewordlist <- function(filename) {
     wordlist <- readtext::readtext(filename)[["text"]] %>%
         stringi::stri_split_regex(pattern = "\\p{WHITE_SPACE}+", simplify = TRUE) %>%

--- a/tests/testthat/test-textstat_readability.R
+++ b/tests/testthat/test-textstat_readability.R
@@ -121,3 +121,19 @@ come to the bottle-fed baby in milk which has not been pasteurized or boiled."
     expect_equal(textstat_readability(dc3, "Dale.Chall.old")$Dale.Chall.old, 6.9474, tolerance = .01)
 })
 
+test_that("textstat_readability with intermediate = TRUE works", {
+    rs1a <- textstat_readability(data_char_sampletext, measure = "Flesch.Kincaid", intermediate = TRUE)
+    rs1b <- textstat_readability(data_char_sampletext, measure = "Flesch.Kincaid", intermediate = FALSE)
+    rs2 <- textstat_readability(data_char_sampletext, measure = c("Dale.Chall.old", "Flesch"), intermediate = TRUE)
+    
+    expect_true(
+        all(c("Flesch.Kincaid", "W", "St", "C", "Sy", "W3Sy", "W2Sy", "W_1Sy", "W6C", "W7C", "Wlt3Sy") %in% names(rs1a))
+    )
+    expect_true(
+        !any(c("W", "St", "C", "Sy", "W3Sy", "W2Sy", "W_1Sy", "W6C", "W7C", "Wlt3Sy") %in% names(rs1b))
+    )
+    expect_true(
+        all(c("Dale.Chall.old", "Flesch", "W", "St", "C", "Sy", "W3Sy", "W2Sy", "W_1Sy", "W6C", "W7C", "Wlt3Sy", "W_wl.Dale.Chall") %in% names(rs2))
+    )
+    
+})


### PR DESCRIPTION
Adds an argument to `textstat_readability()` that I need for the replication materials to work, for a forthcoming article in the _AJPS_ , "Measuring and Explaining Political Sophistication Through Textual
 Complexity", deposited at https://doi.org/10.7910/DVN/9SF3TI.