### PR TITLE
Cast to double to address #1653

### DIFF
--- a/src/tokens_chunk_mt.cpp
+++ b/src/tokens_chunk_mt.cpp
@@ -13,7 +13,7 @@ Texts chunk(Text &tokens,
     std::size_t step;
     Texts chunks;
     step = size - overlap;
-    chunks.reserve(ceil(tokens.size() / step));
+    chunks.reserve(ceil((double)tokens.size() / step));
     for (size_t i = 0; i < tokens.size(); i += step) {
         Text chunk(tokens.begin() + i, tokens.begin() + std::min(i + size, tokens.size()));
         chunks.push_back(chunk);


### PR DESCRIPTION
I remember that we had similar issue in `tokens_select_mt.cpp` etc. earlier.