### PR TITLE
Fix reference url for Klare (1975) in textstat_readability

### DIFF
--- a/R/textstat_readability.R
+++ b/R/textstat_readability.R
@@ -421,7 +421,7 @@
 #'   Gunning, R. (1952). \emph{The Technique of Clear Writing}.  New York: McGraw-Hill.
 #'   
 #'   Klare, G.R. (1975).
-#'   \href{https://www.jstor.org/stable/pdf/747086.pdf}{Assessing Readability}.
+#'   \href{https://www.jstor.org/stable/pdf/747086}{Assessing Readability}.
 #'   \emph{Reading Research Quarterly}, 10(1), 62--102.
 #'   
 #'   Kincaid, J. P., Fishburne Jr, R.P., Rogers, R.L., & Chissom, B.S. (1975).

--- a/man/textstat_readability.Rd
+++ b/man/textstat_readability.Rd
@@ -438,7 +438,7 @@ Anderson, J. (1983). \href{https://www.jstor.org/stable/40031755}{Lix and
   Gunning, R. (1952). \emph{The Technique of Clear Writing}.  New York: McGraw-Hill.
   
   Klare, G.R. (1975).
-  \href{https://www.jstor.org/stable/pdf/747086.pdf}{Assessing Readability}.
+  \href{https://www.jstor.org/stable/pdf/747086}{Assessing Readability}.
   \emph{Reading Research Quarterly}, 10(1), 62--102.
   
   Kincaid, J. P., Fishburne Jr, R.P., Rogers, R.L., & Chissom, B.S. (1975).


### PR DESCRIPTION
Fixes #1593. Amends the JSTOR reference url for Klare (1975) in textstat_readability.