### PR TITLE
Separate remove_symbols, add tests

### DIFF
--- a/R/tokens.R
+++ b/R/tokens.R
@@ -157,7 +157,7 @@
 tokens <-  function(x, what = c("word", "sentence", "character", "fastestword", "fasterword"),
                     remove_numbers = FALSE,
                     remove_punct = FALSE,
-                    remove_symbols = FALSE,
+                    remove_symbols = remove_punct,
                     remove_separators = TRUE,
                     remove_twitter = FALSE,
                     remove_hyphens = FALSE,
@@ -203,7 +203,7 @@ tokens.corpus <- function(x, ..., include_docvars = TRUE) {
 tokens.tokens <-  function(x, what = c("word", "sentence", "character", "fastestword", "fasterword"),
                            remove_numbers = FALSE,
                            remove_punct = FALSE,
-                           remove_symbols = FALSE,
+                           remove_symbols = remove_punct,
                            remove_separators = TRUE,
                            remove_twitter = FALSE,
                            remove_hyphens = FALSE,
@@ -228,7 +228,7 @@ tokens.tokens <-  function(x, what = c("word", "sentence", "character", "fastest
     if (remove_numbers)
         regex <- c(regex, "^[\\p{N}]+$")
     if (remove_punct)
-        regex <- c(regex, "^[\\p{P}\\p{S}]+$")
+        regex <- c(regex, "^[\\p{P}]+$")
     if (remove_symbols)
         regex <- c(regex, "^[\\p{S}]+$")
     if (remove_separators)
@@ -631,7 +631,7 @@ tokens_internal <- function(x, what = c("word", "sentence", "character", "fastes
         if (remove_numbers)
             regex <- c(regex, "^[\\p{N}]+$")
         if (remove_punct)
-            regex <- c(regex, "^[\\p{P}\\p{S}]+$")
+            regex <- c(regex, "^[\\p{P}]+$")
         if (remove_symbols)
             regex <- c(regex, "^[\\p{S}]+$")
         if (remove_separators)

--- a/man/tokens.Rd
+++ b/man/tokens.Rd
@@ -6,7 +6,7 @@
 \usage{
 tokens(x, what = c("word", "sentence", "character", "fastestword",
   "fasterword"), remove_numbers = FALSE, remove_punct = FALSE,
-  remove_symbols = FALSE, remove_separators = TRUE,
+  remove_symbols = remove_punct, remove_separators = TRUE,
   remove_twitter = FALSE, remove_hyphens = FALSE, remove_url = FALSE,
   ngrams = 1L, skip = 0L, concatenator = "_",
   verbose = quanteda_options("verbose"), include_docvars = TRUE, ...)

--- a/tests/testthat/test-tokens.R
+++ b/tests/testthat/test-tokens.R
@@ -543,3 +543,76 @@ test_that("warn when remove_separators = FALSE fasterword and fastestword", {
     expect_warning(tokens("a b c", what = "fastestword", remove_separators = FALSE),
                    "remove_separators = FALSE has no effect")
 })
+
+test_that("remove_punct and remove_symbols are distinct (#1445)", {
+    txt <- c(doc = "I bet ± £100!")
+
+    expect_identical(
+        as.character(tokens(txt, remove_punct = FALSE, remove_symbols = FALSE)),
+        c("I", "bet", "±", "£", "100", "!")
+    )
+    
+    expect_identical(
+        as.character(tokens(txt, remove_punct = TRUE, remove_symbols = FALSE)),
+        c("I", "bet", "±", "£", "100")
+    )
+    
+    expect_identical(
+        as.character(tokens(txt, remove_punct = FALSE, remove_symbols = TRUE)),
+        c("I", "bet", "100", "!")
+    )
+    
+    expect_identical(
+        as.character(tokens(txt, remove_punct = TRUE, remove_symbols = TRUE)),
+        c("I", "bet", "100")
+    )
+  
+    # test defaults
+    expect_identical(
+        as.character(tokens(txt)),
+        c("I", "bet", "±", "£", "100", "!")
+    )
+    expect_identical(
+        as.character(tokens(txt, remove_punct = TRUE)),
+        c("I", "bet", "100")
+    )
+    expect_identical(
+        as.character(tokens(txt, remove_symbols = TRUE)),
+        c("I", "bet", "100", "!")
+    )
+})
+
+test_that("remove_punct and remove_symbols are distinct (#1445)", {
+    # separated because of #1464
+    txt <- c(doc = "I bet ± £ 100 !")
+
+    expect_identical(
+        as.character(tokens(txt, what = "word", remove_punct = FALSE, remove_symbols = FALSE)),
+        c("I", "bet", "±", "£", "100", "!")
+    )
+    
+    expect_identical(
+        as.character(tokens(txt, what = "word", remove_punct = TRUE, remove_symbols = FALSE)),
+        c("I", "bet", "±", "£", "100")
+    )
+    
+    expect_identical(
+        as.character(tokens(txt, what = "fasterword", remove_punct = FALSE, remove_symbols = FALSE)),
+        c("I", "bet", "±", "£", "100", "!")
+    )
+    
+    expect_identical(
+        as.character(tokens(txt, what = "fasterword", remove_punct = TRUE, remove_symbols = FALSE)),
+        c("I", "bet", "±", "£", "100")
+    )
+    
+    expect_identical(
+        as.character(tokens(txt, what = "fastestword", remove_punct = FALSE, remove_symbols = FALSE)),
+        c("I", "bet", "±", "£", "100", "!")
+    )
+    
+    expect_identical(
+        as.character(tokens(txt, what = "fastestword", remove_punct = TRUE, remove_symbols = FALSE)),
+        c("I", "bet", "±", "£", "100")
+    )    
+})


### PR DESCRIPTION
Fixes #1445.

In the spirit of "test-driven development", this PR was started with tests that fail, and it will be ready when we can make them pass.

The tests for 
```r
# separated because of #1464
txt <- c(doc = "I bet ± £ 100 !")
tokens(txt, what = "word", remove_punct = FALSE, remove_symbols = FALSE)
```
fail because of https://github.com/quanteda/quanteda/blob/Issue-1445/R/tokens.R#L676-L677

The tests for 
```r
# separated because of #1464
txt <- c(doc = "I bet ± £ 100 !")
tokens(txt, what = "fastestword", remove_punct = TRUE, remove_symbols = FALSE))
```
fail because https://github.com/quanteda/quanteda/blob/Issue-1445/R/tokens.R#L590 hardwires the options to `FALSE` (meaning we have more problems here than just `remove_symbols`). Note: This could be moved to #1467 for which I have filed a new issue, since it is very different from the issue for `what  = "word"` above.
