### PR TITLE
Replace em dash hyphens with simple hyphen

### DIFF
--- a/R/fcm.R
+++ b/R/fcm.R
@@ -81,7 +81,7 @@
 #'   Church, K. W. & P. Hanks (1990) .
 #'  \href{http://dl.acm.org/citation.cfm?id=89095}{Word association norms,
 #'   mutual information, and lexicography}. \emph{Computational Linguistics},
-#'   16(1), 22–29.
+#'   16(1), 22-29.
 #' @examples
 #' # see http://bit.ly/29b2zOA
 #' txt1 <- "A D A C E A D F E B A C E D"

--- a/R/textstat_dist_old.R
+++ b/R/textstat_dist_old.R
@@ -9,13 +9,13 @@
 #'   E. D. (2001).
 #'   "\href{http://adn.biol.umontreal.ca/~numericalecology/Reprints/Legendre_&_Gallagher.pdf}{Ecologically
 #'    meaningful transformations for ordination of species data}".
-#'   \emph{Oecologia}, 129(2), 271–280. doi.org/10.1007/s004420100716
+#'   \emph{Oecologia}, 129(2), 271-280. doi.org/10.1007/s004420100716
 #'   
 #'   The \code{"chisquared2"} metric is the "Quadratic-Chi" measure from Pele,
 #'   O., & Werman, M. (2010). 
 #'   "\href{https://link.springer.com/chapter/10.1007/978-3-642-15552-9_54}{The
-#'   Quadratic-Chi Histogram Distance Family}". In \emph{Computer Vision – ECCV
-#'   2010} (Vol. 6312, pp. 749–762). Berlin, Heidelberg: Springer, Berlin,
+#'   Quadratic-Chi Histogram Distance Family}". In \emph{Computer Vision - ECCV
+#'   2010} (Vol. 6312, pp. 749-762). Berlin, Heidelberg: Springer, Berlin,
 #'   Heidelberg. doi.org/10.1007/978-3-642-15552-9_54.
 #'
 #'   \code{"kullback"} is the Kullback-Leibler distance, which assumes that

