### PR TITLE
Fix 1509

### DIFF
--- a/R/dfm.R
+++ b/R/dfm.R
@@ -159,8 +159,6 @@ dfm.character <- function(x,
                           groups = NULL,
                           verbose = quanteda_options("verbose"),
                           ...) {
-    
-    check_dots(list(...), names(formals('tokens')))
     dfm.tokens(tokens(corpus(x), ...),
         tolower = tolower, 
         stem = stem, 
@@ -185,8 +183,6 @@ dfm.corpus <- function(x,
                        groups = NULL, 
                        verbose = quanteda_options("verbose"),
                        ...) {
-    
-    check_dots(list(...), names(formals('tokens')))
     dfm.tokens(tokens(x, ...),  
                tolower = tolower, 
                stem = stem, 
@@ -212,7 +208,6 @@ dfm.tokens <- function(x,
                        verbose = quanteda_options("verbose"), 
                        ...) {
     valuetype <- match.arg(valuetype)
-    check_dots(list(...), names(formals('tokens')))
     
     # set document names if none
     if (is.null(names(x))) {
@@ -220,8 +215,10 @@ dfm.tokens <- function(x,
     } 
     
     # call tokens only if options given
-    if (length(intersect(names(list(...)), names(formals('tokens'))))) {
+    if (length(intersect(names(list(...)), names(formals("tokens"))))) {
         x <- tokens(x, ...)
+    } else {
+        check_dots(list(...), names(formals("dfm")))
     }
     
     if (tolower) {

--- a/R/dfm.R
+++ b/R/dfm.R
@@ -1,30 +1,30 @@
 #' Create a document-feature matrix
-#' 
-#' Construct a sparse document-feature matrix, from a character, \link{corpus}, 
+#'
+#' Construct a sparse document-feature matrix, from a character, \link{corpus},
 #' \link{tokens}, or even other \link{dfm} object.
 #' @param x character, \link{corpus}, \link{tokens}, or \link{dfm} object
 #' @param tolower convert all features to lowercase
 #' @param stem if \code{TRUE}, stem words
-#' @param remove a \link{pattern} of user-supplied features to ignore, such as 
-#'   "stop words".  To access one possible list (from any list you wish), use 
-#'   \code{\link{stopwords}()}.  The pattern matching type will be set by 
+#' @param remove a \link{pattern} of user-supplied features to ignore, such as
+#'   "stop words".  To access one possible list (from any list you wish), use
+#'   \code{\link{stopwords}()}.  The pattern matching type will be set by
 #'   \code{valuetype}.  See also \code{\link{tokens_select}}.  For behaviour of
 #'   \code{remove} with \code{ngrams > 1}, see Details.
-#' @param select a  \link{pattern}  of user-supplied features to keep, while 
-#'   excluding all others.  This can be used in lieu of a dictionary if there 
-#'   are only specific features that a user wishes to keep. To extract only 
-#'   Twitter usernames, for example, set \code{select = "@@*"} and make sure 
-#'   that \code{remove_twitter = FALSE} as an additional argument passed to 
+#' @param select a  \link{pattern}  of user-supplied features to keep, while
+#'   excluding all others.  This can be used in lieu of a dictionary if there
+#'   are only specific features that a user wishes to keep. To extract only
+#'   Twitter usernames, for example, set \code{select = "@@*"} and make sure
+#'   that \code{remove_twitter = FALSE} as an additional argument passed to
 #'   \link{tokens}.  Note: \code{select = "^@@\\\w+\\\b"} would be the regular
-#'   expression version of this matching pattern.  The pattern matching type 
+#'   expression version of this matching pattern.  The pattern matching type
 #'   will be set by \code{valuetype}.  See also \code{\link{tokens_remove}}.
-#' @param dictionary a \link{dictionary} object to apply to the tokens when 
+#' @param dictionary a \link{dictionary} object to apply to the tokens when
 #'   creating the dfm
-#' @param thesaurus a \link{dictionary} object that will be applied as if 
-#'   \code{exclusive = FALSE}. See also \code{\link{tokens_lookup}}.  For more 
-#'   fine-grained control over this and other aspects of converting features 
-#'   into dictionary/thesaurus keys from pattern matches to values, consider 
-#'   creating the dfm first, and then applying \code{\link{dfm_lookup}} 
+#' @param thesaurus a \link{dictionary} object that will be applied as if
+#'   \code{exclusive = FALSE}. See also \code{\link{tokens_lookup}}.  For more
+#'   fine-grained control over this and other aspects of converting features
+#'   into dictionary/thesaurus keys from pattern matches to values, consider
+#'   creating the dfm first, and then applying \code{\link{dfm_lookup}}
 #'   separately, or using \code{\link{tokens_lookup}} on the tokenized text
 #'   before calling \code{dfm}.
 #' @inheritParams valuetype
@@ -35,14 +35,14 @@
 #' @param verbose display messages if \code{TRUE}
 #' @param ... additional arguments passed to \link{tokens}; not used when \code{x}
 #'   is a \link{dfm}
-#' @details The default behaviour for \code{remove}/\code{select} when 
-#'   constructing ngrams using \code{dfm(x, } \emph{ngrams > 1}\code{)} is to 
-#'   remove/select any ngram constructed from a matching feature.  If you wish 
+#' @details The default behaviour for \code{remove}/\code{select} when
+#'   constructing ngrams using \code{dfm(x, } \emph{ngrams > 1}\code{)} is to
+#'   remove/select any ngram constructed from a matching feature.  If you wish
 #'   to remove these before constructing ngrams, you will need to first tokenize
-#'   the texts with ngrams, then remove the features to be ignored, and then 
-#'   construct the dfm using this modified tokenization object.  See the code 
+#'   the texts with ngrams, then remove the features to be ignored, and then
+#'   construct the dfm using this modified tokenization object.  See the code
 #'   examples for an illustration.
-#'   
+#'
 #'   To select on and match the features of a another \link{dfm}, \code{x} must
 #'   also be a \link{dfm}.
 #' @return a \link{dfm-class} object
@@ -56,15 +56,15 @@
 #' corpus_post80inaug <- corpus_subset(data_corpus_inaugural, Year > 1980)
 #' dfm(corpus_post80inaug)
 #' dfm(corpus_post80inaug, tolower = FALSE)
-#' 
+#'
 #' # grouping documents by docvars in a corpus
 #' dfm(corpus_post80inaug, groups = "President", verbose = TRUE)
-#' 
+#'
 #' # with English stopwords and stemming
 #' dfm(corpus_post80inaug, remove = stopwords("english"), stem = TRUE, verbose = TRUE)
 #' # works for both words in ngrams too
 #' dfm("Banking industry", stem = TRUE, ngrams = 2, verbose = FALSE)
-#' 
+#'
 #' # with dictionaries
 #' corpus_post1900inaug <- corpus_subset(data_corpus_inaugural, Year > 1900)
 #' mydict <- dictionary(list(christmas = c("Christmas", "Santa", "holiday"),
@@ -74,8 +74,8 @@
 #'                taxregex = "tax*",
 #'                country = "states"))
 #' dfm(corpus_post1900inaug, dictionary = mydict)
-#' 
-#' 
+#'
+#'
 #' # removing stopwords
 #' test_text <- "The quick brown fox named Seamus jumps over the lazy dog also named Seamus, with
 #'              the newspaper from a boy named Seamus, in his mouth."
@@ -85,47 +85,47 @@
 #' # for ngrams
 #' featnames(dfm(test_corpus, ngrams = 2, select = stopwords("english"), remove_punct = TRUE))
 #' featnames(dfm(test_corpus, ngrams = 1:2, select = stopwords("english"), remove_punct = TRUE))
-#' 
+#'
 #' # removing stopwords before constructing ngrams
 #' tokens_all <- tokens(char_tolower(test_text), remove_punct = TRUE)
 #' tokens_no_stopwords <- tokens_remove(tokens_all, stopwords("english"))
 #' tokens_ngrams_no_stopwords <- tokens_ngrams(tokens_no_stopwords, 2)
 #' featnames(dfm(tokens_ngrams_no_stopwords, verbose = FALSE))
-#' 
+#'
 #' # keep only certain words
 #' dfm(test_corpus, select = "*s", verbose = FALSE)  # keep only words ending in "s"
 #' dfm(test_corpus, select = "s$", valuetype = "regex", verbose = FALSE)
-#' 
+#'
 #' # testing Twitter functions
 #' test_tweets <- c("My homie @@justinbieber #justinbieber shopping in #LA yesterday #beliebers",
 #'                 "2all the ha8ers including my bro #justinbieber #emabiggestfansjustinbieber",
 #'                 "Justin Bieber #justinbieber #belieber #fetusjustin #EMABiggestFansJustinBieber")
 #' dfm(test_tweets, select = "#*", remove_twitter = FALSE)  # keep only hashtags
 #' dfm(test_tweets, select = "^#.*$", valuetype = "regex", remove_twitter = FALSE)
-#' 
+#'
 #' # for a dfm
 #' dfm1 <- dfm(data_corpus_irishbudget2010)
-#' dfm2 <- dfm(dfm1, 
+#' dfm2 <- dfm(dfm1,
 #'             groups = ifelse(docvars(data_corpus_irishbudget2010, "party") %in% c("FF", "Green"),
-#'                             "Govt", "Opposition"), 
+#'                             "Govt", "Opposition"),
 #'             tolower = FALSE, verbose = TRUE)
-#' 
-dfm <- function(x, 
+#'
+dfm <- function(x,
                 tolower = TRUE,
                 stem = FALSE,
                 select = NULL,
                 remove = NULL,
                 dictionary = NULL,
                 thesaurus = NULL,
-                valuetype = c("glob", "regex", "fixed"), 
-                groups = NULL, 
-                verbose = quanteda_options("verbose"), 
+                valuetype = c("glob", "regex", "fixed"),
+                groups = NULL,
+                verbose = quanteda_options("verbose"),
                 ...) {
 
     if (!is.dfm(x) && is.dfm(select)) {
         stop("selection on a dfm is only available when x is a dfm")
     }
-    
+
     dfm_env$START_TIME <- proc.time()
     object_class <- class(x)[1]
     if (object_class == "dfmSparse") object_class <- "dfm"
@@ -142,13 +142,13 @@ dfm.default <- function(x, ...) {
 
 # GLOBAL FOR dfm THAT FUNCTIONS CAN RESET AS NEEDED TO RECORD TIME ELAPSED
 dfm_env <- new.env()
-dfm_env$START_TIME <- NULL  
+dfm_env$START_TIME <- NULL
 
 
 #' @rdname dfm
 #' @noRd
 #' @export
-dfm.character <- function(x, 
+dfm.character <- function(x,
                           tolower = TRUE,
                           stem = FALSE,
                           select = NULL,
@@ -160,11 +160,11 @@ dfm.character <- function(x,
                           verbose = quanteda_options("verbose"),
                           ...) {
     dfm.tokens(tokens(corpus(x), ...),
-        tolower = tolower, 
-        stem = stem, 
-        select = select, remove = remove, 
-        dictionary = dictionary, thesaurus = thesaurus, valuetype = valuetype, 
-        groups = groups, 
+        tolower = tolower,
+        stem = stem,
+        select = select, remove = remove,
+        dictionary = dictionary, thesaurus = thesaurus, valuetype = valuetype,
+        groups = groups,
         verbose = verbose)
 }
 
@@ -172,7 +172,7 @@ dfm.character <- function(x,
 #' @rdname dfm
 #' @noRd
 #' @export
-dfm.corpus <- function(x, 
+dfm.corpus <- function(x,
                        tolower = TRUE,
                        stem = FALSE,
                        select = NULL,
@@ -180,70 +180,71 @@ dfm.corpus <- function(x,
                        dictionary = NULL,
                        thesaurus = NULL,
                        valuetype = c("glob", "regex", "fixed"),
-                       groups = NULL, 
+                       groups = NULL,
                        verbose = quanteda_options("verbose"),
                        ...) {
-    dfm.tokens(tokens(x, ...),  
-               tolower = tolower, 
-               stem = stem, 
-               select = select, remove = remove, 
-               dictionary = dictionary, thesaurus = thesaurus, 
-               valuetype = valuetype, 
-               groups = groups, 
+    dfm.tokens(tokens(x, ...),
+               tolower = tolower,
+               stem = stem,
+               select = select, remove = remove,
+               dictionary = dictionary, thesaurus = thesaurus,
+               valuetype = valuetype,
+               groups = groups,
                verbose = verbose)
 }
-    
+
 #' @noRd
 #' @importFrom utils glob2rx
 #' @export
-dfm.tokens <- function(x, 
+dfm.tokens <- function(x,
                        tolower = TRUE,
-                       stem = FALSE, 
+                       stem = FALSE,
                        select = NULL,
                        remove = NULL,
                        dictionary = NULL,
                        thesaurus = NULL,
-                       valuetype = c("glob", "regex", "fixed"), 
-                       groups = NULL, 
-                       verbose = quanteda_options("verbose"), 
+                       valuetype = c("glob", "regex", "fixed"),
+                       groups = NULL,
+                       verbose = quanteda_options("verbose"),
                        ...) {
     valuetype <- match.arg(valuetype)
-    
+
     # set document names if none
     if (is.null(names(x))) {
         names(x) <- paste0(quanteda_options("base_docname"), seq_along(x))
-    } 
-    
+    }
+
     # call tokens only if options given
     if (length(intersect(names(list(...)), names(formals("tokens"))))) {
         x <- tokens(x, ...)
     } else {
         check_dots(list(...), names(formals("dfm")))
     }
-    
+
     if (tolower) {
-        if (verbose) catm("   ... lowercasing\n", sep="")
+        if (verbose) catm("   ... lowercasing\n", sep = "")
         x <- tokens_tolower(x)
         tolower <- FALSE
     }
-    
+
     if (verbose) {
-        catm("   ... found ", 
+        catm("   ... found ",
              format(length(x), big.mark = ","), " document",
-             ifelse(length(x) > 1, "s", ""), ### TODO: replace with: ntoken()
+             # TODO: replace with: ntoken()
+             ifelse(length(x) > 1, "s", ""),
              ", ",
-             format(length(types(x)), big.mark = ","),  # TODO: replace with: ntype()
+             # TODO: replace with: ntype()
+             format(length(types(x)), big.mark = ","),
              " feature",
              ifelse(length(types(x)) > 1, "s", ""),
-             "\n", sep="")
+             "\n", sep = "")
     }
-    
+
     if (!is.null(groups)) {
-        if (verbose) catm("   ... grouping texts\n") 
-        group <- generate_groups(x, groups)
+        if (verbose) catm("   ... grouping texts\n")
         x <- tokens_group(x, groups)
     }
-    
+
     # use tokens_lookup for tokens objects
     if (!is.null(dictionary) || !is.null(thesaurus)) {
         if (!is.null(thesaurus)) dictionary <- dictionary(thesaurus)
@@ -253,36 +254,36 @@ dfm.tokens <- function(x,
                            valuetype = valuetype,
                            verbose = verbose)
     }
-    
+
     # use tokens_select for tokens objects
     if (!is.null(c(remove, select))) {
-        if (!is.null(remove) & !is.null(select)) 
+        if (!is.null(remove) & !is.null(select))
             stop("only one of select and remove may be supplied at once")
         if (verbose) catm("   ... ")
-        x <- tokens_select(x, 
+        x <- tokens_select(x,
                            pattern = if (!is.null(remove)) remove else select,
                            selection = if (!is.null(remove)) "remove" else "keep",
-                           valuetype = valuetype, 
+                           valuetype = valuetype,
                            verbose = verbose)
     }
-    
+
     # compile the dfm
     result <- compile_dfm(x, verbose = verbose)
-    
+
     # copy, set attributes
     result@ngrams <- as.integer(attr(x, "ngrams"))
     result@skip <- as.integer(attr(x, "skip"))
     result@concatenator <- attr(x, "concatenator")
-    if (attr(x, 'what') == "dictionary") {
-        attr(result, 'what') <- "dictionary"
-        attr(result, 'dictionary') <- attr(x, 'dictionary')
+    if (attr(x, "what") == "dictionary") {
+        attr(result, "what") <- "dictionary"
+        attr(result, "dictionary") <- attr(x, "dictionary")
     }
     if (!is.null(attr(x, "docvars"))) {
         result@docvars <- attr(x, "docvars")
     } else {
         result@docvars <- data.frame(matrix(ncol = 0, nrow = length(x)))
     }
-    
+
     dfm.dfm(result, tolower = FALSE, stem = stem, verbose = verbose)
 }
 
@@ -290,32 +291,32 @@ dfm.tokens <- function(x,
 #' @author Kenneth Benoit
 #' @import Matrix
 #' @export
-dfm.dfm <- function(x, 
+dfm.dfm <- function(x,
                     tolower = TRUE,
                     stem = FALSE,
                     select = NULL,
                     remove = NULL,
                     dictionary = NULL,
                     thesaurus = NULL,
-                    valuetype = c("glob", "regex", "fixed"), 
-                    groups = NULL, 
-                    verbose = quanteda_options("verbose"), 
+                    valuetype = c("glob", "regex", "fixed"),
+                    groups = NULL,
+                    verbose = quanteda_options("verbose"),
                     ...) {
-    
+
     x <- as.dfm(x)
     valuetype <- match.arg(valuetype)
     check_dots(list(...))
 
     if (tolower) {
-        if (verbose) catm("   ... lowercasing\n", sep="")
+        if (verbose) catm("   ... lowercasing\n", sep = "")
         x <- dfm_tolower(x)
     }
-    
+
     if (!is.null(groups)) {
-        if (verbose) catm("   ... grouping texts\n") 
+        if (verbose) catm("   ... grouping texts\n")
         x <- dfm_group(x, groups)
     }
-    
+
     if (!is.null(dictionary) | !is.null(thesaurus)) {
         if (!is.null(thesaurus)) dictionary <- dictionary(thesaurus)
         if (verbose) catm("   ... ")
@@ -324,55 +325,55 @@ dfm.dfm <- function(x,
                         valuetype = valuetype,
                         verbose = verbose)
     }
-    
+
     if (!is.null(c(remove, select))) {
-        if (!is.null(remove) & !is.null(select)) 
+        if (!is.null(remove) & !is.null(select))
             stop("only one of select and remove may be supplied at once")
         if (verbose) catm("   ... ")
-        # if ngrams > 1 and remove or selct is specified, then convert these 
+        # if ngrams > 1 and remove or selct is specified, then convert these
         # into a regex that will remove any ngram containing one of the words
         if (!identical(x@ngrams, 1L)) {
             remove <- make_ngram_pattern(remove, valuetype, x@concatenator)
             valuetype <- "regex"
         }
-        x <- dfm_select(x, 
+        x <- dfm_select(x,
                         pattern = if (!is.null(remove)) remove else select,
                         selection = if (!is.null(remove)) "remove" else "keep",
-                        valuetype = valuetype, 
+                        valuetype = valuetype,
                         verbose = verbose)
     }
-    
+
     language <- quanteda_options("language_stemmer")
     if (stem) {
-        if (verbose) 
-            catm("   ... stemming features (", stri_trans_totitle(language), 
-                 ")\n", sep="")
+        if (verbose)
+            catm("   ... stemming features (", stri_trans_totitle(language),
+                 ")\n", sep = "")
         nfeat_org <- nfeat(x)
         x <- dfm_wordstem(x, language)
-        if (verbose) 
-            if (nfeat_org - nfeat(x) > 0) 
+        if (verbose)
+            if (nfeat_org - nfeat(x) > 0)
                 catm(", trimmed ", nfeat_org - nfeat(x), " feature variant",
-                     ifelse(nfeat_org - nfeat(x) != 1, "s", ""), 
+                     ifelse(nfeat_org - nfeat(x) != 1, "s", ""),
                      "\n", sep = "")
     }
-    
+
     # remove any NA named columns
     is_na <- is.na(featnames(x))
     if (any(is_na))
         x <- x[, !is_na, drop = FALSE]
 
-    if (verbose) 
-        catm("   ... created a", 
-             paste(format(dim(x), big.mark = ",", trim = TRUE), collapse = " x "), 
-             "sparse dfm\n   ... complete. \nElapsed time:", 
-             format((proc.time() - dfm_env$START_TIME)[3], digits = 3),
+    if (verbose)
+        catm("   ... created a",
+             paste(format(dim(x), big.mark = ",", trim = TRUE), collapse = " x "),
+             "sparse dfm\n   ... complete. \nElapsed time:",
+             format( (proc.time() - dfm_env$START_TIME)[3], digits = 3),
              "seconds.\n")
     return(x)
 }
 
 
 ####
-#### core constructors for dfm 
+#### core constructors for dfm
 ####
 
 ## internal function to compile the dfm
@@ -381,20 +382,20 @@ compile_dfm <- function(x, verbose = TRUE) {
 }
 
 compile_dfm.tokens <- function(x, verbose = TRUE) {
-    
+
     types <- types(x)
     x <- unclass(x)
-    
+
     # shift index for padding, if any
     index <- unlist(x, use.names = FALSE)
-    if (attr(x, 'padding')) {
+    if (attr(x, "padding")) {
         types <- c("", types)
         index <- index + 1
     }
-    
-    temp <- sparseMatrix(j = index, 
-                         p = cumsum(c(1, lengths(x))) - 1, 
-                         x = 1L, 
+
+    temp <- sparseMatrix(j = index,
+                         p = cumsum(c(1, lengths(x))) - 1,
+                         x = 1L,
                          dims = c(length(names(x)), length(types)),
                          dimnames = list(docs = names(x),
                                          features = as.character(types)))
@@ -412,14 +413,14 @@ make_ngram_pattern <- function(features, valuetype, concatenator) {
         features <- stri_replace_all_regex(features, "\\*", ".*")
         features <- stri_replace_all_regex(features, "\\?", ".{1}")
     }
-    features <- paste0("(\\b|(\\w+", concatenator, ")+)", 
+    features <- paste0("(\\b|(\\w+", concatenator, ")+)",
                        features, "(\\b|(", concatenator, "\\w+)+)")
     features
 }
 
 # create an empty dfm for given features and documents
 make_null_dfm <- function(feature = NULL, document = NULL) {
-    new("dfm", 
+    new("dfm",
         as(sparseMatrix(
         i = NULL,
         j = NULL,
@@ -435,7 +436,7 @@ pad_dfm <- function(x, feature = NULL) {
     if (length(feat_pad)) {
         x <- cbind(x, make_null_dfm(feat_pad, docnames(x)))
     }
-    x <- x[,feature]
+    x <- x[, feature]
     return(x)
 }
 
@@ -445,7 +446,7 @@ force_conformance <- function(x, feature, force) {
         n <- length(featnames(x)) - length(intersect(featnames(x), feature))
         if (n)
             warning(n, " feature", if (n == 1) "" else "s",
-                    " in newdata not used in prediction.", 
+                    " in newdata not used in prediction.",
                     call. = FALSE, noBreaks. = TRUE)
         return(dfm_select(x, make_null_dfm(feature)))
     } else {

--- a/R/textstat_simil.R
+++ b/R/textstat_simil.R
@@ -39,7 +39,8 @@
 #'   \code{\link[stats]{as.dist}}
 #' @examples
 #' # similarities for documents
-#' mt <- dfm(corpus_subset(data_corpus_inaugural, Year > 1980), remove_punct = TRUE, remove = stopwords("english"))
+#' mt <- dfm(corpus_subset(data_corpus_inaugural, Year > 1980), 
+#'           remove_punct = TRUE, remove = stopwords("english"))
 #' (s1 <- textstat_simil(mt, method = "cosine", margin = "documents"))
 #' as.matrix(s1)
 #' as.list(s1)

--- a/R/tokens.R
+++ b/R/tokens.R
@@ -549,6 +549,8 @@ tokens_internal <- function(x, what = c("word", "sentence", "character", "fastes
     #     return(do.call(tokens, thecall))
     # }
     
+    check_dots(list(...), names(formals("tokens")))
+
     what <- match.arg(what)
     attrs <- attributes(x)
     
@@ -556,13 +558,6 @@ tokens_internal <- function(x, what = c("word", "sentence", "character", "fastes
     if (!remove_punct & remove_twitter) {
         remove_twitter <- FALSE
         warning("remove_twitter reset to FALSE when remove_punct = FALSE")
-    }
-    
-    # warn about unused arguments
-    if (length(added_args <- list(...)) & 
-        !all(names(added_args) %in% paste0("remove", c("Numbers", "Punct", "Symbols", "Separators", "Twitter", "Hyphens", "URL", "simplify")))) {
-        warning("Argument", if (length(added_args) > 1L) "s " else " ", names(added_args), 
-                " not used.", sep = "", call. = FALSE, noBreaks. = TRUE)
     }
     
     if (!remove_separators && what %in% c("fasterword", "fastestword"))

--- a/R/tokens.R
+++ b/R/tokens.R
@@ -536,19 +536,7 @@ tokens_internal <- function(x, what = c("word", "sentence", "character", "fastes
                             verbose = getOption("verbose"),  
                             include_docvars = TRUE, 
                             ...) {
-    
-    # # trap older arguments, issue a warning, and call with correct arguments
-    # thecall <- as.list(match.call())[-1]
-    # oldargindex <- 
-    #     stri_detect_regex(names(thecall), 
-    #                       "remove(Numbers|Punct|Symbols|Separators|Twitter|Hyphens|URL)$")
-    # if (any(oldargindex)) {
-    #     warning(names(thecall)[oldargindex], " is deprecated; use ",
-    #             tolower(gsub("([A-Z]+)", "_\\1", names(thecall)[oldargindex])), " instead", call. = FALSE)
-    #     names(thecall)[oldargindex] <- tolower(gsub("([A-Z]+)", "_\\1", names(thecall)[oldargindex]))
-    #     return(do.call(tokens, thecall))
-    # }
-    
+
     check_dots(list(...), names(formals("tokens")))
 
     what <- match.arg(what)

--- a/R/tokens.R
+++ b/R/tokens.R
@@ -1,3 +1,5 @@
+# tokens() functions -----------
+
 #' Tokenize a set of texts
 #'
 #' Tokenize the texts from a character vector or from a corpus.
@@ -104,7 +106,7 @@
 #' tokens("<tags> and other + symbols.", remove_symbols = FALSE, what = "fasterword")
 #' tokens("<tags> and other + symbols.", remove_symbols = TRUE, what = "fasterword")
 #'
-#' ## examples with URLs - hardly perfect!
+#' # examples with URLs - hardly perfect!
 #' txt <- "Repo https://githib.com/kbenoit/quanteda, and www.stackoverflow.com."
 #' tokens(txt, remove_url = TRUE, remove_punct = TRUE)
 #' tokens(txt, remove_url = FALSE, remove_punct = TRUE)
@@ -116,8 +118,8 @@
 #' txt <- "#textanalysis is MY <3 4U @@myhandle gr8 #stuff :-)"
 #' tokens(txt, remove_punct = TRUE)
 #' tokens(txt, remove_punct = TRUE, remove_twitter = TRUE)
-#' #tokens("great website http://textasdata.com", remove_url = FALSE)
-#' #tokens("great website http://textasdata.com", remove_url = TRUE)
+#' tokens("great website http://textasdata.com", remove_url = FALSE)
+#' tokens("great website http://textasdata.com", remove_url = TRUE)
 #'
 #' txt <- c(text1="This is $10 in 999 different ways,\n up and down; left and right!",
 #'          text2="@@kenbenoit working: on #quanteda 2day\t4ever, http://textasdata.com?page=123.")
@@ -201,7 +203,8 @@ tokens.corpus <- function(x, ..., include_docvars = TRUE) {
 #' @rdname tokens
 #' @export
 #' @noRd
-tokens.tokens <-  function(x, what = c("word", "sentence", "character", "fastestword", "fasterword"),
+tokens.tokens <-  function(x,
+                           what = c("word", "sentence", "character", "fastestword", "fasterword"),
                            remove_numbers = FALSE,
                            remove_punct = FALSE,
                            remove_symbols = FALSE,
@@ -215,13 +218,13 @@ tokens.tokens <-  function(x, what = c("word", "sentence", "character", "fastest
                            verbose = quanteda_options("verbose"),
                            include_docvars = TRUE,
                            ...) {
-    
+
     if (remove_hyphens)
         x <- tokens_split(x, separator = "\\p{Pd}", valuetype = "regex", remove_separator = FALSE)
-    
+
     if (remove_twitter)
         x <- tokens_replace(x, types(x), stri_replace_first_regex(types(x), "^(@|#)", ""))
-    
+
     regex <- c()
     if (remove_numbers)
         regex <- c(regex, "^[\\p{N}]+$")
@@ -230,12 +233,12 @@ tokens.tokens <-  function(x, what = c("word", "sentence", "character", "fastest
     if (remove_symbols)
         regex <- c(regex, "^[\\p{S}]+$")
     if (remove_separators)
-        regex <- c(regex, "^[\uFE00-\uFE0F\\p{Z}\\p{C}]+$") 
+        regex <- c(regex, "^[\uFE00-\uFE0F\\p{Z}\\p{C}]+$")
     if (remove_url)
         regex <- c(regex, "^https?")
-    
+
     if (length(regex))
-        x <- tokens_remove(x, paste(regex, collapse = '|'), valuetype = 'regex', padding = FALSE)
+        x <- tokens_remove(x, paste(regex, collapse = "|"), valuetype = "regex", padding = FALSE)
     if (!identical(ngrams, 1L) || !identical(skip, 0L))
         x <- tokens_ngrams(x, n = ngrams, skip = skip, concatenator = concatenator)
     if (!include_docvars)
@@ -244,10 +247,12 @@ tokens.tokens <-  function(x, what = c("word", "sentence", "character", "fastest
 }
 
 
+# coercion and checking functions -----------
+
 #' Coercion, checking, and combining functions for tokens objects
-#' 
-#' Coercion functions to and from \link{tokens} objects, checks for whether an 
-#' object is a \link{tokens} object, and functions to combine \link{tokens} 
+#'
+#' Coercion functions to and from \link{tokens} objects, checks for whether an
+#' object is a \link{tokens} object, and functions to combine \link{tokens}
 #' objects.
 #' @param x object to be coerced or checked
 #' @param concatenator character between multi-word expressions, default is the
@@ -259,23 +264,23 @@ tokens.tokens <-  function(x, what = c("word", "sentence", "character", "fastest
 #'   values for multi-word expressions in \code{\link{tokens_lookup}} and
 #'   \code{\link{dfm_lookup}}. The underscore character is commonly used to join
 #'   elements of multi-word expressions (e.g. "piece_of_cake", "New_York"), but
-#'   other characters (e.g. whitespace " " or a hyphen "-") can also be used. 
-#'   In those cases, users have to tell the system what is the concatenator in 
+#'   other characters (e.g. whitespace " " or a hyphen "-") can also be used.
+#'   In those cases, users have to tell the system what is the concatenator in
 #'   your tokens so that the conversion knows to treat this character as the
 #'   inter-word delimiter, when reading in the elements that will become the
 #'   tokens.
 #' @export
 #' @rdname as.tokens
-#' @examples 
-#' 
+#' @examples
+#'
 #' # create tokens object from list of characters with custom concatenator
-#' dict <- dictionary(list(country = "United States", 
+#' dict <- dictionary(list(country = "United States",
 #'                    sea = c("Atlantic Ocean", "Pacific Ocean")))
-#' lis <- list(c("The", "United-States", "has", "the", "Atlantic-Ocean", 
+#' lis <- list(c("The", "United-States", "has", "the", "Atlantic-Ocean",
 #'               "and", "the", "Pacific-Ocean", "."))
 #' toks <- as.tokens(lis, concatenator = "-")
 #' tokens_lookup(toks, dict)
-#' 
+#'
 as.tokens <- function(x, concatenator = "_", ...) {
     UseMethod("as.tokens")
 }
@@ -293,19 +298,12 @@ as.tokens.list <- function(x, concatenator = "_", ...) {
                         names = docnames(x),
                         what = "word",
                         ngrams = 1L,
-                        skip = 0L, 
+                        skip = 0L,
                         concatenator = concatenator,
                         padding = FALSE)
     docvars(result) <- data.frame(row.names = docnames(x))
     return(result)
 }
-
-# # @export
-# # @method as.tokens collocations
-# # @rdname as.tokens
-# as.tokens.collocations <- function(x, concatenator = '_') {
-#     as.tokens(phrase(x$collocation), concatenator = concatenator)
-# }
 
 #' @rdname as.tokens
 #' @param use_lemma logical; if \code{TRUE}, use the lemma rather than the raw
@@ -315,18 +313,18 @@ as.tokens.list <- function(x, concatenator = "_", ...) {
 #'   \code{pos} variable, \code{"tag"} use the \code{tag} variable.  The POS
 #'   will be added to the token after \code{"concatenator"}.
 #' @export
-as.tokens.spacyr_parsed <- function(x, concatenator = "/", 
-                                    include_pos = c("none", "pos", "tag"), 
+as.tokens.spacyr_parsed <- function(x, concatenator = "/",
+                                    include_pos = c("none", "pos", "tag"),
                                     use_lemma = FALSE, ...) {
     token_index <-  if (use_lemma) "lemma" else "token"
-    
+
     include_pos <- match.arg(include_pos)
     if (include_pos != "none") {
-        x[[token_index]] <- 
+        x[[token_index]] <-
             paste(x[[token_index]], x[[include_pos]], sep = concatenator)
     }
-    
-    as.tokens(base::split(x[[token_index]], 
+
+    as.tokens(base::split(x[[token_index]],
                           factor(x[["doc_id"]], levels = unique(x[["doc_id"]]))))
 }
 
@@ -337,14 +335,32 @@ as.tokens.spacyr_parsed <- function(x, concatenator = "/",
 #' @export
 as.list.tokens <- function(x, ...) {
     types <- c("", types(x))
-    result <- lapply(unclass(x), function(y) types[y + 1]) # shift index to show padding 
+    result <- lapply(unclass(x), function(y) types[y + 1]) # shift index to show padding
     attributes(result) <- NULL
     names(result) <- names(x)
     return(result)
 }
 
 #' @rdname as.tokens
-#' @return \code{unlist} returns a simple vector of characters from a 
+#' @param use.names logical; preserve names if \code{TRUE}.  For
+#'   \code{as.character} and \code{unlist} only.
+#' @return \code{as.character} returns a character vector from a
+#'   \link{tokens} object.
+#' @export
+as.character.tokens <- function(x, use.names = FALSE, ...) {
+    unlist(as.list(x), use.names = use.names)
+}
+
+#' @rdname as.tokens
+#' @export
+#' @return \code{is.tokens} returns \code{TRUE} if the object is of class
+#'   tokens, \code{FALSE} otherwise.
+is.tokens <- function(x) "tokens" %in% class(x)
+
+# extension of generics for tokens -----------
+
+#' @rdname as.tokens
+#' @return \code{unlist} returns a simple vector of characters from a
 #'   \link{tokens} object.
 #' @param recursive a required argument for \link{unlist} but inapplicable to
 #'   \link{tokens} objects
@@ -354,61 +370,6 @@ unlist.tokens <- function(x, recursive = FALSE, use.names = TRUE) {
     unlist(as.list(x), use.names = use.names)
 }
 
-#' @rdname as.tokens
-#' @param use.names logical; preserve names if \code{TRUE}.  For
-#'   \code{as.character} and \code{unlist} only.
-#' @return \code{as.character} returns a character vector from a 
-#'   \link{tokens} object.
-#' @export
-as.character.tokens <- function(x, use.names = FALSE, ...) {
-    unlist(as.list(x), use.names = use.names)
-} 
-
-#' @rdname as.tokens
-#' @export
-#' @return \code{is.tokens} returns \code{TRUE} if the object is of class
-#'   tokens, \code{FALSE} otherwise.
-is.tokens <- function(x) "tokens" %in% class(x)
-
-
-
-#' Function to serialized list-of-character tokens
-#' 
-#' Creates a serialized object of tokens, called by \code{\link{tokens}}.
-#' @param x a list of character vectors
-#' @param types_reserved optional pre-existing types for mapping of tokens
-#' @param ... additional arguments
-#' @return a list the serialized tokens found in each text
-#' @importFrom fastmatch fmatch
-#' @keywords internal tokens
-tokens_serialize <- function(x, types_reserved = NULL, ...) {
-    
-    attrs <- attributes(x)
-    types <- unique(unlist(x, use.names = FALSE))
-    types <- types[types != '']  # remove empty tokens
-    
-    if (!is.null(types_reserved)) {
-        types <- c(types_reserved, setdiff(types, types_reserved))
-    }
-    x <- lapply(x, function(x) {
-        id <- fastmatch::fmatch(x, types)
-        is_na <- is.na(id)
-        if (length(is_na) > 0) {
-            id[!is_na]
-        } else {
-            integer()
-        }
-    })
-    
-    attributes(x) <- attrs
-    attr(x, "types") <- stri_trans_nfc(types) # unicode normalization
-    class(x) <- "tokens"
-    return(x)
-}
-
-
-
-
 #' print a tokens objects
 #' print method for a tokens object
 #' @param x a tokens object created by \code{\link{tokens}}
@@ -417,10 +378,10 @@ tokens_serialize <- function(x, types_reserved = NULL, ...) {
 #' @method print tokens
 #' @noRd
 print.tokens <- function(x, ...) {
-    cat(class(x)[1], " from ", ndoc(x), " document", 
+    cat(class(x)[1], " from ", ndoc(x), " document",
         if (ndoc(x) > 1L) "s" else "", ".\n", sep = "")
     types <- c("", types(x))
-    x <- lapply(unclass(x), function(y) types[y + 1]) # shift index to show padding 
+    x <- lapply(unclass(x), function(y) types[y + 1]) # shift index to show padding
     class(x) <- "listof"
     print(x, ...)
 }
@@ -429,23 +390,23 @@ print.tokens <- function(x, ...) {
 #' @method "[" tokens
 #' @export
 #' @noRd
-#' @examples 
+#' @examples
 #' toks <- tokens(c(d1 = "one two three", d2 = "four five six", d3 = "seven eight"))
 #' str(toks)
 #' toks[c(1,3)]
 "[.tokens" <- function(x, i, ...) {
-    
+
     if (length(x) == 1 && is.null(x[[1]])) return(x)
-    
+
     error <- FALSE
     if (is.character(i) && any(!i %in% names(x))) error <- TRUE
     if (is.numeric(i) && any(i > length(x))) error <- TRUE
     if (error) stop("Subscript out of bounds")
-    
+
     attrs <- attributes(x)
     x <- unclass(x)[i]
     if (is.data.frame(attrs$docvars)) {
-        attrs$docvars <- attrs$docvars[i,,drop = FALSE]
+        attrs$docvars <- attrs$docvars[i, , drop = FALSE]
     }
     attributes(x, FALSE) <- attrs
     tokens_recompile(x)
@@ -454,19 +415,19 @@ print.tokens <- function(x, ...) {
 #' @method "[[" tokens
 #' @export
 #' @noRd
-#' @examples 
+#' @examples
 #' toks <- tokens(c(d1 = "one two three", d2 = "four five six", d3 = "seven eight"))
 #' str(toks)
 #' toks[[2]]
 "[[.tokens" <- function(x, i, ...) {
     types <- c("", types(x))
-    types[unclass(x)[[i]] + 1] # shift index to show padding 
+    types[unclass(x)[[i]] + 1] # shift index to show padding
 }
 
 #' @method "$" tokens
 #' @export
 #' @noRd
-#' @examples 
+#' @examples
 #' toks <- tokens(c(d1 = "one two three", d2 = "four five six", d3 = "seven eight"))
 #' str(toks)
 #' toks$d3
@@ -478,14 +439,14 @@ print.tokens <- function(x, ...) {
 #' @export
 #' @noRd
 "[<-.tokens" <- function(x, i, value) {
-    stop('assignment to tokens objects is not allowed', call. = FALSE)
+    stop("assignment to tokens objects is not allowed", call. = FALSE)
 }
 
 #' @method "[[<-" tokens
 #' @export
 #' @noRd
 "[[<-.tokens" <- function(x, i, value) {
-    stop('assignment to tokens objects is not allowed', call. = FALSE)
+    stop("assignment to tokens objects is not allowed", call. = FALSE)
 }
 
 #' @method lengths tokens
@@ -495,11 +456,66 @@ lengths.tokens <- function(x, use.names = TRUE) {
     NextMethod()
 }
 
+#' @rdname as.tokens
+#' @param t1 tokens one to be added
+#' @param t2 tokens two to be added
+#' @return \code{c(...)} and \code{+} return a tokens object whose documents
+#'   have been added as a single sequence of documents.
+#' @examples
+#' # combining tokens
+#' toks1 <- tokens(c(doc1 = "a b c d e", doc2 = "f g h"))
+#' toks2 <- tokens(c(doc3 = "1 2 3"))
+#' toks1 + toks2
+#' c(toks1, toks2)
+#'
+#' @export
+`+.tokens` <- function(t1, t2) {
+    if (length(intersect(docnames(t1), docnames(t2))))
+        stop("Cannot combine tokens with duplicated document names")
+    if (!identical(attr(t1, "what"), attr(t2, "what")))
+        stop("Cannot combine tokens in different units")
+    if (!identical(attr(t1, "concatenator"), attr(t2, "concatenator")))
+        stop("Cannot combine tokens with different concatenators")
+
+    attrs <- list(what = attr(t1, "what"),
+                  ngrams = sort(unique(c(attr(t1, "ngrams"), attr(t2, "ngrams")))),
+                  skip = sort(unique(c(attr(t1, "skip"), attr(t2, "skip")))),
+                  concatenator = attr(t1, "concatenator"),
+                  docvars = data.frame(row.names = c(docnames(t1), docnames(t2))))
+
+    docvars(t1) <- docvars(t2) <- NULL
+    types2 <- types(t2)
+    types1 <- types(t1)
+    t2 <- unclass(t2)
+    t1 <- unclass(t1)
+    t2 <- lapply(t2, function(x, y) x + y, length(types1)) # shift IDs
+    t1 <- c(t1, t2)
+    class(t1) <- "tokens"
+    types(t1) <- c(types1, types2)
+    t1 <- tokens_recompile(t1)
+    attributes(t1, FALSE) <- attrs
+    return(t1)
+}
+
+#' @rdname as.tokens
+#' @export
+c.tokens <- function(...) {
+    x <- list(...)
+    if (length(x) == 1) return(x[[1]])
+    result <- x[[1]] + x[[2]]
+    if (length(x) == 2) return(result)
+    for (i in seq(3, length(x)))
+        result <- result + x[[i]]
+    return(result)
+}
+
+# quanteda methods for tokens ---------
+
 #' @noRd
 #' @export
 docnames.tokens <- function(x) {
     if (is.null(names(x))) {
-        paste0('text', seq_along(x))
+        paste0("text", seq_along(x))
     } else {
         names(x)
     }
@@ -509,7 +525,7 @@ docnames.tokens <- function(x) {
 #' @export
 docnames.list <- function(x) {
     if (is.null(names(x))) {
-        paste0('text', seq_along(x))
+        paste0("text", seq_along(x))
     } else {
         names(x)
     }
@@ -517,12 +533,11 @@ docnames.list <- function(x) {
 
 
 
-##
-## ============== INTERNAL FUNCTIONS =======================================
-##
+# ============== INTERNAL FUNCTIONS =======================================
 
 # TODO we can be rename this "tokenize" once quanteda::tokenize has gone
-tokens_internal <- function(x, what = c("word", "sentence", "character", "fastestword", "fasterword"),
+tokens_internal <- function(x,
+                            what = c("word", "sentence", "character", "fastestword", "fasterword"),
                             remove_numbers = FALSE,
                             remove_punct = FALSE,
                             remove_symbols = FALSE,
@@ -533,60 +548,61 @@ tokens_internal <- function(x, what = c("word", "sentence", "character", "fastes
                             ngrams = 1L,
                             skip = 0L,
                             concatenator = "_",
-                            verbose = getOption("verbose"),  
-                            include_docvars = TRUE, 
+                            verbose = getOption("verbose"),
+                            include_docvars = TRUE,
                             ...) {
 
     check_dots(list(...), names(formals("tokens")))
 
     what <- match.arg(what)
     attrs <- attributes(x)
-    
+
     # disable remove_twitter if remove_punct = FALSE
     if (!remove_punct & remove_twitter) {
         remove_twitter <- FALSE
         warning("remove_twitter reset to FALSE when remove_punct = FALSE")
     }
-    
+
     if (!remove_separators && what %in% c("fasterword", "fastestword"))
         warning("remove_separators = FALSE has no effect when what = fasterword or fastestword",
                 call. = FALSE, noBreaks. = TRUE)
-    
+
     if (!is.integer(ngrams)) ngrams <- as.integer(ngrams)
-    
+
     if (verbose) catm("Starting tokenization...\n")
-    
+
     time_start <- proc.time()
-    
+
     # Split x into smaller blocks to reducre peak memory consumption
     x <- split(x, ceiling(seq_along(x) / 10000))
     for (i in seq_along(x)) {
-        
-        if (verbose) catm("...tokenizing", i, "of" , length(x), "blocks\n")
+
+        if (verbose) catm("...tokenizing", i, "of", length(x), "blocks\n")
         if (what %in% c("word", "fasterword")) {
             temp <- preserve_special(x[[i]], remove_hyphens, remove_url, remove_twitter, verbose)
-            temp <- tokens_word(temp, what, remove_numbers, remove_punct, remove_symbols, 
+            temp <- tokens_word(temp, what, remove_numbers, remove_punct, remove_symbols,
                                 remove_separators, verbose)
         } else if (what == "fastestword") {
             temp <- tokens_word(x[[i]], what, FALSE, FALSE, FALSE, FALSE, verbose)
         } else if (what == "character") {
-            temp <- tokens_character(x[[i]], remove_punct, remove_symbols, remove_separators, verbose)
+            temp <- tokens_character(x[[i]], remove_punct, remove_symbols,
+                                     remove_separators, verbose)
         } else if (what == "sentence") {
             temp <- tokens_sentence(x[[i]], verbose)
         } else {
             stop(what, " not implemented in tokens().")
         }
-        
+
         if (verbose) catm("...serializing tokens ")
         if (i == 1) {
             x[[i]] <- tokens_serialize(temp)
         } else {
-            x[[i]] <- tokens_serialize(temp, attr(x[[i - 1]], 'types'))
+            x[[i]] <- tokens_serialize(temp, attr(x[[i - 1]], "types"))
         }
-        if (verbose) catm(length(attr(x[[i]], 'types')), 'unique types\n')
+        if (verbose) catm(length(attr(x[[i]], "types")), "unique types\n")
 
     }
-    
+
     x <- structure(unlist(x, recursive = FALSE), # put all the blocked results togather
                    class = "tokens",
                    names = attrs$names,
@@ -595,15 +611,16 @@ tokens_internal <- function(x, what = c("word", "sentence", "character", "fastes
                    skip = skip,
                    concatenator = concatenator,
                    padding = FALSE,
-                   types = attr(x[[length(x)]], 'types') # last block has all the types
+                   types = attr(x[[length(x)]], "types") # last block has all the types
                    )
     if (what %in% c("word", "fasterword")) {
-        
+
         types <- types(x)
         if (!remove_punct || remove_punct)
             types <- stri_replace_all_fixed(types, "_hy_", "-") # run this always
         if (!remove_twitter)
-            types <- stri_replace_all_fixed(types, c("_ht_", "_as_"), c("#", "@"), vectorize_all = FALSE)
+            types <- stri_replace_all_fixed(types, c("_ht_", "_as_"), c("#", "@"),
+                                            vectorize_all = FALSE)
         if (!identical(types, types(x)))
             types(x) <- types
             x <- tokens_recompile(x)
@@ -616,55 +633,56 @@ tokens_internal <- function(x, what = c("word", "sentence", "character", "fastes
         if (remove_symbols)
             regex <- c(regex, "^[\\p{S}]+$")
         if (remove_separators)
-            regex <- c(regex, "^[\\p{Z}\\p{C}]+$") 
-            #regex <- c(regex, "^[\uFE00-\uFE0F\\p{Z}\\p{C}]+$") 
+            regex <- c(regex, "^[\\p{Z}\\p{C}]+$")
         if (remove_punct & !remove_twitter)
             regex <- c(regex, "^#+$|^@+$") # remove @ # only if not part of Twitter names
         if (length(regex))
-            x <- tokens_remove(x, paste(regex, collapse = '|'), valuetype = "regex")
+            x <- tokens_remove(x, paste(regex, collapse = "|"), valuetype = "regex")
     }
-    
-        
+
+
     if (!identical(ngrams, 1L)) {
         if (verbose) catm("...creating ngrams\n")
         x <- tokens_ngrams(x, n = ngrams, skip = skip, concatenator = concatenator)
     }
-        
+
     if (verbose){
         catm("...total elapsed: ", (proc.time() - time_start)[3], "seconds.\n")
-        catm("Finished tokenizing and cleaning", format(length(x), big.mark=","), "texts.\n")
+        catm("Finished tokenizing and cleaning", format(length(x), big.mark = ","), "texts.\n")
     }
-    
+
     return(x)
 }
 
-tokens_word <- function(txt, 
-                        what = 'word', 
-                        remove_numbers = FALSE, 
-                        remove_punct = FALSE, 
-                        remove_symbols = FALSE, 
+tokens_word <- function(txt,
+                        what = "word",
+                        remove_numbers = FALSE,
+                        remove_punct = FALSE,
+                        remove_symbols = FALSE,
                         remove_separators = TRUE,
                         verbose = FALSE){
-    
+
     if (what == "fastestword") {
         tok <- stri_split_fixed(txt, " ")
     } else if (what == "fasterword") {
-        tok <- stri_split_regex(txt, "[\\p{Z}\\p{C}]+") 
+        tok <- stri_split_regex(txt, "[\\p{Z}\\p{C}]+")
     } else {
-        txt <- stri_replace_all_regex(txt, "[\uFE00-\uFE0F]", '') # remove variant selector
-        txt <- stri_replace_all_regex(txt, "\\s[\u0300-\u036F]", '') # remove whitespace with diacritical marks
-        tok <- stri_split_boundaries(txt, type = "word", 
-                                     # this is what obliterates currency symbols, Twitter tags, and URLs
-                                     skip_word_none = remove_punct && remove_separators, 
+        # remove variant selector
+        txt <- stri_replace_all_regex(txt, "[\uFE00-\uFE0F]", "")
+        # remove whitespace with diacritical marks
+        txt <- stri_replace_all_regex(txt, "\\s[\u0300-\u036F]", "")
+        tok <- stri_split_boundaries(txt, type = "word",
+                                     # this is what kills currency symbols, Twitter tags, URLs
+                                     skip_word_none = remove_punct && remove_separators,
                                      # but does not remove 4u, 2day, etc.
-                                     skip_word_number = remove_numbers) 
-        
+                                     skip_word_number = remove_numbers)
+
     }
     return(tok)
 }
 
 preserve_special <- function(txt, remove_hyphens, remove_url, remove_twitter, verbose) {
-    
+
     if (remove_hyphens) {
         txt <- stri_replace_all_regex(txt, "(\\b)[\\p{Pd}](\\b)", "$1 _hy_ $2")
     } else {
@@ -684,20 +702,20 @@ preserve_special <- function(txt, remove_hyphens, remove_url, remove_twitter, ve
 }
 
 tokens_sentence <- function(txt, verbose = FALSE){
-    
+
     if (verbose) catm("...separating into sentences.\n")
-    
+
     # Replace . delimiter from common title abbreviations, with _pd_
     exceptions <- c("Mr", "Mrs", "Ms", "Dr", "Jr", "Prof", "Ph.D", "M", "MM", "St", "etc")
     findregex <- paste0("\\b(", exceptions, ")\\.")
     txt <- stri_replace_all_regex(txt, findregex, "$1_pd_", vectorize_all = FALSE)
-    
-    ## Remove newline chars 
-    txt <- lapply(txt,stri_replace_all_fixed, "\n", " ")
-    
+
+    ## Remove newline chars
+    txt <- lapply(txt, stri_replace_all_fixed, "\n", " ")
+
     ## Perform the tokenization
     tok <- stri_split_boundaries(txt, type = "sentence")
-    
+
     ## Cleaning
     tok <- lapply(tok, function(x){
         x <- x[which(x != "")] # remove any "sentences" that were completely blanked out
@@ -705,16 +723,16 @@ tokens_sentence <- function(txt, verbose = FALSE){
         x <- stri_replace_all_fixed(x, "_pd_", ".") # replace the non-full-stop "." characters
         return(x)
     })
-    
+
     return(tok)
 }
 
-tokens_character <- function(txt, 
-                             remove_punct = FALSE, 
-                             remove_symbols = FALSE, 
-                             remove_separators = FALSE, 
+tokens_character <- function(txt,
+                             remove_punct = FALSE,
+                             remove_symbols = FALSE,
+                             remove_separators = FALSE,
                              verbose = FALSE){
-    
+
     # note: does not implement remove_numbers
     tok <- stri_split_boundaries(txt, type = "character")
     if (remove_punct) {
@@ -722,31 +740,64 @@ tokens_character <- function(txt,
         tok <- lapply(tok, function(x){
             x <- stri_replace_all_charclass(x, "[\\p{P}]", "")
             x <- x[which(x != "")]
-            return(x)    
+            return(x)
         })
-    } 
+    }
     if (remove_symbols) {
         if (verbose) catm("...removing symbols.\n")
         tok <- lapply(tok, function(x){
             x <- stri_replace_all_charclass(x, "[\\p{S}]", "")
             x <- x[which(x != "")]
-            return(x)    
+            return(x)
         })
-    } 
+    }
     if (remove_separators) {
         if (verbose) catm("...removing separators.\n")
         tok <- lapply(tok, function(x){
             x <- stri_subset_regex(x, "^\\p{Z}$", negate = TRUE)
             x <- x[which(x != "")]
-            return(x)    
+            return(x)
         })
     }
     return(tok)
 }
 
+#' Function to serialized list-of-character tokens
+#'
+#' Creates a serialized object of tokens, called by \code{\link{tokens}}.
+#' @param x a list of character vectors
+#' @param types_reserved optional pre-existing types for mapping of tokens
+#' @param ... additional arguments
+#' @return a list the serialized tokens found in each text
+#' @importFrom fastmatch fmatch
+#' @keywords internal tokens
+tokens_serialize <- function(x, types_reserved = NULL, ...) {
+
+    attrs <- attributes(x)
+    types <- unique(unlist(x, use.names = FALSE))
+    types <- types[types != ""]  # remove empty tokens
+
+    if (!is.null(types_reserved)) {
+        types <- c(types_reserved, setdiff(types, types_reserved))
+    }
+    x <- lapply(x, function(x) {
+        id <- fastmatch::fmatch(x, types)
+        is_na <- is.na(id)
+        if (length(is_na) > 0) {
+            id[!is_na]
+        } else {
+            integer()
+        }
+    })
+
+    attributes(x) <- attrs
+    attr(x, "types") <- stri_trans_nfc(types) # unicode normalization
+    class(x) <- "tokens"
+    return(x)
+}
 
 #' recompile a serialized tokens object
-#' 
+#'
 #' This function recompiles a serialized tokens object when the vocabulary has
 #' been changed in a way that makes some of its types identical, such as
 #' lowercasing when a lowercased version of the type already exists in the type
@@ -756,27 +807,27 @@ tokens_character <- function(txt,
 #' addition of new tokens through compounding.
 #' @param x the \link{tokens} object to be recompiled
 #' @param gap if \code{TRUE}, remove gaps between token IDs
-#' @param dup if \code{TRUE}, merge duplicated token types into the same ID 
+#' @param dup if \code{TRUE}, merge duplicated token types into the same ID
 #' @param method \code{"C++"} for C++ implementation or \code{"R"} for an older
 #'   R-based method
-#' @examples 
+#' @examples
 #' # lowercasing
 #' toks1 <- tokens(c(one = "a b c d A B C D",
 #'                  two = "A B C d"))
 #' attr(toks1, "types") <- char_tolower(attr(toks1, "types"))
 #' unclass(toks1)
 #' unclass(quanteda:::tokens_recompile(toks1))
-#' 
+#'
 #' # stemming
 #' toks2 <- tokens("Stemming stemmed many word stems.")
 #' unclass(toks2)
 #' unclass(quanteda:::tokens_recompile(tokens_wordstem(toks2)))
-#' 
+#'
 #' # compounding
 #' toks3 <- tokens("One two three four.")
 #' unclass(toks3)
 #' unclass(tokens_compound(toks3, "two three"))
-#' 
+#'
 #' # lookup
 #' dict <- dictionary(list(test = c("one", "three")))
 #' unclass(tokens_lookup(toks3, dict))
@@ -784,46 +835,46 @@ tokens_character <- function(txt,
 #' # empty pads
 #' unclass(tokens_select(toks3, dict))
 #' unclass(tokens_select(toks3, dict, pad = TRUE))
-#' 
+#'
 #' # ngrams
 #' unclass(tokens_ngrams(toks3, n = 2:3))
-#' 
+#'
 #' @keywords internal tokens
 #' @author Kenneth Benoit and Kohei Watanabe
 tokens_recompile <- function(x, method = c("C++", "R"), gap = TRUE, dup = TRUE) {
-    
+
     method <- match.arg(method)
     attrs <- attributes(x)
-    
+
     if (method == "C++") {
         x <- qatd_cpp_tokens_recompile(x, types(x), gap, dup)
         attributes(x, FALSE) <- attrs
         return(x)
     }
-    
+
     # Check for padding
     index_unique <- unique(unlist(unclass(x), use.names = FALSE))
     padding <- (index_unique == 0)
     attrs$padding <- any(padding) # add padding flag
     index_unique <- index_unique[!padding] # exclude padding
-    
+
     if (!gap && !dup) {
         attributes(x) <- attrs
         return(x)
     }
-    
+
     # Remove gaps in the type index, if any, remap index
     if (gap) {
-        if (any(is.na(match(seq_len(length(types(x))), index_unique)))) { 
+        if (any(is.na(match(seq_len(length(types(x))), index_unique)))) {
             types_new <- types(x)[index_unique]
             index_new <- c(0, seq_along(index_unique)) # padding index is zero but not in types
             index_unique <- c(0, index_unique) # padding index is zero but not in types
-            x <- lapply(unclass(x), function(y) index_new[fastmatch::fmatch(y, index_unique)]) 
+            x <- lapply(unclass(x), function(y) index_new[fastmatch::fmatch(y, index_unique)])
             attributes(x) <- attrs
             types(x) <- types_new
         }
     }
-    
+
     # Reindex duplicates, if any
     if (dup) {
         if (any(duplicated(types(x)))) {
@@ -849,12 +900,12 @@ get_tokens.tokens <- function(x) {
 }
 
 #' Get word types from a tokens object
-#' 
-#' Get unique types of tokens from a \link{tokens} object. 
+#'
+#' Get unique types of tokens from a \link{tokens} object.
 #' @param x a tokens object
 #' @export
 #' @seealso \link{featnames}
-#' @examples 
+#' @examples
 #' toks <- tokens(data_corpus_inaugural)
 #' types(toks)
 types <- function(x) {
@@ -875,67 +926,9 @@ types.tokens <- function(x) {
     UseMethod("types<-")
 }
 
-# "types<-.default" <- function(x, value) {
-#     stop(friendly_class_undefined_message(class(x), "types<-"))
-# }
-
 "types<-.tokens" <- function(x, value) {
     if (!is.character(value))
         stop("replacement value must be character")
     attr(x, "types") <- value
     return(x)
-}
-
-
-#' @rdname as.tokens
-#' @param t1 tokens one to be added
-#' @param t2 tokens two to be added
-#' @return \code{c(...)} and \code{+} return a tokens object whose documents
-#'   have been added as a single sequence of documents.
-#' @examples 
-#' # combining tokens
-#' toks1 <- tokens(c(doc1 = "a b c d e", doc2 = "f g h"))
-#' toks2 <- tokens(c(doc3 = "1 2 3"))
-#' toks1 + toks2
-#' c(toks1, toks2)
-#' 
-#' @export
-`+.tokens` <- function(t1, t2) {
-    if (length(intersect(docnames(t1), docnames(t2))))
-        stop("Cannot combine tokens with duplicated document names")
-    if (!identical(attr(t1, "what"), attr(t2, "what")))
-        stop("Cannot combine tokens in different units")
-    if (!identical(attr(t1, "concatenator"), attr(t2, "concatenator")))
-        stop("Cannot combine tokens with different concatenators")
-    
-    attrs <- list(what = attr(t1, "what"),
-                  ngrams = sort(unique(c(attr(t1, "ngrams"), attr(t2, "ngrams")))),
-                  skip = sort(unique(c(attr(t1, "skip"), attr(t2, "skip")))),
-                  concatenator = attr(t1, "concatenator"),
-                  docvars = data.frame(row.names = c(docnames(t1), docnames(t2))))
-    
-    docvars(t1) <- docvars(t2) <- NULL
-    types2 <- types(t2)
-    types1 <- types(t1)
-    t2 <- unclass(t2)
-    t1 <- unclass(t1)
-    t2 <- lapply(t2, function(x, y) x + y, length(types1)) # shift IDs
-    t1 <- c(t1, t2)
-    class(t1) <- "tokens"
-    types(t1) <- c(types1, types2)
-    t1 <- tokens_recompile(t1)
-    attributes(t1, FALSE) <- attrs
-    return(t1)
-}
-
-#' @rdname as.tokens
-#' @export
-c.tokens <- function(...) {
-    x <- list(...)
-    if (length(x) == 1) return(x[[1]])
-    result <- x[[1]] + x[[2]]
-    if (length(x) == 2) return(result)
-    for (i in seq(3, length(x)))
-        result <- result + x[[i]]
-    return(result)
 }

--- a/man/as.tokens.Rd
+++ b/man/as.tokens.Rd
@@ -5,9 +5,9 @@
 \alias{as.tokens.list}
 \alias{as.tokens.spacyr_parsed}
 \alias{as.list.tokens}
-\alias{unlist.tokens}
 \alias{as.character.tokens}
 \alias{is.tokens}
+\alias{unlist.tokens}
 \alias{+.tokens}
 \alias{c.tokens}
 \title{Coercion, checking, and combining functions for tokens objects}
@@ -21,11 +21,11 @@ as.tokens(x, concatenator = "_", ...)
 
 \method{as.list}{tokens}(x, ...)
 
-\method{unlist}{tokens}(x, recursive = FALSE, use.names = TRUE)
-
 \method{as.character}{tokens}(x, use.names = FALSE, ...)
 
 is.tokens(x)
+
+\method{unlist}{tokens}(x, recursive = FALSE, use.names = TRUE)
 
 \method{+}{tokens}(t1, t2)
 
@@ -48,11 +48,11 @@ will be added to the token after \code{"concatenator"}.}
 \item{use_lemma}{logical; if \code{TRUE}, use the lemma rather than the raw
 token}
 
-\item{recursive}{a required argument for \link{unlist} but inapplicable to
-\link{tokens} objects}
-
 \item{use.names}{logical; preserve names if \code{TRUE}.  For
 \code{as.character} and \code{unlist} only.}
+
+\item{recursive}{a required argument for \link{unlist} but inapplicable to
+\link{tokens} objects}
 
 \item{t1}{tokens one to be added}
 
@@ -64,21 +64,21 @@ token}
 \code{as.list} returns a simple list of characters from a
   \link{tokens} object.
 
-\code{unlist} returns a simple vector of characters from a 
-  \link{tokens} object.
-
-\code{as.character} returns a character vector from a 
+\code{as.character} returns a character vector from a
   \link{tokens} object.
 
 \code{is.tokens} returns \code{TRUE} if the object is of class
   tokens, \code{FALSE} otherwise.
 
+\code{unlist} returns a simple vector of characters from a
+  \link{tokens} object.
+
 \code{c(...)} and \code{+} return a tokens object whose documents
   have been added as a single sequence of documents.
 }
 \description{
-Coercion functions to and from \link{tokens} objects, checks for whether an 
-object is a \link{tokens} object, and functions to combine \link{tokens} 
+Coercion functions to and from \link{tokens} objects, checks for whether an
+object is a \link{tokens} object, and functions to combine \link{tokens}
 objects.
 }
 \details{
@@ -86,8 +86,8 @@ The \code{concatenator} is used to automatically generate dictionary
   values for multi-word expressions in \code{\link{tokens_lookup}} and
   \code{\link{dfm_lookup}}. The underscore character is commonly used to join
   elements of multi-word expressions (e.g. "piece_of_cake", "New_York"), but
-  other characters (e.g. whitespace " " or a hyphen "-") can also be used. 
-  In those cases, users have to tell the system what is the concatenator in 
+  other characters (e.g. whitespace " " or a hyphen "-") can also be used.
+  In those cases, users have to tell the system what is the concatenator in
   your tokens so that the conversion knows to treat this character as the
   inter-word delimiter, when reading in the elements that will become the
   tokens.
@@ -95,9 +95,9 @@ The \code{concatenator} is used to automatically generate dictionary
 \examples{
 
 # create tokens object from list of characters with custom concatenator
-dict <- dictionary(list(country = "United States", 
+dict <- dictionary(list(country = "United States",
                    sea = c("Atlantic Ocean", "Pacific Ocean")))
-lis <- list(c("The", "United-States", "has", "the", "Atlantic-Ocean", 
+lis <- list(c("The", "United-States", "has", "the", "Atlantic-Ocean",
               "and", "the", "Pacific-Ocean", "."))
 toks <- as.tokens(lis, concatenator = "-")
 tokens_lookup(toks, dict)

--- a/man/dfm.Rd
+++ b/man/dfm.Rd
@@ -15,29 +15,29 @@ dfm(x, tolower = TRUE, stem = FALSE, select = NULL, remove = NULL,
 
 \item{stem}{if \code{TRUE}, stem words}
 
-\item{select}{a  \link{pattern}  of user-supplied features to keep, while 
-excluding all others.  This can be used in lieu of a dictionary if there 
-are only specific features that a user wishes to keep. To extract only 
-Twitter usernames, for example, set \code{select = "@*"} and make sure 
-that \code{remove_twitter = FALSE} as an additional argument passed to 
+\item{select}{a  \link{pattern}  of user-supplied features to keep, while
+excluding all others.  This can be used in lieu of a dictionary if there
+are only specific features that a user wishes to keep. To extract only
+Twitter usernames, for example, set \code{select = "@*"} and make sure
+that \code{remove_twitter = FALSE} as an additional argument passed to
 \link{tokens}.  Note: \code{select = "^@\\\w+\\\b"} would be the regular
-expression version of this matching pattern.  The pattern matching type 
+expression version of this matching pattern.  The pattern matching type
 will be set by \code{valuetype}.  See also \code{\link{tokens_remove}}.}
 
-\item{remove}{a \link{pattern} of user-supplied features to ignore, such as 
-"stop words".  To access one possible list (from any list you wish), use 
-\code{\link{stopwords}()}.  The pattern matching type will be set by 
+\item{remove}{a \link{pattern} of user-supplied features to ignore, such as
+"stop words".  To access one possible list (from any list you wish), use
+\code{\link{stopwords}()}.  The pattern matching type will be set by
 \code{valuetype}.  See also \code{\link{tokens_select}}.  For behaviour of
 \code{remove} with \code{ngrams > 1}, see Details.}
 
-\item{dictionary}{a \link{dictionary} object to apply to the tokens when 
+\item{dictionary}{a \link{dictionary} object to apply to the tokens when
 creating the dfm}
 
-\item{thesaurus}{a \link{dictionary} object that will be applied as if 
-\code{exclusive = FALSE}. See also \code{\link{tokens_lookup}}.  For more 
-fine-grained control over this and other aspects of converting features 
-into dictionary/thesaurus keys from pattern matches to values, consider 
-creating the dfm first, and then applying \code{\link{dfm_lookup}} 
+\item{thesaurus}{a \link{dictionary} object that will be applied as if
+\code{exclusive = FALSE}. See also \code{\link{tokens_lookup}}.  For more
+fine-grained control over this and other aspects of converting features
+into dictionary/thesaurus keys from pattern matches to values, consider
+creating the dfm first, and then applying \code{\link{dfm_lookup}}
 separately, or using \code{\link{tokens_lookup}} on the tokenized text
 before calling \code{dfm}.}
 
@@ -59,18 +59,18 @@ is a \link{dfm}}
 a \link{dfm-class} object
 }
 \description{
-Construct a sparse document-feature matrix, from a character, \link{corpus}, 
+Construct a sparse document-feature matrix, from a character, \link{corpus},
 \link{tokens}, or even other \link{dfm} object.
 }
 \details{
-The default behaviour for \code{remove}/\code{select} when 
-  constructing ngrams using \code{dfm(x, } \emph{ngrams > 1}\code{)} is to 
-  remove/select any ngram constructed from a matching feature.  If you wish 
+The default behaviour for \code{remove}/\code{select} when
+  constructing ngrams using \code{dfm(x, } \emph{ngrams > 1}\code{)} is to
+  remove/select any ngram constructed from a matching feature.  If you wish
   to remove these before constructing ngrams, you will need to first tokenize
-  the texts with ngrams, then remove the features to be ignored, and then 
-  construct the dfm using this modified tokenization object.  See the code 
+  the texts with ngrams, then remove the features to be ignored, and then
+  construct the dfm using this modified tokenization object.  See the code
   examples for an illustration.
-  
+
   To select on and match the features of a another \link{dfm}, \code{x} must
   also be a \link{dfm}.
 }
@@ -133,9 +133,9 @@ dfm(test_tweets, select = "^#.*$", valuetype = "regex", remove_twitter = FALSE)
 
 # for a dfm
 dfm1 <- dfm(data_corpus_irishbudget2010)
-dfm2 <- dfm(dfm1, 
+dfm2 <- dfm(dfm1,
             groups = ifelse(docvars(data_corpus_irishbudget2010, "party") \%in\% c("FF", "Green"),
-                            "Govt", "Opposition"), 
+                            "Govt", "Opposition"),
             tolower = FALSE, verbose = TRUE)
 
 }

--- a/man/textstat_simil.Rd
+++ b/man/textstat_simil.Rd
@@ -69,7 +69,8 @@ If you want to compute similarity on a "normalized" dfm object
 }
 \examples{
 # similarities for documents
-mt <- dfm(corpus_subset(data_corpus_inaugural, Year > 1980), remove_punct = TRUE, remove = stopwords("english"))
+mt <- dfm(corpus_subset(data_corpus_inaugural, Year > 1980), 
+          remove_punct = TRUE, remove = stopwords("english"))
 (s1 <- textstat_simil(mt, method = "cosine", margin = "documents"))
 as.matrix(s1)
 as.list(s1)

--- a/man/tokens.Rd
+++ b/man/tokens.Rd
@@ -132,7 +132,7 @@ tokens("<tags> and other + symbols.", remove_symbols = TRUE)
 tokens("<tags> and other + symbols.", remove_symbols = FALSE, what = "fasterword")
 tokens("<tags> and other + symbols.", remove_symbols = TRUE, what = "fasterword")
 
-## examples with URLs - hardly perfect!
+# examples with URLs - hardly perfect!
 txt <- "Repo https://githib.com/kbenoit/quanteda, and www.stackoverflow.com."
 tokens(txt, remove_url = TRUE, remove_punct = TRUE)
 tokens(txt, remove_url = FALSE, remove_punct = TRUE)
@@ -144,8 +144,8 @@ tokens(txt, remove_url = FALSE, remove_punct = FALSE, what = "fasterword")
 txt <- "#textanalysis is MY <3 4U @myhandle gr8 #stuff :-)"
 tokens(txt, remove_punct = TRUE)
 tokens(txt, remove_punct = TRUE, remove_twitter = TRUE)
-#tokens("great website http://textasdata.com", remove_url = FALSE)
-#tokens("great website http://textasdata.com", remove_url = TRUE)
+tokens("great website http://textasdata.com", remove_url = FALSE)
+tokens("great website http://textasdata.com", remove_url = TRUE)
 
 txt <- c(text1="This is $10 in 999 different ways,\\n up and down; left and right!",
          text2="@kenbenoit working: on #quanteda 2day\\t4ever, http://textasdata.com?page=123.")

--- a/tests/testthat/test-dfm.R
+++ b/tests/testthat/test-dfm.R
@@ -1011,27 +1011,18 @@ test_that("unused argument warning only happens only once (#1509)", {
         dfm("some text", NOTARG = TRUE),
         "^Argument NOTARG not used\\.$"
     )
-    w <- suppressWarnings(warnings(dfm("some text", NOTARG = TRUE)))
-    expect_equal(length(w), 1)
     expect_warning(
         dfm(corpus("some text"), NOTARG = TRUE),
         "^Argument NOTARG not used\\.$"
     )
-    w <- suppressWarnings(warnings(dfm(corpus("some text"), NOTARG = TRUE)))
-    expect_equal(length(w), 1)
     expect_warning(
         dfm(tokens("some text"), NOTARG = TRUE),
         "^Argument NOTARG not used\\.$"
     )
-    w <- suppressWarnings(warnings(dfm(tokens("some text"), NOTARG = TRUE)))
-    expect_equal(length(w), 1)
-    
     expect_warning(
         dfm(tokens("some text"), NOTARG = TRUE, NOTARG2 = FALSE),
         "^Arguments NOTARG, NOTARG2 not used\\.$"
     )
-    w <- suppressWarnings(warnings(dfm(tokens("some text"), NOTARG = TRUE, NOTARG2 = FALSE)))
-    expect_equal(length(w), 1)
 })
 
 test_that("dfm.tokens() with groups works as expected", {

--- a/tests/testthat/test-dfm.R
+++ b/tests/testthat/test-dfm.R
@@ -1041,3 +1041,12 @@ test_that("unused argument warning only happens only once (#1509)", {
         1
     )
 })
+
+test_that("dfm.tokens() with groups works as expected", {
+    x <- tokens(data_corpus_irishbudget2010)
+    groupeddfm <- dfm(tokens(x), 
+                      groups = c("FF", "FF", rep("non-FF", ndoc(x) - 2)))
+    expect_equal(ndoc(groupeddfm), 2)
+    expect_equal(docnames(groupeddfm), c("FF", "non-FF"))
+    expect_equal(featnames(groupeddfm), featnames(dfm(x)))
+})

--- a/tests/testthat/test-dfm.R
+++ b/tests/testthat/test-dfm.R
@@ -1005,3 +1005,39 @@ test_that("format_sparsity works correctly", {
     expect_identical(quanteda:::format_sparsity(.00011), " (0.011% sparse)")
     expect_identical(quanteda:::format_sparsity(.00011, digits = 3), " (0.011% sparse)")
 })
+
+test_that("unused argument warning only happens only once (#1509)", {
+    expect_warning(
+        dfm("some text", NOTARG = TRUE),
+        "^Argument NOTARG not used\\.$"
+    )
+    expect_equal(
+        suppressWarnings(length(warnings(dfm("some text", NOTARG = TRUE)))),
+        1
+    )
+    expect_warning(
+        dfm(corpus("some text"), NOTARG = TRUE),
+        "^Argument NOTARG not used\\.$"
+    )
+    expect_equal(
+        suppressWarnings(length(warnings(dfm(corpus("some text", NOTARG = TRUE))))),
+        1
+    )
+    expect_warning(
+        dfm(tokens("some text"), NOTARG = TRUE),
+        "^Argument NOTARG not used\\.$"
+    )
+    expect_equal(
+        suppressWarnings(length(warnings(dfm(tokens("some text", NOTARG = TRUE))))),
+        1
+    )
+    expect_warning(
+        dfm(tokens("some text"), NOTARG = TRUE, NOTARG2 = FALSE),
+        "^Arguments NOTARG, NOTARG2 not used\\.$"
+    )
+    expect_equal(
+        suppressWarnings(length(warnings(dfm(tokens("some text"), 
+                                             NOTARG = TRUE, NOTARG2 = FALSE)))),
+        1
+    )
+})

--- a/tests/testthat/test-dfm.R
+++ b/tests/testthat/test-dfm.R
@@ -1011,35 +1011,27 @@ test_that("unused argument warning only happens only once (#1509)", {
         dfm("some text", NOTARG = TRUE),
         "^Argument NOTARG not used\\.$"
     )
-    expect_equal(
-        suppressWarnings(length(warnings(dfm("some text", NOTARG = TRUE)))),
-        1
-    )
+    w <- suppressWarnings(warnings(dfm("some text", NOTARG = TRUE)))
+    expect_equal(length(w), 1)
     expect_warning(
         dfm(corpus("some text"), NOTARG = TRUE),
         "^Argument NOTARG not used\\.$"
     )
-    expect_equal(
-        suppressWarnings(length(warnings(dfm(corpus("some text", NOTARG = TRUE))))),
-        1
-    )
+    w <- suppressWarnings(warnings(dfm(corpus("some text"), NOTARG = TRUE)))
+    expect_equal(length(w), 1)
     expect_warning(
         dfm(tokens("some text"), NOTARG = TRUE),
         "^Argument NOTARG not used\\.$"
     )
-    expect_equal(
-        suppressWarnings(length(warnings(dfm(tokens("some text", NOTARG = TRUE))))),
-        1
-    )
+    w <- suppressWarnings(warnings(dfm(tokens("some text"), NOTARG = TRUE)))
+    expect_equal(length(w), 1)
+    
     expect_warning(
         dfm(tokens("some text"), NOTARG = TRUE, NOTARG2 = FALSE),
         "^Arguments NOTARG, NOTARG2 not used\\.$"
     )
-    expect_equal(
-        suppressWarnings(length(warnings(dfm(tokens("some text"), 
-                                             NOTARG = TRUE, NOTARG2 = FALSE)))),
-        1
-    )
+    w <- suppressWarnings(warnings(dfm(tokens("some text"), NOTARG = TRUE, NOTARG2 = FALSE)))
+    expect_equal(length(w), 1)
 })
 
 test_that("dfm.tokens() with groups works as expected", {

--- a/tests/testthat/test-tokens.R
+++ b/tests/testthat/test-tokens.R
@@ -251,27 +251,22 @@ test_that("unlist retuns character vector, issue #716", {
 })
 
 
-test_that("deprecated tokens arguments still work", {
-    
-    # expect_warning(
-    #     tokens("This contains 99 numbers.", removeNumbers = TRUE),
-    #     "removeNumbers is deprecated"
-    # )
+test_that("unused argument warnings for tokens work as expected", {
     
     # for tokens
     expect_identical(
         as.character(tokens(c(d1 = "This: punctuation"), remove_punct = TRUE)),
         c("This", "punctuation")
     )
-    # expect_identical(
-    #     as.character(tokens(c(d1 = "This: punctuation"), remove_punct = TRUE)),
-    #     as.character(tokens(c(d1 = "This: punctuation"), removePunct = TRUE))
-    # )
     expect_warning(
-        tokens(c(d1 = "This: punctuation"), notanargument = TRUE),
-        "Argument notanargument not used"
+        tokens(c(d1 = "This: punctuation"), notarg1 = TRUE),
+        "^Argument notarg1 not used\\."
     )
-    
+    expect_warning(
+        tokens(c(d1 = "This: punctuation"), notarg1 = TRUE, notarg2 = FALSE),
+        "^Arguments notarg1, notarg2 not used\\."
+    )
+
 })
 
 test_that("tokens arguments works with values from parent frame (#721)", {


### PR DESCRIPTION
Fixes #1509, by stopping multiple unused argument messages when passed to `dfm()` via `...`.

- Now uses `check_dots()` in `dfm.dfm()`, whereas all other checking is done because the arguments are passed to `tokens()` via `...`.

- `tokens_internal()` now uses `check_dots()` instead of the separate checking that was previously in the code.  This handles multiple unused arguments correctly in addition to not duplicating the functionality.

- Kills off last vestiges of old tokenize() arguments, which were in commented code and in the argument checking.

- Removes an unnecessary line in `dfm.tokens(x, groups = something)` and adds tests for this option.

- Lints `dfm.R` and `tokens.R`.