### PR TITLE
More fixes to 1574

### DIFF
--- a/R/dfm-methods.R
+++ b/R/dfm-methods.R
@@ -87,8 +87,8 @@ as.dfm.default <- function(x) {
 #' @method as.dfm dfm
 #' @export
 as.dfm.dfm <- function(x) {
-    # make sure those dimensions are character
-    x@Dimnames <- lapply(x@Dimnames, as.character)
+    # make sure the dimension names are character
+    set_dfm_dimnames(x) <- lapply(x@Dimnames, as.character)
     # for compatibility with older dfm objects
     if (identical(dim(x@docvars), c(0L, 0L)))
         x@docvars <- data.frame(matrix(ncol = 0, nrow = nrow(x)))

--- a/R/dfm-methods.R
+++ b/R/dfm-methods.R
@@ -88,7 +88,7 @@ as.dfm.default <- function(x) {
 #' @export
 as.dfm.dfm <- function(x) {
     # make sure the dimension names are character
-    set_dfm_dimnames(x) <- lapply(x@Dimnames, as.character)
+    set_dfm_dimnames(x) <- x@Dimnames
     # for compatibility with older dfm objects
     if (identical(dim(x@docvars), c(0L, 0L)))
         x@docvars <- data.frame(matrix(ncol = 0, nrow = nrow(x)))

--- a/R/dfm-methods.R
+++ b/R/dfm-methods.R
@@ -87,6 +87,8 @@ as.dfm.default <- function(x) {
 #' @method as.dfm dfm
 #' @export
 as.dfm.dfm <- function(x) {
+    # make sure those dimensions are character
+    x@Dimnames <- lapply(x@Dimnames, as.character)
     # for compatibility with older dfm objects
     if (identical(dim(x@docvars), c(0L, 0L)))
         x@docvars <- data.frame(matrix(ncol = 0, nrow = nrow(x)))

--- a/R/dimnames.R
+++ b/R/dimnames.R
@@ -18,7 +18,8 @@
     if (is.null(value[[2]])) value[[2]] <- character()
     stopifnot(nrow(x) == length(value[[1]]))
     stopifnot(ncol(x) == length(value[[2]]))
-    x@Dimnames <- list("docs" = value[[1]], "features" = value[[2]])
+    x@Dimnames <- list("docs" = as.character(value[[1]]), 
+                       "features" = as.character(value[[2]]))
     Encoding(x@Dimnames[[1]]) <- Encoding(x@Dimnames[[2]]) <- "UTF-8"
     return(x)
 }
@@ -26,7 +27,7 @@
 #' @rdname set_dfm_dimnames
 "set_dfm_docnames<-" <- function(x, value) {
     stopifnot(nrow(x) == length(value))
-    x@Dimnames[[1]] <- value
+    x@Dimnames[[1]] <- as.character(value)
     Encoding(x@Dimnames[[1]]) <- "UTF-8"
     return(x)
 }
@@ -35,7 +36,7 @@
 "set_dfm_featnames<-" <- function(x, value) {
     if (is.null(value)) value <- character()
     stopifnot(ncol(x) == length(value))
-    x@Dimnames[[2]] <- value
+    x@Dimnames[[2]] <- as.character(value)
     Encoding(x@Dimnames[[2]]) <- "UTF-8"
     return(x)
 }
@@ -46,7 +47,8 @@
     if (is.null(value[[2]])) value[[2]] <- character()
     stopifnot(nrow(x) == length(value[[1]]))
     stopifnot(ncol(x) == length(value[[2]]))
-    x@Dimnames <- list("features" = value[[1]], "features" = value[[2]])
+    x@Dimnames <- list("features" = as.character(value[[1]]), 
+                       "features" = as.character(value[[2]]))
     Encoding(x@Dimnames[[1]]) <- Encoding(x@Dimnames[[2]]) <- "UTF-8"
     return(x)
 }
@@ -56,7 +58,7 @@
     if (is.null(value)) value <- character()
     stopifnot(nrow(x) == length(value))
     stopifnot(ncol(x) == length(value))
-    x@Dimnames[[1]] <- x@Dimnames[[2]] <- value
+    x@Dimnames[[1]] <- x@Dimnames[[2]] <- as.character(value)
     Encoding(x@Dimnames[[1]]) <- Encoding(x@Dimnames[[2]]) <- "UTF-8"
     return(x)
 }

--- a/R/textstat_simil.R
+++ b/R/textstat_simil.R
@@ -80,6 +80,7 @@ textstat_simil.dfm <- function(x, selection = NULL,
                                method = c("correlation", "cosine", "jaccard", "ejaccard",
                                           "dice", "edice", "hamman", "simple matching", "faith"),
                                upper = FALSE, diag = FALSE) {
+    x <- as.dfm(x)
 
     margin <- match.arg(margin)
     method <- match.arg(method)
@@ -170,6 +171,7 @@ textstat_dist.dfm <- function(x, selection = NULL,
                               method = c("euclidean", "kullback",
                                          "manhattan", "maximum", "canberra", "minkowski"),
                               upper = FALSE, diag = FALSE, p = 2) {
+    x <- as.dfm(x)
 
     margin <- match.arg(margin)
     method <- match.arg(method)

--- a/tests/testthat/test-docnames.R
+++ b/tests/testthat/test-docnames.R
@@ -46,3 +46,12 @@ test_that("docnames are character only (#1574)", {
     rownames(dfmat) <- 1:2
     expect_is(docnames(dfmat), "character")
 })
+
+test_that("dfm docnames cannot be made integer before textstat_simil", {
+    dfmat <- data_dfm_lbgexample
+    dfmat@Dimnames$docs <- seq_len(ndoc(dfmat))
+    expect_identical(
+        dimnames(as.matrix(textstat_simil(dfmat)))[[1]],
+        as.character(1:6)
+    )
+})

--- a/tests/testthat/test-textstat_dist_old.R
+++ b/tests/testthat/test-textstat_dist_old.R
@@ -76,7 +76,7 @@ test_that("test textstat_dist_old method = \"Kullback-Leibler\" against proxy di
     expect_equivalent(kullQuanteda, kullProxy)
     
     rownames(m) <- c("a", "b", "c", "d", "e")
-    mydfm <- new("dfm", Matrix::Matrix(as.matrix(m), sparse=TRUE, dimnames = list(docs = rownames(m), features=colnames(m))))
+    mydfm <- as.dfm(m)
     kullQuanteda <- round(textstat_dist_old(mydfm, "a", method = "kullback", margin = "documents")[, "a"], 2)
     kullProxy <- round(drop(proxy::dist(as.matrix(mydfm), as.matrix(mydfm[1, ]), "kullback", diag = FALSE, upper = FALSE)), 2)
     kullProxy <- kullProxy[order(names(kullProxy))]


### PR DESCRIPTION
Found a few more places where we should coerce the elements of `dfmat@Dimnames` to `character`. 

I even wrote an S4 validator function but that doesn't work since in dfm.R you are now creating the dfm without dimnames, and then setting them separately. And the class validators are not invoked with low-level manipulations anyway, so it's not a robust solution.

Anyway take a look at these latest additions.