### PR TITLE
Add explicit prefix for dplyr::n() verb

### DIFF
--- a/tests/testthat/test-corpus.R
+++ b/tests/testthat/test-corpus.R
@@ -356,7 +356,7 @@ test_that("corpus works on dplyr grouped data.frames (#1232)", {
                    stringsAsFactors = FALSE,
                    row.names = paste0("fromDf_", 1:6)) %>%
         dplyr::group_by(letter_factor) %>% 
-        dplyr::mutate(n_group = n())
+        dplyr::mutate(n_group = dplyr::n())
     expect_output(
         print(corpus(mydf_grouped)),
         "^Corpus consisting of 6 documents and 3 docvars\\.$"


### PR DESCRIPTION
Fixes #1534 

For compliance with soon-to-be-released 0.80 CRAN update of **dplyr**.