--- a/R/textstat_keyness.R
+++ b/R/textstat_keyness.R
@@ -193,7 +193,7 @@ keyness_chi2_dt <- function(x, correction = c("default", "yates", "williams", "n
         dt[, cor_app := (((a+b)*(a+c)/N < 5 | (a+b)*(b+d)/N < 5 | (a+c)*(c+d)/N < 5 | (c+d)*(b+d)/N < 5) 
                          & abs(a*d - b*c) >= N/2)]
         # the correction is usually only recommended if the smallest expected frequency is less than 5
-        # the correction should not be applied if |ad − bc| is less than N/2.
+        # the correction should not be applied if |ad - bc| is less than N/2.
         # compute using the direct formula - see link above (adds sign)
         dt[, chi2 := ifelse(cor_app, 
                             (N * (abs(a*d - b*c) - N * 0.5)^2) / ((a+b)*(c+d)*(a+c)*(b+d)) * ifelse(a > E, 1, -1), 
@@ -313,7 +313,7 @@ keyness_lr <- function(x, correction = c("default", "yates", "williams", "none")
         dt[, cor_app := (((a+b)*(a+c)/N < 5 | (a+b)*(b+d)/N < 5 | (a+c)*(c+d)/N < 5 | (c+d)*(b+d)/N < 5)
                          & abs(a*d - b*c) > N/2)]
         # the correction is usually only recommended if the smallest expected frequency is less than 5
-        # the correction should not be applied if |ad − bc| is less than N/2.
+        # the correction should not be applied if |ad - bc| is less than N/2.
         # implement Yates continuity correction
         # If (ad-bc) is positive, subtract 0.5 from a and d and add 0.5 to b and c. 
         # If (ad-bc) is negative, add 0.5 to a and d and subtract 0.5 from b and c.

--- a/R/textstat_readability.R
+++ b/R/textstat_readability.R
@@ -352,7 +352,7 @@
 #'   Reading}, 26(6), 490--496.
 #'
 #'   Bamberger, R. & Vanecek, E. (1984).
-#'   \emph{Lesen–Verstehen–Lernen–Schreiben}. Wien: Jugend und Volk.
+#'   \emph{Lesen-Verstehen-Lernen-Schreiben}. Wien: Jugend und Volk.
 #'
 #'   Björnsson, C. H. (1968). \emph{Läsbarhet}. Stockholm: Liber.
 #'
@@ -416,13 +416,13 @@
 #'   221.
 #'   
 #'   Fucks, W. (1955). Der Unterschied des Prosastils von Dichtern und anderen Schriftstellern. 
-#'   \emph{Sprachforum}, 1, 233-–244.
+#'   \emph{Sprachforum}, 1, 233-244.
 #'   
 #'   Gunning, R. (1952). \emph{The Technique of Clear Writing}.  New York: McGraw-Hill.
 #'   
 #'   Klare, G.R. (1975).
 #'   \href{https://www.jstor.org/stable/pdf/747086}{Assessing Readability}.
-#'   \emph{Reading Research Quarterly}, 10(1), 62--102.
+#'   \emph{Reading Research Quarterly}, 10(1), 62-102.
 #'   
 #'   Kincaid, J. P., Fishburne Jr, R.P., Rogers, R.L., & Chissom, B.S. (1975).
 #'   \href{https://stars.library.ucf.edu/istlibrary/56/}{Derivation of New

--- a/man/fcm.Rd
+++ b/man/fcm.Rd
@@ -120,7 +120,7 @@ Momtazi, S., Khudanpur, S., & Klakow, D. (2010).
   Church, K. W. & P. Hanks (1990) .
  \href{http://dl.acm.org/citation.cfm?id=89095}{Word association norms,
   mutual information, and lexicography}. \emph{Computational Linguistics},
-  16(1), 22–29.
+  16(1), 22-29.
 }
 \author{
 Kenneth Benoit (R), Haiyan Wang (R, C++), Kohei Watanabe (C++)

--- a/man/textstat_readability.Rd
+++ b/man/textstat_readability.Rd
@@ -369,7 +369,7 @@ Anderson, J. (1983). \href{https://www.jstor.org/stable/40031755}{Lix and
   Reading}, 26(6), 490--496.
 
   Bamberger, R. & Vanecek, E. (1984).
-  \emph{Lesen–Verstehen–Lernen–Schreiben}. Wien: Jugend und Volk.
+  \emph{Lesen-Verstehen-Lernen-Schreiben}. Wien: Jugend und Volk.
 
   Björnsson, C. H. (1968). \emph{Läsbarhet}. Stockholm: Liber.
 
@@ -433,13 +433,13 @@ Anderson, J. (1983). \href{https://www.jstor.org/stable/40031755}{Lix and
   221.
   
   Fucks, W. (1955). Der Unterschied des Prosastils von Dichtern und anderen Schriftstellern. 
-  \emph{Sprachforum}, 1, 233-–244.
+  \emph{Sprachforum}, 1, 233-244.
   
   Gunning, R. (1952). \emph{The Technique of Clear Writing}.  New York: McGraw-Hill.
   
   Klare, G.R. (1975).
   \href{https://www.jstor.org/stable/pdf/747086}{Assessing Readability}.
-  \emph{Reading Research Quarterly}, 10(1), 62--102.
+  \emph{Reading Research Quarterly}, 10(1), 62-102.
   
   Kincaid, J. P., Fishburne Jr, R.P., Rogers, R.L., & Chissom, B.S. (1975).
   \href{https://stars.library.ucf.edu/istlibrary/56/}{Derivation of New

--- a/man/textstat_simil_old.Rd
+++ b/man/textstat_simil_old.Rd
@@ -67,13 +67,13 @@ The \code{"chisquared"} metric is from Legendre, P., & Gallagher,
   E. D. (2001).
   "\href{http://adn.biol.umontreal.ca/~numericalecology/Reprints/Legendre_&_Gallagher.pdf}{Ecologically
    meaningful transformations for ordination of species data}".
-  \emph{Oecologia}, 129(2), 271–280. doi.org/10.1007/s004420100716
+  \emph{Oecologia}, 129(2), 271-280. doi.org/10.1007/s004420100716
   
   The \code{"chisquared2"} metric is the "Quadratic-Chi" measure from Pele,
   O., & Werman, M. (2010). 
   "\href{https://link.springer.com/chapter/10.1007/978-3-642-15552-9_54}{The
-  Quadratic-Chi Histogram Distance Family}". In \emph{Computer Vision – ECCV
-  2010} (Vol. 6312, pp. 749–762). Berlin, Heidelberg: Springer, Berlin,
+  Quadratic-Chi Histogram Distance Family}". In \emph{Computer Vision - ECCV
+  2010} (Vol. 6312, pp. 749-762). Berlin, Heidelberg: Springer, Berlin,
   Heidelberg. doi.org/10.1007/978-3-642-15552-9_54.
 
   \code{"kullback"} is the Kullback-Leibler distance, which assumes that

--- a/tests/testthat/test-as.dfm.R
+++ b/tests/testthat/test-as.dfm.R
@@ -139,7 +139,7 @@ test_that("dfm2dataframe same as as.data.frame.dfm", {
 
 test_that("as.data.frame.dfm handles irregular feature names correctly", {
     skip_on_os("windows")
-    skip_on_appveyor()
+    skip_on_cran()
     mydfm <- dfm(data_char_sampletext, 
                  dictionary = dictionary(list("字" = "a", "spe cial" = "the", 
                                               "飛機" = "if", "spec+ial" = "of")))


### PR DESCRIPTION
- Fixes some problems seen at https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-debian-clang/quanteda-00check.html

- Skips (on CRAN) some failing tests related to dfm dimension name element encoding