### PR TITLE
fix textstat_keyness when only 2 docs with same name

### DIFF
--- a/R/textstat_keyness.R
+++ b/R/textstat_keyness.R
@@ -117,8 +117,8 @@ textstat_keyness.dfm <- function(x, target = 1L,
         stop("number of target documents must be < ndoc")
     }
     
-    # use original docnames only when there are two documents
-    if (ndoc(x) == 2) {
+    # use original docnames only when there are two (different) documents
+    if (ndoc(x) == 2 & length(unique(docnames(x))) > 1) {
         label <- docnames(x)[order(target, decreasing = TRUE)]
     } else {
         if (sum(target) == 1 && !is.null(docnames(x)[target])) {

--- a/R/textstat_keyness.R
+++ b/R/textstat_keyness.R
@@ -118,7 +118,7 @@ textstat_keyness.dfm <- function(x, target = 1L,
     }
     
     # use original docnames only when there are two (different) documents
-    if (ndoc(x) == 2 & length(unique(docnames(x))) > 1) {
+    if (ndoc(x) == 2 && length(unique(docnames(x))) > 1) {
         label <- docnames(x)[order(target, decreasing = TRUE)]
     } else {
         if (sum(target) == 1 && !is.null(docnames(x)[target])) {


### PR DESCRIPTION
Hi once again @kbenoit! This is a very minor PR mostly intended to inform you that, after a long time on other stuff (i.e., my day job), I'm once again on a side project using `quanteda`. We (myself and @fjensz) are developing a package for intended ROpenSci submission which bundles a bunch of `quanteda` and `topicmodels` tools into meta-functions for the analysis of temporally structured text collections (such as collections of historical reports). The key aspects of interest in these are temporal patterns, and so standard `keyness` and `topicmodels` results are mapped onto time, and results presented in interactive visualisations to allow time series to be plotted, with word associations or topics displayed on hover. (People who need this generally resort to commercial software because (i) they're humanities-type folk, not coders; and (ii) there is currently no open-source software that enables this.) There will also be some (likely limited) extensions to geo-locate words and include a few crude spatial analyses. Dev will be [here](https://github.com/mpadge/texttimetravel) if you're interested. If it's okay with you, I'll likely ping you along the way for any help, suggestions, as needed :smiley:

Anyway, this problem has arisen in the meantime,
``` r
devtools::load_all (".", export_all = FALSE)
#> Loading quanteda
#> Package version: 1.3.18
#> Parallel computing: 2 of 8 threads used.
#> See https://quanteda.io for tutorials and examples.
tok <- quanteda::data_corpus_inaugural %>% tokens()
word <- "politic*"
years <- docvars (tok)$Year
x <- quanteda::tokens_subset (tok, years == years [49])
word_dfm <- quanteda::tokens_keep (x, quanteda::phrase (word)) %>%
    quanteda::dfm ()
not_word_dfm <- quanteda::tokens_remove (x, quanteda::phrase (word)) %>%
    quanteda::dfm ()
x2 <- rbind (word_dfm, not_word_dfm)
ndoc (x2)
#> [1] 2
docnames (x2)
#> [1] "1981-Reagan" "1981-Reagan"
k <- quanteda::textstat_keyness (x2)
#> Error in x[2, ]: Subscript out of bounds
```

<sup>Created on 2019-01-11 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>

It arises because there are only 2 docs and they share the same name, so [this line](https://github.com/quanteda/quanteda/blob/master/R/textstat_keyness.R#L122) gives both of them the same `label`, meaning [`grouping`](https://github.com/quanteda/quanteda/blob/master/R/textstat_keyness.R#L130) has only one level, and [`temp`](https://github.com/quanteda/quanteda/blob/master/R/textstat_keyness.R#L131) contains only one document, not the desired and required **two**. This PR provides the very simple solution of only using `docnames` when there are 2 docs **AND** they have different names. This now succeeds:
``` r
devtools::load_all (".", export_all = FALSE)
#> Loading quanteda
#> Package version: 1.3.18
#> Parallel computing: 2 of 8 threads used.
#> See https://quanteda.io for tutorials and examples.
tok <- quanteda::data_corpus_inaugural %>% tokens()
word <- "politic*"
years <- docvars (tok)$Year
x <- quanteda::tokens_subset (tok, years == years [49])
word_dfm <- quanteda::tokens_keep (x, quanteda::phrase (word)) %>%
    quanteda::dfm ()
not_word_dfm <- quanteda::tokens_remove (x, quanteda::phrase (word)) %>%
    quanteda::dfm ()
x2 <- rbind (word_dfm, not_word_dfm)
ndoc (x2)
#> [1] 2
docnames (x2)
#> [1] "1981-Reagan" "1981-Reagan"
k <- quanteda::textstat_keyness (x2)
```

<sup>Created on 2019-01-11 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>

---

Separate topic: I can't get local tests to pass, yet see that they pass on travis. I see lots of fails such as `test-features.R:71, 187`, and `test-kwic.R:231,292,297,302,307,312,317,321,349,357,440,...` This is what happens:
``` r
devtools::load_all (".", export_all = FALSE)
#> Loading quanteda
#> Package version: 1.3.18
#> Parallel computing: 2 of 8 threads used.
#> See https://quanteda.io for tutorials and examples.
txt <- c("a b c d e a_b_c d e") # tests/tests.features.R:40
toks <- tokens(txt)
toksch <- as.character(toks)
feat <- 'a b c'
kwic(toks, pattern = phrase(feat))
#>                                       
#>  [text1, 1:3]  | a b c | d e a_b_c d e
devtools::test_file ("./tests/testthat/test-features.R")
#> Loading quanteda
#> Package version: 1.3.18
#> Parallel computing: 2 of 8 threads used.
#> See https://quanteda.io for tutorials and examples.
#> Testing quanteda
#> ✔ | OK F W S | Context
#> ✖ | 34 2     | test features.R [0.4 s]
#> ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
#> test-features.R:71: failure: character vector with whitespace works consistently on tokens
#> nrow(kwic(toks, pattern = phrase(feat))) not equal to 1.
#> 1/1 mismatches
#> [1] 0 - 1 == -1
#> 
#> test-features.R:187: failure: dictionary works consistently on tokens
#> kwic(toks, pattern = phrase(dict))$keyword not equal to c("a b c", "d", "e", "d", "e").
#> target is NULL, current is character
#> ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
#> 
#> ══ Results ═════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
#> Duration: 0.4 s
#> 
#> OK:       34
#> Failed:   2
#> Warnings: 0
#> Skipped:  0
kwic(toks, pattern = phrase(feat)) 
#> kwic object with 0 rows
```
<sup>Created on 2019-01-11 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>

And it seems that `testthat::test...` somehow changes the namespace so that exactly the same `kwic` call no longer returns the same object. Any ideas? It seems kinda important, because current state means I can't get tests to pass locally. Shall I open an issue?