### PR TITLE
Fix docvar addressing for corpus

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: quanteda
-Version: 1.4.0
+Version: 1.4.1
 Title: Quantitative Analysis of Textual Data
 Description: A fast, flexible, and comprehensive framework for 
     quantitative text analysis in R.  Provides functionality for corpus management,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# quanteda > 1.4.0
+
+## Bug fixes and stability enhancements
+
+* Fixed the operation of `docvars<-.corpus()` in a way that solves #1603 (reassignment of docvar names).
+
+
 # quanteda 1.4.0
 
 ## Bug fixes and stability enhancements

--- a/R/docvars.R
+++ b/R/docvars.R
@@ -43,7 +43,7 @@ docvars.tokens <- function(x, field = NULL) {
     dvars <- attr(x, "docvars")
     if (is.null(field))
         dvars <- dvars[, which(substring(names(dvars), 1, 1) != "_"), drop = FALSE]
-    get_docvars(dvars, field)    
+    get_docvars(dvars, field)  
 }
 
 #' @noRd
@@ -53,18 +53,18 @@ docvars.dfm <- function(x, field = NULL) {
     dvars <- x@docvars
     if (is.null(field))
         dvars <- dvars[, which(substring(names(dvars), 1, 1) != "_"), drop = FALSE]
-    get_docvars(dvars, field)    
+    get_docvars(dvars, field)  
 }
 
 #' @noRd
 #' @keywords internal
 docvars.kwic <- function(x) {
-    dvars <- attr(x, 'docvars')
+    dvars <- attr(x, "docvars")
     if (is.null(dvars))
         dvars <- data.frame()
-    dvars <- structure(dvars[attr(x, 'docid'),], 
-                       class = 'data.frame',
-                       row.names = paste(x$docname, attr(x, 'segid'), sep = "."))
+    dvars <- structure(dvars[attr(x, "docid"), ],
+                       class = "data.frame",
+                       row.names = paste(x$docname, attr(x, "segid"), sep = "."))
     select_fields(dvars)
 }
 
