### PR TITLE
Minor corrections in documentation of textmodel_wordscores() and textplot_scale1d()

### DIFF
--- a/R/textmodel_wordscores.R
+++ b/R/textmodel_wordscores.R
@@ -13,9 +13,9 @@
 #' @param x the \link{dfm} on which the model will be trained
 #' @param y vector of training scores associated with each document 
 #'   in \code{x}
-#' @param smooth a smoothing parameter for word counts; defaults to zero for the
-#'   to match the LBG (2003) method.  See Value below for additional
-#'   information on the behaviour of this argument.
+#' @param smooth a smoothing parameter for word counts; defaults to zero to match the LBG (2003) method. 
+#' See Value below for additional information on the behaviour
+#'  of this argument.
 #' @param scale scale on which to score the words; \code{"linear"} for classic 
 #'   LBG linear posterior weighted word class differences, or \code{"logit"}
 #'   for log posterior differences

--- a/R/textmodel_wordscores.R
+++ b/R/textmodel_wordscores.R
@@ -13,9 +13,9 @@
 #' @param x the \link{dfm} on which the model will be trained
 #' @param y vector of training scores associated with each document 
 #'   in \code{x}
-#' @param smooth a smoothing parameter for word counts; defaults to zero to match the LBG (2003) method. 
-#' See Value below for additional information on the behaviour
-#'  of this argument.
+#' @param smooth a smoothing parameter for word counts; defaults to zero to
+#'   match the LBG (2003) method. See Value below for additional information on
+#'   the behaviour of this argument.
 #' @param scale scale on which to score the words; \code{"linear"} for classic 
 #'   LBG linear posterior weighted word class differences, or \code{"logit"}
 #'   for log posterior differences
@@ -23,8 +23,8 @@
 #'   \code{\link[=predict.textmodel_wordscores]{predict()}} method are designed
 #'   to function in the same manner as \code{\link[stats]{predict.lm}}.
 #'   \code{coef()} can also be used to extract the word coefficients from the
-#'   fitted \code{textmodel_wordscores} object, and \code{summary()} will print a
-#'   nice summary of the fitted object.
+#'   fitted \code{textmodel_wordscores} object, and \code{summary()} will print
+#'   a nice summary of the fitted object.
 #' @return  A fitted \code{textmodel_wordscores} object.  This object will
 #'   contain a copy of the input data, but in its original form without any
 #'   smoothing applied. Calling \code{\link{predict.textmodel_wordscores}} on
@@ -42,9 +42,10 @@
 #' predict(ws)
 #' predict(ws, rescaling = "lbg")
 #' predict(ws, se.fit = TRUE, interval = "confidence", rescaling = "mv")
-#' @references Laver, Michael, Kenneth R Benoit, and John Garry. 2003. 
-#'   "\href{http://www.kenbenoit.net/pdfs/WORDSCORESAPSR.pdf}{Extracting Policy Positions From Political Texts Using Words as Data.}" 
-#'   \emph{American Political Science Review} 97(02): 311-31
+#' @references Laver, Michael, Kenneth R Benoit, and John Garry. 2003.
+#'   "\href{http://www.kenbenoit.net/pdfs/WORDSCORESAPSR.pdf}{Extracting Policy
+#'   Positions From Political Texts Using Words as Data.}" \emph{American
+#'   Political Science Review} 97(02): 311-31
 #'   
 #'   Beauchamp, N. 2012. "Using Text to Scale Legislatures with Uninformative 
 #'   Voting." New York University Mimeo.

--- a/R/textplot_scale1d.R
+++ b/R/textplot_scale1d.R
@@ -49,7 +49,7 @@
 #'                  groups = docvars(data_corpus_irishbudget2010, "party"))
 #'
 #' ## wordfish
-#' wf <- textmodel_wordfish(dfm(data_corpus_irishbudget2010), dir = c(6,5))
+#' wf <- textmodel_wordfish(ie_dfm, dir = c(6,5))
 #' # plot estimated document positions
 #' textplot_scale1d(wf, doclabels = doclab)
 #' textplot_scale1d(wf, doclabels = doclab,

