### PR TITLE
Add ... to textstat_frequency to pass to dfm_group

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: quanteda
-Version: 1.4.2
+Version: 1.4.3
 Title: Quantitative Analysis of Textual Data
 Description: A fast, flexible, and comprehensive framework for 
     quantitative text analysis in R.  Provides functionality for corpus management,

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,8 +2,12 @@
 
 ## Bug fixes and stability enhancements
 
-* Added a `force = TRUE` option and error checking for the situations of applying `dfm_weight()` or `dfm_group()` to a dfm that has already been weighted.  (#1545)
 * Changed the default value of the `size` argument in `dfm_sample()` to the number of features, not the number of documents.  (#1643)
+
+## Behaviour changes
+
+* Added a `force = TRUE` option and error checking for the situations of applying `dfm_weight()` or `dfm_group()` to a dfm that has already been weighted.  (#1545)  The function `textstat_frequency()` now allows passing this argument to `dfm_group()` via `...`.  (#1646)
+* `textstat_frequency()` now has a new argument for resolving ties when ranking term frequencies, defaulting to the "min" method.  (#1634)
 
 
 # quanteda 1.4.1

--- a/R/textstat_frequency.R
+++ b/R/textstat_frequency.R
@@ -10,6 +10,9 @@
 #'   \code{\link[data.table]{frank}} for details.  Unlike that function,
 #'   however, the default is \code{"min"}, so that frequencies of 10, 10, 11
 #'   would be ranked 1, 1, 3.
+#' @param ... additional arguments passed to \code{\link{dfm_group}}.  This can
+#'   be useful in passing `force = TRUE`, for instance, if you are grouping a
+#'   dfm that has been weighted.
 #' @inheritParams groups
 #' @return a data.frame containing the following variables:
 #' \describe{
@@ -69,20 +72,23 @@
 #' @export
 #' @keywords plot
 textstat_frequency <- function(x, n = NULL, groups = NULL, 
-                               ties_method = c("min", "average", "first", "random", "max", "dense")) {
+                               ties_method = c("min", "average", "first", "random", "max", "dense"),
+                               ...) {
     UseMethod("textstat_frequency")
 }
     
 #' @export
 textstat_frequency.default <- function(x, n = NULL, groups = NULL,
-                               ties_method = c("min", "average", "first", "random", "max", "dense")) {
+                               ties_method = c("min", "average", "first", "random", "max", "dense"),
+                               ...) {
     stop(friendly_class_undefined_message(class(x), "textstat_frequency"))
 }
 
 #' @importFrom data.table data.table setcolorder setorder frank
 #' @export
 textstat_frequency.dfm <- function(x, n = NULL, groups = NULL,
-                               ties_method = c("min", "average", "first", "random", "max", "dense")) {
+                               ties_method = c("min", "average", "first", "random", "max", "dense"),
+                               ...) {
     group <- frequency <- NULL
     ties_method <- match.arg(ties_method)
     
@@ -92,9 +98,9 @@ textstat_frequency.dfm <- function(x, n = NULL, groups = NULL,
     if (is.null(groups)) groups <- rep("all", ndoc(x))
     
     x@weightTf[["scheme"]] <- "count" # reset for docfreq
-    docfreq <- dfm_group(dfm_weight(x, "boolean"), groups)@x
+    docfreq <- dfm_group(dfm_weight(x, "boolean"), groups, ...)@x
     
-    x <- as(dfm_group(x, groups), "dgTMatrix")
+    x <- as(dfm_group(x, groups, ...), "dgTMatrix")
     result <- data.table(feature = colnames(x)[x@j + 1],
                        frequency = x@x,
                        docfreq = docfreq,

--- a/man/textstat_frequency.Rd
+++ b/man/textstat_frequency.Rd
@@ -5,7 +5,7 @@
 \title{Tabulate feature frequencies}
 \usage{
 textstat_frequency(x, n = NULL, groups = NULL, ties_method = c("min",
-  "average", "first", "random", "max", "dense"))
+  "average", "first", "random", "max", "dense"), ...)
 }
 \arguments{
 \item{x}{a \link{dfm} object}
@@ -22,6 +22,10 @@ See \link{groups} for details.}
 \code{\link[data.table]{frank}} for details.  Unlike that function,
 however, the default is \code{"min"}, so that frequencies of 10, 10, 11
 would be ranked 1, 1, 3.}
+
+\item{...}{additional arguments passed to \code{\link{dfm_group}}.  This can
+be useful in passing `force = TRUE`, for instance, if you are grouping a
+dfm that has been weighted.}
 }
 \value{
 a data.frame containing the following variables:

--- a/tests/testthat/test-textstat_frequency.R
+++ b/tests/testthat/test-textstat_frequency.R
@@ -20,7 +20,6 @@ test_that("test textstat_frequency without groups", {
                  group = rep('all', 4),
                  stringsAsFactors = FALSE)[1:2, ]
     )
-    
 })
 
 test_that("test textstat_frequency without groups", {
@@ -91,5 +90,26 @@ test_that("test textstat_frequency ties methods defaults work (min)", {
         data.frame(feature = c("a", "b", "d", "c"),
                    frequency = c(1, 1, 3, 4),
                    stringsAsFactors = FALSE)
+    )
+})
+
+test_that("test textstat_frequency with groups and weighted dfm (#1646)", {
+    dfmat <- dfm(c("a a b b c d", "a d d d", "a a a")) %>%
+        dfm_tfidf()
+    
+    expect_error(
+        textstat_frequency(dfmat, groups = c(1, 2, 2)),
+        "will not group a weighted dfm; use force = TRUE to override",
+        fixed = TRUE
+    )
+    expect_equivalent(
+        textstat_frequency(dfmat, groups = c(1, 2, 2), force = TRUE),
+        data.frame(feature = c("b", "c", "d", "a", "d", "a"),
+                   frequency = c(.95, .48, .18, 0, .53, .00),
+                   rank = c(1, 2, 3, 4, 1, 2),
+                   docfreq = c(1, 1, 1, 0, 1, 0),
+                   group = as.character(c(rep(1, 4), 2, 2)),
+                   stringsAsFactors = FALSE),
+        tolerance = .01
     )
 })


### PR DESCRIPTION
Fixes #1646 by allowing `force = TRUE` to be passed to `dfm_group()` via `...` in `textstat_frequency()`.

However note that it is now possible to have a group with no "frequency":
``` r
library("quanteda")
## Package version: 1.4.2
## Parallel computing: 2 of 12 threads used.
## See https://quanteda.io for tutorials and examples.
## 
## Attaching package: 'quanteda'
## The following object is masked from 'package:utils':
## 
##     View

dfmat <- dfm(c("a", "a b", "a c")) %>%
  dfm_tfidf()
dfmat
## Document-feature matrix of: 3 documents, 3 features (44.4% sparse).
## 3 x 3 sparse Matrix of class "dfm"
##        features
## docs    a         b         c
##   text1 0 0         0        
##   text2 0 0.4771213 0        
##   text3 0 0         0.4771213

tstat <- textstat_frequency(dfmat, groups = c(1, 2, 2), force = TRUE)
tstat
##   feature frequency rank docfreq group
## 1       a 0.0000000    1       0     1
## 2       b 0.4771213    1       1     2
## 3       c 0.4771213    1       1     2
## 4       a 0.0000000    3       0     2

str(tstat)
## Classes 'frequency', 'textstat' and 'data.frame':    4 obs. of  5 variables:
##  $ feature  : chr  "a" "b" "c" "a"
##  $ frequency: num  0 0.477 0.477 0
##  $ rank     : int  1 1 1 3
##  $ docfreq  : num  0 1 1 0
##  $ group    : chr  "1" "2" "2" "2"
```

We could filter out the zero-frequency features, but keep at least one feature per group, or we could just leave it as is, even if this looks strange. The user "used the force" so maybe we just consider that it's on the user's head?