### PR TITLE
Coerce all assigned docvars to character

### DIFF
--- a/R/docnames.R
+++ b/R/docnames.R
@@ -34,14 +34,16 @@ docnames.corpus <- function(x) {
     # didn't use accessor documents() because didn't want to pass
     # that large object
     if (is.null(rownames(x$documents))) {
-        paste0('text', seq_len(ndoc(x)))
+        paste0("text", seq_len(ndoc(x)))
     } else {
         rownames(x$documents)
     }
 }
 
 #' @param value a character vector of the same length as \code{x}
-#' @return \code{docnames <-} assigns new values to the document names of an object.
+#' @return \code{docnames <-} assigns new values to the document names of an object.  
+#' docnames can only be character, so any non-character value assigned to be a
+#' docname will be coerced to mode `character`.
 #' @export
 #' @examples 
 #' # reassign the document names of the inaugural speech corpus
@@ -60,21 +62,20 @@ docnames.corpus <- function(x) {
 #' @noRd
 #' @export
 "docnames<-.corpus" <- function(x, value) {
-    docvars(x, '_document') <- rownames(x$documents) <- value
+    docvars(x, "_document") <- rownames(x$documents) <- as.character(value)
     return(x)
 }
 
 #' @noRd
 #' @export
 "docnames<-.tokens" <- function(x, value) {
-    docvars(x, '_document') <- names(x) <- value
+    docvars(x, "_document") <- names(x) <- as.character(value)
     return(x)
 }
 
 #' @noRd
 #' @export
 "docnames<-.dfm" <- function(x, value) {
-    docvars(x, '_document') <- x@Dimnames$docs <- value
+    docvars(x, "_document") <- x@Dimnames$docs <- as.character(value)
     return(x)
 }
-

--- a/man/docnames.Rd
+++ b/man/docnames.Rd
@@ -17,7 +17,9 @@ docnames(x) <- value
 \value{
 \code{docnames} returns a character vector of the document names
 
-\code{docnames <-} assigns new values to the document names of an object.
+\code{docnames <-} assigns new values to the document names of an object.  
+docnames can only be character, so any non-character value assigned to be a
+docname will be coerced to mode `character`.
 }
 \description{
 Get or set the document names of a \link{corpus}, \link{tokens}, or \link{dfm} object.

--- a/tests/testthat/test-docnames.R
+++ b/tests/testthat/test-docnames.R
@@ -1,22 +1,19 @@
 context("test docnames")
 
 test_that("docnames always return names even if there aren't", {
-    
-    corp <- corpus(c('aaa', 'bbb', 'ccc'))
+    corp <- corpus(c("aaa", "bbb", "ccc"))
     expect_equal(length(docnames(corp)), ndoc(corp))
-    
-    toks <- as.tokens(list('aaa', 'bbb', 'ccc'))
+
+    toks <- as.tokens(list("aaa", "bbb", "ccc"))
     expect_equal(length(docnames(toks)), ndoc(toks))
-    
 })
 
 test_that("docnames<- works with corpus, tokens and dfm (#987)", {
-    
-    corp <- corpus(c('aaa', 'bbb', 'ccc'))
+    corp <- corpus(c("aaa", "bbb", "ccc"))
     toks <- tokens(corp)
     mx <- dfm(toks)
-    
-    name_new <- c('doc1', 'doc2', 'doc3')
+
+    name_new <- c("doc1", "doc2", "doc3")
     docnames(corp) <- name_new
     docnames(toks) <- name_new
     docnames(mx) <- name_new
@@ -24,9 +21,28 @@ test_that("docnames<- works with corpus, tokens and dfm (#987)", {
     expect_equal(docnames(corp), name_new)
     expect_equal(docnames(toks), name_new)
     expect_equal(docnames(mx), name_new)
-    
-    expect_equal(docvars(corp, '_document'), name_new)
-    expect_equal(docvars(toks, '_document'), name_new)
-    expect_equal(docvars(mx, '_document'), name_new)
-    
+
+    expect_equal(docvars(corp, "_document"), name_new)
+    expect_equal(docvars(toks, "_document"), name_new)
+    expect_equal(docvars(mx, "_document"), name_new)
+})
+
+test_that("docnames are character only (#1574)", {
+    # for corpus
+    corp <- corpus(c("a b c", "x y z"), docnames = 1:2)
+    expect_is(docnames(corp), "character")
+
+    # for tokens
+    toks <- tokens(c("a b c", "x y z"))
+    docnames(toks) <- 1:2
+    expect_is(docnames(toks), "character")
+    names(toks) <- 1:2
+    expect_is(docnames(toks), "character")
+
+    # for tokens
+    dfmat <- dfm(c("a b c", "x y z"))
+    docnames(dfmat) <- 1:2
+    expect_is(docnames(dfmat), "character")
+    rownames(dfmat) <- 1:2
+    expect_is(docnames(dfmat), "character")
 })


### PR DESCRIPTION
Fixes #1574 by coercing all assigned docvars to `character`.