--- a/man/textmodel_wordscores.Rd
+++ b/man/textmodel_wordscores.Rd
@@ -16,9 +16,9 @@ in \code{x}}
 LBG linear posterior weighted word class differences, or \code{"logit"}
 for log posterior differences}
 
-\item{smooth}{a smoothing parameter for word counts; defaults to zero to match the LBG (2003) method. 
-See Value below for additional information on the behaviour
- of this argument.}
+\item{smooth}{a smoothing parameter for word counts; defaults to zero to
+match the LBG (2003) method. See Value below for additional information on
+the behaviour of this argument.}
 }
 \value{
 A fitted \code{textmodel_wordscores} object.  This object will
@@ -42,8 +42,8 @@ The \code{textmodel_wordscores()} function and the associated
   \code{\link[=predict.textmodel_wordscores]{predict()}} method are designed
   to function in the same manner as \code{\link[stats]{predict.lm}}.
   \code{coef()} can also be used to extract the word coefficients from the
-  fitted \code{textmodel_wordscores} object, and \code{summary()} will print a
-  nice summary of the fitted object.
+  fitted \code{textmodel_wordscores} object, and \code{summary()} will print
+  a nice summary of the fitted object.
 }
 \examples{
 (ws <- textmodel_wordscores(data_dfm_lbgexample, c(seq(-1.5, 1.5, .75), NA)))
@@ -54,9 +54,10 @@ predict(ws, rescaling = "lbg")
 predict(ws, se.fit = TRUE, interval = "confidence", rescaling = "mv")
 }
 \references{
-Laver, Michael, Kenneth R Benoit, and John Garry. 2003. 
-  "\href{http://www.kenbenoit.net/pdfs/WORDSCORESAPSR.pdf}{Extracting Policy Positions From Political Texts Using Words as Data.}" 
-  \emph{American Political Science Review} 97(02): 311-31
+Laver, Michael, Kenneth R Benoit, and John Garry. 2003.
+  "\href{http://www.kenbenoit.net/pdfs/WORDSCORESAPSR.pdf}{Extracting Policy
+  Positions From Political Texts Using Words as Data.}" \emph{American
+  Political Science Review} 97(02): 311-31
   
   Beauchamp, N. 2012. "Using Text to Scale Legislatures with Uninformative 
   Voting." New York University Mimeo.

--- a/man/textmodel_wordscores.Rd
+++ b/man/textmodel_wordscores.Rd
@@ -16,9 +16,9 @@ in \code{x}}
 LBG linear posterior weighted word class differences, or \code{"logit"}
 for log posterior differences}
 
-\item{smooth}{a smoothing parameter for word counts; defaults to zero for the
-to match the LBG (2003) method.  See Value below for additional
-information on the behaviour of this argument.}
+\item{smooth}{a smoothing parameter for word counts; defaults to zero to match the LBG (2003) method. 
+See Value below for additional information on the behaviour
+ of this argument.}
 }
 \value{
 A fitted \code{textmodel_wordscores} object.  This object will

--- a/man/textplot_scale1d.Rd
+++ b/man/textplot_scale1d.Rd
@@ -70,7 +70,7 @@ textplot_scale1d(predict(ws, se.fit = TRUE), doclabels = doclab,
                  groups = docvars(data_corpus_irishbudget2010, "party"))
 
 ## wordfish
-wf <- textmodel_wordfish(dfm(data_corpus_irishbudget2010), dir = c(6,5))
+wf <- textmodel_wordfish(ie_dfm, dir = c(6,5))
 # plot estimated document positions
 textplot_scale1d(wf, doclabels = doclab)
 textplot_scale1d(wf, doclabels = doclab,


### PR DESCRIPTION
- Correct syntax in `textmodel_wordscores()` man
- Use `ie_dfm` for the Wordfish example in `textplot_scale1d()` to match the structure with the Wordscores and CA examples