@@ -115,21 +115,24 @@ docvars.kwic <- function(x) {
 "docvars<-.corpus" <- function(x, field = NULL, value) {
     if (is.dfm(value))
         value <- convert(value, to = "data.frame")[, -1, drop = FALSE]
-    if ("texts" %in% field) 
+    if ("texts" %in% field)
         stop("You should use texts() instead to replace the corpus texts.")
     if (is.null(field)) {
-        field <- names(value)
-        if (is.null(field))
-            field <- paste("docvar", seq_len(ncol(as.data.frame(value))), 
-                           sep = "")
+        newdv <- data.frame(value, stringsAsFactors = FALSE, check.names = FALSE)
+        # uses the V1, V2 etc scheme
+        names(newdv) <- names(as.data.frame(as.matrix(value)))
+    } else {
+        newdv <- docvars(x)
+        newdv[field] <- value
     }
-    documents(x)[field] <- value
-    x
+    meta_names_not_in_newdv <- setdiff(grep("^_.+", names(documents(x)), value = TRUE), names(newdv))
+    documents(x) <- cbind(documents(x)[, c("texts", meta_names_not_in_newdv), drop = FALSE], newdv)
+    return(x)
 }
 
 #' @export
 "docvars<-.tokens" <- function(x, field = NULL, value) {
-    if (is.dfm(value)) 
+    if (is.dfm(value))
         value <- convert(value, to = "data.frame")[, -1, drop = FALSE]
     if (is.null(value)) {
         attr(x, "docvars") <- attr(x, "docvars")[, seq(ncol(attr(x, "docvars"))) * -1, drop = FALSE]
@@ -152,7 +155,7 @@ docvars.kwic <- function(x) {
 
 #' @export
 "docvars<-.dfm" <- function(x, field = NULL, value) {
-    if (is.dfm(value)) 
+    if (is.dfm(value))
         value <- convert(value, to = "data.frame")[, -1, drop = FALSE]
     if (is.null(value)) {
         x@docvars <- x@docvars[, seq(ncol(x@docvars)) * -1, drop = FALSE]
@@ -206,7 +209,7 @@ docvars.kwic <- function(x) {
 #' @seealso \code{\link{metacorpus}}
 #' @export
 #' @keywords corpus
-metadoc <- function(x, field = NULL) 
+metadoc <- function(x, field = NULL)
     UseMethod("metadoc")
 
 #' @export
@@ -221,7 +224,7 @@ metadoc.corpus <- function(x, field = NULL) {
         field <- paste0("_", field)
         check_fields(x, field)
     }
-    dvars <- documents(x)[, which(substring(names(documents(x)), 1, 1) == "_"), 
+    dvars <- documents(x)[, which(substring(names(documents(x)), 1, 1) == "_"),
                           drop = FALSE]
     get_docvars(dvars, field)
 }
@@ -251,7 +254,7 @@ metadoc.dfm <- function(x, field = NULL) {
 #' @rdname metadoc
 #' @param value the new value of the new meta-data field
 #' @export
-"metadoc<-" <- function(x, field = NULL, value) 
+"metadoc<-" <- function(x, field = NULL, value)
     UseMethod("metadoc<-")
 
 #' @export
@@ -265,11 +268,11 @@ metadoc.dfm <- function(x, field = NULL) {
     # CHECK TO SEE THAT VALUE LIST IS IN VALID DOCUMENT-LEVEL METADATA LIST
     # (this check not yet implemented)
     if (is.null(field)) {
-        field <- paste("_", names(value), sep="")
+        field <- paste("_", names(value), sep = "")
         if (is.null(field))
             field <- paste("_metadoc", seq_len(ncol(as.data.frame(value))), sep = "")
     } else {
-        field <- paste("_", field, sep="")
+        field <- paste("_", field, sep = "")
     }
     documents(x)[field] <- value
     x
@@ -306,7 +309,7 @@ docvars_internal <- function(x) {
     if (is.corpus(x)) {
         return(documents(x))
     } else if (is.tokens(x)) {
-        return(attr(x, 'docvars'))
+        return(attr(x, "docvars"))
     } else if (is.dfm(x)) {
         return(x@docvars)
     }
@@ -315,7 +318,7 @@ docvars_internal <- function(x) {
 get_docvars2 <- function(x, fields) {
     is_field <- check_docvars(x, fields)
     if (any(is_field)) {
-        return(docvars_internal(x)[,is_field, drop = FALSE])
+        return(docvars_internal(x)[, is_field, drop = FALSE])
     } else {
         return(NULL)
     }
@@ -324,28 +327,27 @@ get_docvars2 <- function(x, fields) {
 ## helper function to check fields
 check_docvars <- function(x, fields) {
     dvars <- docvars_internal(x)
-    if (is.null(dvars)) 
+    if (is.null(dvars))
         return(rep(FALSE, length(fields)))
     return(fields %in% names(dvars))
 }
 
 ## internal function to select docvar fields
-select_fields <- function(x, types = c('user', 'system')) {
+select_fields <- function(x, types = c("user", "system")) {
 
     names <- names(x)
-    is_system <- stri_startswith_fixed(names, '_') 
-    is_text <- stri_detect_fixed(names, 'texts') | stri_detect_fixed(names, '_texts')
-    
+    is_system <- stri_startswith_fixed(names, "_")
+    is_text <- stri_detect_fixed(names, "texts") | stri_detect_fixed(names, "_texts")
+
     result <- data.frame(row.names = row.names(x))
-    if ('text' %in% types) {
+    if ("text" %in% types) {
         result <- cbind(result, x[is_text])
-    } 
-    if ('system' %in% types) {
+    }
+    if ("system" %in% types) {
         result <- cbind(result, x[is_system & !is_text])
     }
-    if ('user' %in% types) {
+    if ("user" %in% types) {
         result <- cbind(result, x[!is_system & !is_text])
-    } 
+    }
     return(result)
 }
-

--- a/tests/testthat/test-docvars.R
+++ b/tests/testthat/test-docvars.R
@@ -122,7 +122,6 @@ test_that("metadoc works with selection", {
     )
 }) 
 
-
 test_that("docvars is working with dfm", {
     corp <- data_corpus_irishbudget2010
     toks <- tokens(corp, include_docvars = TRUE)
@@ -325,5 +324,55 @@ test_that("can assign docvars when value is a dfm (#1417)", {
     expect_identical(
         docvars(toks),
         data.frame(and = as.vector(anddfm), row.names = 1:ndoc(mycorp)) # docnames(mycorp))
+    )
+})
+
+test_that("docvar assignment is fully robust including to renaming (#1603)", {
+    # assigning a data.frame to blank docars
+    corp <- corpus(c("A b c d.", "A a b. B c."))
+    docvars(corp) <- data.frame(testdv = 10:11)
+    expect_identical(
+        docvars(corp),
+        data.frame(testdv = 10:11, row.names = docnames(corp))
+    )
+    
+    # assigning a vector to blank docars
+    corp <- corpus(c("A b c d.", "A a b. B c."))
+    docvars(corp) <- c("x", "y")
+    expect_identical(
+        docvars(corp),
+        data.frame(V1 = c("x", "y"), row.names = docnames(corp), stringsAsFactors = FALSE)
+    )
+    
+    # renaming a docvar
+    corp <- corpus(c("A b c d.", "A a b. B c."),
+               docvars = data.frame(testdv = 10:11))
+    names(docvars(corp))[1] <- "renamed_dv"
+    expect_identical(
+        docvars(corp),
+        data.frame(renamed_dv = 10:11, row.names = docnames(corp))
+    )
+    expect_identical(
+        texts(corp),
+        c(text1 = "A b c d.", text2 = "A a b. B c.")
+    )
+})
+
+test_that("docvars<-.corpus error trapping works", {
+    expect_error(
+        docvars(data_corpus_irishbudget2010, "texts") <- 
+            paste0("newtext", seq_len(ndoc(data_corpus_irishbudget2010))),
+        "You should use texts"
+    )
+    
+    # preexisting docvars keep unique names
+    corp <- corpus(c("A b c d.", "A a b. B c."))
+    docvars(corp) <- data.frame(docvar1 = 1:2)
+    docvars(corp)[2] <- 11:12
+    docvars(corp)[3] <- c("a", "b")
+    expect_identical(
+        docvars(corp),
+        data.frame(docvar1 = 1:2, V2 = 11:12, V3 = c("a", "b"), stringsAsFactors = FALSE, 
+                   row.names = c("text1", "text2"))
     )
 })


### PR DESCRIPTION
- fixes names(docvars())<- to solve #1603
- linting changes for docvars.R
- ensures V1, V2, ... names for docvars without names (vectors)

@koheiw I know this will be solved in `dev-corpus2` (and provides yet one more good reason to move to that structure) but this provides a fix in the meantime. Ain't pretty but it works.