### PR TITLE
return metadoc as well as docvars from group_dfm()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ### Bug fixes and stability enhancements
 
-* None (yet).
+* Fixed bug in `dfm_compress()` and `dfm_group()` that changed or deleted docvars attributes of dfm objects (#1506).
 
 ### New features
 

--- a/R/dfm_compress.R
+++ b/R/dfm_compress.R
@@ -37,24 +37,23 @@ dfm_compress <- function(x, margin = c("both", "documents", "features")) {
 }
     
 #' @export
-dfm_compress.default <- function(x, 
+dfm_compress.default <- function(x,
                                  margin = c("both", "documents", "features")) {
     stop(friendly_class_undefined_message(class(x), "dfm_compress"))
 }
 
 #' @export
 dfm_compress.dfm <- function(x, margin = c("both", "documents", "features")) {
-    
+
     x <- as.dfm(x)
     if (!nfeat(x) || !ndoc(x)) return(x)
     margin <- match.arg(margin)
-    if (margin == 'documents') {
+    if (margin == "documents") {
         result <- group_dfm(x, NULL, docnames(x))
-    } else if (margin == 'features') {
+    } else if (margin == "features") {
         result <- group_dfm(x, featnames(x), NULL)
     } else {
         result <- group_dfm(x, featnames(x), docnames(x))
     }
     return(result)
 }
-

--- a/R/dfm_group.R
+++ b/R/dfm_group.R
@@ -42,10 +42,9 @@ dfm_group.default <- function(x, groups = NULL, fill = FALSE) {
     
 #' @export
 dfm_group.dfm <- function(x, groups = NULL, fill = FALSE) {
-    
-    if (is.null(groups))
-        return(x)
-    
+
+    if (is.null(groups)) return(x)
+
     x <- as.dfm(x)
     dvars <- docvars_internal(x)
     if (!nfeat(x) || !ndoc(x)) return(x)
@@ -54,7 +53,7 @@ dfm_group.dfm <- function(x, groups = NULL, fill = FALSE) {
     if (!fill)
         groups <- droplevels(groups)
     x <- group_dfm(x, documents = groups, fill = fill)
-    x <- x[as.character(levels(groups)),]
+    x <- x[as.character(levels(groups)), ]
     if (length(dvars)) {
         x@docvars <- group_docvars(dvars, groups)
     } else {
@@ -69,13 +68,13 @@ dfm_group.dfm <- function(x, groups = NULL, fill = FALSE) {
 # internal code to perform dfm compression and grouping
 # on features and/or documents
 group_dfm <- function(x, features = NULL, documents = NULL, fill = FALSE) {
-    
+
     if (is.null(features) && is.null(documents)) {
         return(x)
     }
-    
+
     temp <- as(x, "dgTMatrix")
-    
+
     if (is.null(features)) {
         features_name <- temp@Dimnames[[2]]
         j_new <- temp@j + 1
@@ -83,15 +82,13 @@ group_dfm <- function(x, features = NULL, documents = NULL, fill = FALSE) {
         features_unique <- unique(features)
         features_index <- match(features, features_unique)
         j_new <- features_index[temp@j + 1]
-        
-        #print(as.character(levels(features)))
-        #print(features_name)
-        if(!is.factor(features))
+
+        if (!is.factor(features))
             features <- factor(features, levels = features_unique)
         features_name <- as.character(features_unique)
         if (fill && !identical(levels(features), features_unique)) {
-            features_name <- 
-                c(features_name, setdiff(as.character(levels(features)), 
+            features_name <-
+                c(features_name, setdiff(as.character(levels(features)),
                                          as.character(features_unique)))
         }
     }
@@ -102,25 +99,23 @@ group_dfm <- function(x, features = NULL, documents = NULL, fill = FALSE) {
         documents_unique <- unique(documents)
         documents_index <- match(documents, documents_unique)
         i_new <- documents_index[temp@i + 1]
-        
-        #print(as.character(levels(documents)))
-        #print(documents_name)
-        if(!is.factor(documents))
+
+        if (!is.factor(documents))
             documents <- factor(documents, levels = documents_unique)
         documents_name <- as.character(documents_unique)
         if (fill && !identical(levels(documents), documents_unique)) {
-            documents_name <- 
-                c(documents_name, setdiff(as.character(levels(documents)), 
+            documents_name <-
+                c(documents_name, setdiff(as.character(levels(documents)),
                                           as.character(documents_unique)))
         }
     }
-    
+
     x_new <- temp@x
     dims <- c(length(documents_name), length(features_name))
     dimnames <- list(docs = documents_name, features = features_name)
-    
-    result <- new("dfm", 
-                  sparseMatrix(i = i_new, j = j_new, x = x_new, 
+
+    result <- new("dfm",
+                  sparseMatrix(i = i_new, j = j_new, x = x_new,
                                dims = dims, dimnames = dimnames),
                   settings = x@settings,
                   weightTf = x@weightTf,
@@ -129,20 +124,20 @@ group_dfm <- function(x, features = NULL, documents = NULL, fill = FALSE) {
                   ngrams = x@ngrams,
                   skip = x@skip,
                   concatenator = x@concatenator)
-    
+
     if (is.null(documents)) {
-        docvars(result) <- docvars(x)
+        docvars(result) <- cbind(docvars(x), metadoc(x))
     } else {
         docvars(result) <- data.frame(row.names = documents_name)
     }
-    return(result)
+    result
 }
 
 # select docvar fields that have all the same values within groups
 group_docvars <- function(x, group) {
     result <- x[match(levels(group), group), sapply(x, is_grouped, as.integer(group)), drop = FALSE]
     rownames(result) <- as.character(levels(group))
-    return(result)
+    result
 }
 
 # check if values are uniform within groups

--- a/tests/testthat/test-dfm_compress.R
+++ b/tests/testthat/test-dfm_compress.R
@@ -62,4 +62,23 @@ test_that("dfm_compress: empty documents are preserved", {
 #    )
 #})
 
+test_that("dfm_compress preserves docvars (#1506)", {
+    corp <- corpus(c(d1 = "A A A b c D D",
+                 d2 = "b b b b D D D"),
+               docvars = data.frame(bool = c(TRUE, FALSE)))
+    thedfm <- dfm(corp)
+    # this ensures the existence of _document
+    docnames(thedfm) <- docnames(thedfm)
+    
+    expect_true("_document" %in% names(thedfm@docvars))
 
+    expect_identical(
+        thedfm@docvars,
+        dfm_compress(thedfm, margin = "features")@docvars
+    )
+    
+    expect_identical(
+        thedfm@docvars,
+        dfm(thedfm)@docvars
+    )
+})


### PR DESCRIPTION
Fixes #1506.

`group_dfm()` when applied to features returned docvars but not "metadoc" such as `_document`. This fix ensures that it does.

- plus some linting improvements
- added tests for #1506
- updated NEWS