### PR TITLE
Update docs.quanteda.io

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -77,7 +77,7 @@ Suggests:
     xtable,
     knitr,
     igraph
-URL: http://quanteda.io
+URL: https://quanteda.io
 Encoding: UTF-8
 BugReports: https://github.com/quanteda/quanteda/issues
 LazyData: TRUE

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 
 [![quanteda: quantitative analysis of textual
-data](https://cdn.rawgit.com/quanteda/quanteda/master/images/quanteda_logo.svg)](http://quanteda.io)
+data](https://cdn.rawgit.com/quanteda/quanteda/master/images/quanteda_logo.svg)](https://quanteda.io)
 
 [![CRAN
 Version](https://www.r-pkg.org/badges/version/quanteda)](https://CRAN.R-project.org/package=quanteda)

--- a/docs/articles/design.Rmd
+++ b/docs/articles/design.Rmd
@@ -15,7 +15,7 @@ knitr::opts_chunk$set(
 )
 ```
 
-See http://docs.quanteda.io for additional tutorials, examples, and general documentation.
+See https://quanteda.io for additional tutorials, examples, and general documentation.
 
 # Introduction
 

--- a/index.md
+++ b/index.md
@@ -76,7 +76,7 @@ How to Use
 ----------
 
 See the [quick start
-guide](http://docs.quanteda.io/articles/quickstart.html) to learn how to
+guide](http://quanteda.io/articles/quickstart.html) to learn how to
 use **quanteda**.
 
 Leaving Feedback

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -6,7 +6,7 @@ bibentry(bibtype = "Manual",
          title = "quanteda: Quantitative Analysis of Textual Data",
          author = c(person("Kenneth", "Benoit")),
          doi = "10.5281/zenodo.1004683",
-         url = "http://quanteda.io",
+         url = "https://quanteda.io",
          year = 2018,
          note = note
 )

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -145,7 +145,7 @@ package more reliable for other packages that depend on it.
 
 _Accessibility_.  **quanteda** contains extensive manual pages structured around
 the naming rules. Furthermore, there are references, package vignettes, examples,
-and tutorials on the website at http://docs.quanteda.io. These materials help
+and tutorials on the website at https://quanteda.io. These materials help
 beginner users to understand how to use these functions for basic operations,
 and expert users to combine the functions for advanced text processing and analysis.
 

--- a/vignettes/pkgdown/comparison-packages-data.csv
+++ b/vignettes/pkgdown/comparison-packages-data.csv
@@ -25,7 +25,7 @@ Distance/similarity measures,Text statistics,textstat_simil(); textstat_dist(),,
 Keyness statistics,Text statistics,textstat_keyness(),,,,,
 Wordcloud,Text statistics,textplot_wordcloud(),,,,,
 Correspondence Analysis,Text scaling models,textmodel_ca(),,,,,
-Naïve Bayes,Text scaling models,textmodel_NB(),,,,,NaiveBayesClassifier
+Naïve Bayes,Text scaling models,textmodel_nb(),,,,,NaiveBayesClassifier
 Wordscores,Text scaling models,textmodel_wordscores(),,,,,
 Wordfish,Text scaling models,textmodel_wordfish(),,,,,
 Convert dfm to other format,Additional functions,convert(),,cast_tdm(),,,

--- a/vignettes/pkgdown/design.Rmd
+++ b/vignettes/pkgdown/design.Rmd
@@ -13,7 +13,7 @@ knitr::opts_chunk$set(
 )
 ```
 
-See http://docs.quanteda.io for additional tutorials, examples, and general documentation.
+See https://quanteda.io for additional tutorials, examples, and general documentation.
 
 # Introduction
 

--- a/vignettes/pkgdown/quickstart_cn.Rmd
+++ b/vignettes/pkgdown/quickstart_cn.Rmd
@@ -416,7 +416,7 @@ if (require(topicmodels)) {
     get_terms(my_lda_fit20, 5)
 }
 ```
-注：以上这个指南翻译于英文版[quickstart](http://docs.quanteda.io/articles/pkgdown/quickstart.html).
+注：以上这个指南翻译于英文版[quickstart](https://quanteda.io/articles/pkgdown/quickstart.html).
 
 
 # Quanteda处理中文文档 {#processing-chinese-documentation}

--- a/vignettes/pkgdown/quickstart_es.Rmd
+++ b/vignettes/pkgdown/quickstart_es.Rmd
@@ -293,8 +293,8 @@ Para un objeto `dfm` se puede graficar una nube de palabras usando `textplot_wor
 
 ```{r warning=FALSE, fig.width = 7, fig.height = 7}
 set.seed(100)
-textplot_wordcloud(mydfm, min.freq = 6, random.order = FALSE,
-                  rot.per = .25, 
+textplot_wordcloud(mydfm, min_freq = 6, random_order = FALSE,
+                  rotation = .25, 
                   colors = RColorBrewer::brewer.pal(8,"Dark2"))
 ```
 


### PR DESCRIPTION
- Changes remaining occurrences of `http://docs.quanteda.io` to `https://quanteda.io`
- Updates comparison table
- Updates code for `textplot_wordcloud()` in vignette

Requires rebuilding **pkgdown** site and the documentation.