### PR TITLE
Tick up R-version for Appveyor CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,4 +42,4 @@ artifacts:
     name: Bits
 
 environment:
-  R_VERSION: 3.5.2
+  R_VERSION: 3.5.3


### PR DESCRIPTION
Just changing R version for appveyor CI from 3.5.2 to 3.5.3