### PR TITLE
Fix typo in corpus documentation

### DIFF
--- a/R/corpus.R
+++ b/R/corpus.R
@@ -7,7 +7,7 @@
 #'   the elements are named, these names will be used as document names.
 #' \item a \link{data.frame} (or a \pkg{tibble} \code{tbl_df}), whose default
 #' document id is a variable identified by \code{docid_field}; the text of the
-#' document is a variable identified by \code{textid_field}; and other variables
+#' document is a variable identified by \code{text_field}; and other variables
 #' are imported as document-level meta-data.  This matches the format of
 #' data.frames constructed by the the \pkg{readtext} package.
 #' \item a \link{kwic} object constructed by \code{\link{kwic}}.

--- a/man/corpus.Rd
+++ b/man/corpus.Rd
@@ -87,7 +87,7 @@ sources are:
   the elements are named, these names will be used as document names.
 \item a \link{data.frame} (or a \pkg{tibble} \code{tbl_df}), whose default
 document id is a variable identified by \code{docid_field}; the text of the
-document is a variable identified by \code{textid_field}; and other variables
+document is a variable identified by \code{text_field}; and other variables
 are imported as document-level meta-data.  This matches the format of
 data.frames constructed by the the \pkg{readtext} package.
 \item a \link{kwic} object constructed by \code{\link{kwic}}.


### PR DESCRIPTION
Changes 

> the text of the document is a variable identified by \code{textid_field};

to

> the text of the document is a variable identified by \code{text_field};
