### PR TITLE
Add size control for sampling by group

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ## New features
 
 * Add `flatten` and `levels` arguments to `as.list.dictionary2()` to enable more flexible conversion of dictionary objects. (#1661)
+* In `corpus_sample()`, the `size` now works with the `by` argument, to control the size of units sampled from each group.
 
 ## Bug fixes and stability enhancements
 

--- a/R/corpus_sample.R
+++ b/R/corpus_sample.R
@@ -4,14 +4,17 @@
 #' or without replacement.  Works just as \code{\link{sample}} works for the
 #' documents and their associated document-level variables.
 #' @param x a corpus object whose documents will be sampled
-#' @param size a positive number, the number of documents to select
+#' @param size a positive number, the number of documents to select; when used
+#'   with groups, the number to select from each group or a vector equal in
+#'   length to the number of groups defining the samples to be chosen in each
+#'   group category.  By defining a size larger than the number of documents, it
+#'   is possible to \emph{over}sample groups.
 #' @param replace Should sampling be with replacement?
 #' @param prob A vector of probability weights for obtaining the elements of the
 #'   vector being sampled.  May not be applied when \code{by} is used.
 #' @param by a grouping variable for sampling.  Useful for resampling
 #'   sub-document units such as sentences, for instance by specifying \code{by =
 #'   "document"}
-#' @param ... unused
 #' @return A corpus object with number of documents equal to \code{size}, drawn 
 #'   from the corpus \code{x}.  The returned corpus object will contain all of 
 #'   the meta-data of the original corpus, and the same document variables for 
@@ -30,24 +33,27 @@
 #' corpsent <- corpus_reshape(corp, to = "sentences")
 #' texts(corpsent)
 #' texts(corpus_sample(corpsent, replace = TRUE, by = "document"))
-corpus_sample <- function(x, size = ndoc(x), replace = FALSE, prob = NULL, by = NULL, ...) {
+corpus_sample <- function(x, size = ndoc(x), replace = FALSE, prob = NULL, by = NULL) {
     UseMethod("corpus_sample")
 }
 
 #' @export
-corpus_sample.default <- function(x, size = ndoc(x), replace = FALSE, prob = NULL, by = NULL, ...) {
+corpus_sample.default <- function(x, size = ndoc(x), replace = FALSE, prob = NULL, by = NULL) {
     stop(friendly_class_undefined_message(class(x), "corpus_sample"))
 }
 
 #' @import data.table data.table
 #' @export
-corpus_sample.corpus <- function(x, size = ndoc(x), replace = FALSE, prob = NULL, by = NULL, ...) {
+corpus_sample.corpus <- function(x, size = ndoc(x), replace = FALSE, prob = NULL, by = NULL) {
     index <- docID <- temp <- NULL
-    
+
     if (!is.null(by)) {
         if (!is.null(prob)) stop("prob not implemented with by")
         if (by == "document") by <- "_document"
-        sample_index <- sample_bygroup(seq_len(ndoc(x)), group = docvars(x, by), replace = replace)
+        # define size as null for passing to sample_bygroup, if not defined
+        if (missing(size)) size <- NULL
+        sample_index <- sample_bygroup(seq_len(ndoc(x)), group = docvars(x, by), 
+                                       size = size, replace = replace)
     } else {
         sample_index <- base::sample(ndoc(x), size, replace, prob) 
     }

--- a/R/utils.R
+++ b/R/utils.R
@@ -278,18 +278,17 @@ message_error <- function(key = NULL) {
 #' quanteda:::sample_bygroup(1:10, group = grvec, size = 2, replace = TRUE)
 #' quanteda:::sample_bygroup(1:10, group = grvec, size = c(1, 1, 3), replace = TRUE)
 sample_bygroup <- function(x, group, size = NULL, replace = FALSE) {
-    xsplit <- split(x, group)
+    if (length(x) != length(group))
+        stop("group not equal in length of x")
+    x <- split(x, group)
     if (is.null(size)) 
-        size <- lengths(xsplit)
-    if (length(size) > 1 && length(size) != length(xsplit))
+        size <- lengths(x)
+    if (length(size) > 1 && length(size) != length(x))
         stop("size not equal in length to the number of groups")
     if (length(size) == 1)
-        size <- rep(size, length(xsplit))
-    result <- lapply(seq_along(xsplit), function(y) {
-        # workaround for the problem that sample(2) is the same as sample(1:2)!
-        as.integer(
-            sample(as.character(xsplit[[y]]), size = size[y], replace = replace)
-        )
-    })
+        size <- rep(size, length(x))
+    result <- mapply(function(x, size, replace) {
+                 x[sample.int(length(x), size = size, replace = replace)]
+              }, x, size, replace)
     unlist(result, use.names = FALSE)
-} 
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -286,7 +286,10 @@ sample_bygroup <- function(x, group, size = NULL, replace = FALSE) {
     if (length(size) == 1)
         size <- rep(size, length(xsplit))
     result <- lapply(seq_along(xsplit), function(y) {
-        sample(xsplit[[y]], size = size[y], replace = replace)
+        # workaround for the problem that sample(2) is the same as sample(1:2)!
+        as.integer(
+            sample(as.character(xsplit[[y]]), size = size[y], replace = replace)
+        )
     })
     unlist(result, use.names = FALSE)
 } 

--- a/R/utils.R
+++ b/R/utils.R
@@ -285,10 +285,8 @@ sample_bygroup <- function(x, group, size = NULL, replace = FALSE) {
         size <- lengths(x)
     if (length(size) > 1 && length(size) != length(x))
         stop("size not equal in length to the number of groups")
-    if (length(size) == 1)
-        size <- rep(size, length(x))
     result <- mapply(function(x, size, replace) {
                  x[sample.int(length(x), size = size, replace = replace)]
-              }, x, size, replace)
+              }, x, size, replace, SIMPLIFY = FALSE)
     unlist(result, use.names = FALSE)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -262,6 +262,10 @@ message_error <- function(key = NULL) {
 #' 
 #' Return a sample from a vector within a grouping variable.
 #' @param x any vector
+#' @param size the number of items to sample within each group, as a positive
+#'   number or a vector of numbers equal in length to the number of groups. If
+#'   \code{NULL}, the sampling is stratified by group in the original group
+#'   sizes.
 #' @param group a grouping vector equal in length to \code{length(x)}
 #' @param replace logical; should sampling be with replacement?
 #' @return \code{x} resampled within groups
@@ -271,7 +275,18 @@ message_error <- function(key = NULL) {
 #' grvec <- c(rep("a", 3), rep("b", 4), rep("c", 3))
 #' quanteda:::sample_bygroup(1:10, group = grvec, replace = FALSE)
 #' quanteda:::sample_bygroup(1:10, group = grvec, replace = TRUE)
-sample_bygroup <- function(x, group, replace = FALSE) {
-    result <- lapply(split(x, group), sample, replace = replace)
+#' quanteda:::sample_bygroup(1:10, group = grvec, size = 2, replace = TRUE)
+#' quanteda:::sample_bygroup(1:10, group = grvec, size = c(1, 1, 3), replace = TRUE)
+sample_bygroup <- function(x, group, size = NULL, replace = FALSE) {
+    xsplit <- split(x, group)
+    if (is.null(size)) 
+        size <- lengths(xsplit)
+    if (length(size) > 1 && length(size) != length(xsplit))
+        stop("size not equal in length to the number of groups")
+    if (length(size) == 1)
+        size <- rep(size, length(xsplit))
+    result <- lapply(seq_along(xsplit), function(y) {
+        sample(xsplit[[y]], size = size[y], replace = replace)
+    })
     unlist(result, use.names = FALSE)
 } 

--- a/man/corpus_sample.Rd
+++ b/man/corpus_sample.Rd
@@ -5,12 +5,16 @@
 \title{Randomly sample documents from a corpus}
 \usage{
 corpus_sample(x, size = ndoc(x), replace = FALSE, prob = NULL,
-  by = NULL, ...)
+  by = NULL)
 }
 \arguments{
 \item{x}{a corpus object whose documents will be sampled}
 
-\item{size}{a positive number, the number of documents to select}
+\item{size}{a positive number, the number of documents to select; when used
+with groups, the number to select from each group or a vector equal in
+length to the number of groups defining the samples to be chosen in each
+group category.  By defining a size larger than the number of documents, it
+is possible to \emph{over}sample groups.}
 
 \item{replace}{Should sampling be with replacement?}
 
@@ -20,8 +24,6 @@ vector being sampled.  May not be applied when \code{by} is used.}
 \item{by}{a grouping variable for sampling.  Useful for resampling
 sub-document units such as sentences, for instance by specifying \code{by =
 "document"}}
-
-\item{...}{unused}
 }
 \value{
 A corpus object with number of documents equal to \code{size}, drawn 

--- a/man/sample_bygroup.Rd
+++ b/man/sample_bygroup.Rd
@@ -4,12 +4,17 @@
 \alias{sample_bygroup}
 \title{Sample a vector by a group}
 \usage{
-sample_bygroup(x, group, replace = FALSE)
+sample_bygroup(x, group, size = NULL, replace = FALSE)
 }
 \arguments{
 \item{x}{any vector}
 
 \item{group}{a grouping vector equal in length to \code{length(x)}}
+
+\item{size}{the number of items to sample within each group, as a positive
+number or a vector of numbers equal in length to the number of groups. If
+\code{NULL}, the sampling is stratified by group in the original group
+sizes.}
 
 \item{replace}{logical; should sampling be with replacement?}
 }
@@ -24,5 +29,7 @@ set.seed(100)
 grvec <- c(rep("a", 3), rep("b", 4), rep("c", 3))
 quanteda:::sample_bygroup(1:10, group = grvec, replace = FALSE)
 quanteda:::sample_bygroup(1:10, group = grvec, replace = TRUE)
+quanteda:::sample_bygroup(1:10, group = grvec, size = 2, replace = TRUE)
+quanteda:::sample_bygroup(1:10, group = grvec, size = c(1, 1, 3), replace = TRUE)
 }
 \keyword{internal}

--- a/tests/testthat/test-bootstrap.R
+++ b/tests/testthat/test-bootstrap.R
@@ -8,8 +8,8 @@ test_that("bootstrap_dfm works with character and corpus objects", {
                    docvars = data.frame(country = c("UK", "USA", "UK"),
                                         year = c(1990, 2000, 2005)),
                    metacorpus = list(notes = "Example showing how corpus_reshape() works."))
-    set.seed(10)
 
+    set.seed(10)
     dfmatresamp1 <- bootstrap_dfm(corp, n = 10)
     expect_equal(dfmatresamp1[[1]], dfm(corp))
 

--- a/tests/testthat/test-corpus_sample.R
+++ b/tests/testthat/test-corpus_sample.R
@@ -37,3 +37,58 @@ test_that("corpus with prob does not work with by", {
         "prob not implemented with by"
     )
 })
+
+test_that("sample_bygroup works with sizes", {
+    grvec <- c(rep("a", 3), rep("b", 4), rep("c", 3))
+    
+    # sampling same size each group
+    tmp <- quanteda:::sample_bygroup(1:10, group = grvec, size = 2, replace = TRUE)
+    expect_true(all(tmp[1:2] >= 0 & tmp[1:2] <= 3))
+    expect_true(all(tmp[3:4] >= 4 & tmp[3:4] <= 7))
+    expect_true(all(tmp[5:6] >= 8 & tmp[5:6] <= 10))
+    
+    # sampling from a vector of sizes
+    tmp <- quanteda:::sample_bygroup(1:10, group = grvec, size = c(1, 1, 3), replace = TRUE)
+    expect_true(all(tmp[1] >= 0 & tmp[1] <= 3))
+    expect_true(all(tmp[2] >= 4 & tmp[2] <= 7))
+    expect_true(all(tmp[3:5] >= 8 & tmp[3:5] <= 10))
+    
+    # default group size sampling
+    tmp <- quanteda:::sample_bygroup(1:10, group = grvec, replace = TRUE)
+    expect_true(all(tmp[1:3] >= 0 & tmp[1:3] <= 3))
+    expect_true(all(tmp[4:7] >= 4 & tmp[4:7] <= 7))
+    expect_true(all(tmp[8:10] >= 8 & tmp[8:10] <= 10))
+    
+    # oversampling within group
+    tmp <- quanteda:::sample_bygroup(c(1:2, c(101:102)), 
+                                     group = rep(letters[1:2], each = 2),
+                                     size = 5, replace = TRUE)
+    expect_true(all(tmp[1:5] >= 0 & tmp[1:5] <= 2))
+    expect_true(all(tmp[6:10] >= 100 & tmp[6:10] <= 102))
+    
+    expect_error(
+        quanteda:::sample_bygroup(1:10, group = grvec, size = c(2, 3), replace = TRUE),
+        "size not equal in length to the number of groups"
+    )
+})
+
+test_that("corpus_sample by group works", {
+    corp <- corpus(
+        paste("Document number", seq_len(10)),
+        docvars = data.frame(id = paste0("id", seq_len(10)),
+                             grp = c(rep("A", 5), rep("B", 5)), 
+                             stringsAsFactors = FALSE)
+    )
+    expect_equal(
+        docvars(corpus_sample(corp, size = 2, by = "grp"), "grp"),
+        rep(LETTERS[1:2], each = 2)
+    )
+    expect_equal(
+        docvars(corpus_sample(corp, size = 25, by = "grp", replace = TRUE), "grp"),
+        rep(LETTERS[1:2], each = 25)
+    )
+    expect_equal(
+        docvars(corpus_sample(corp, by = "grp"), "grp"),
+        rep(LETTERS[1:2], each = 5)
+    )
+})

--- a/tests/testthat/test-corpus_sample.R
+++ b/tests/testthat/test-corpus_sample.R
@@ -38,40 +38,6 @@ test_that("corpus with prob does not work with by", {
     )
 })
 
-test_that("sample_bygroup works with sizes", {
-    grvec <- c(rep("a", 3), rep("b", 4), rep("c", 3))
-    
-    # sampling same size each group
-    tmp <- quanteda:::sample_bygroup(1:10, group = grvec, size = 2, replace = TRUE)
-    expect_true(all(tmp[1:2] >= 0 & tmp[1:2] <= 3))
-    expect_true(all(tmp[3:4] >= 4 & tmp[3:4] <= 7))
-    expect_true(all(tmp[5:6] >= 8 & tmp[5:6] <= 10))
-    
-    # sampling from a vector of sizes
-    tmp <- quanteda:::sample_bygroup(1:10, group = grvec, size = c(1, 1, 3), replace = TRUE)
-    expect_true(all(tmp[1] >= 0 & tmp[1] <= 3))
-    expect_true(all(tmp[2] >= 4 & tmp[2] <= 7))
-    expect_true(all(tmp[3:5] >= 8 & tmp[3:5] <= 10))
-    
-    # default group size sampling
-    tmp <- quanteda:::sample_bygroup(1:10, group = grvec, replace = TRUE)
-    expect_true(all(tmp[1:3] >= 0 & tmp[1:3] <= 3))
-    expect_true(all(tmp[4:7] >= 4 & tmp[4:7] <= 7))
-    expect_true(all(tmp[8:10] >= 8 & tmp[8:10] <= 10))
-    
-    # oversampling within group
-    tmp <- quanteda:::sample_bygroup(c(1:2, c(101:102)), 
-                                     group = rep(letters[1:2], each = 2),
-                                     size = 5, replace = TRUE)
-    expect_true(all(tmp[1:5] >= 0 & tmp[1:5] <= 2))
-    expect_true(all(tmp[6:10] >= 100 & tmp[6:10] <= 102))
-    
-    expect_error(
-        quanteda:::sample_bygroup(1:10, group = grvec, size = c(2, 3), replace = TRUE),
-        "size not equal in length to the number of groups"
-    )
-})
-
 test_that("corpus_sample by group works", {
     corp <- corpus(
         paste("Document number", seq_len(10)),

--- a/tests/testthat/test-dfm_sample.R
+++ b/tests/testthat/test-dfm_sample.R
@@ -13,7 +13,7 @@ test_that("dfm_sample works as expected", {
 })
 
 test_that("dfm_sample for features works as expected", {
-    RNGversion("3.5.3")
+    suppressWarnings(RNGversion("3.5.3"))
     dfmat <- dfm(c("a b c c d", "a a c c d d d"))
     expect_identical({
         set.seed(100)
@@ -30,6 +30,7 @@ test_that("dfm_sample for features works as expected", {
 })
 
 test_that("dfm_sample default size arguments work as expected", {
+    suppressWarnings(RNGversion("3.5.3"))
     dfmat <- dfm(c("a b c c d", "a a c c d d d"))
     expect_identical({
         set.seed(100)

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -116,3 +116,45 @@ test_that("check_font is working", {
     expect_equal(quanteda:::check_font("mono"), "mono")
 })
 
+test_that("sample_bygroup works with sizes", {
+    grvec <- c(rep("a", 3), rep("b", 4), rep("c", 3))
+    
+    # sampling same size each group
+    tmp <- quanteda:::sample_bygroup(1:10, group = grvec, size = 2, replace = TRUE)
+    expect_true(all(tmp[1:2] >= 0 & tmp[1:2] <= 3))
+    expect_true(all(tmp[3:4] >= 4 & tmp[3:4] <= 7))
+    expect_true(all(tmp[5:6] >= 8 & tmp[5:6] <= 10))
+    
+    # sampling from a vector of sizes
+    tmp <- quanteda:::sample_bygroup(1:10, group = grvec, size = c(1, 1, 3), replace = TRUE)
+    expect_true(all(tmp[1] >= 0 & tmp[1] <= 3))
+    expect_true(all(tmp[2] >= 4 & tmp[2] <= 7))
+    expect_true(all(tmp[3:5] >= 8 & tmp[3:5] <= 10))
+    
+    # default group size sampling
+    tmp <- quanteda:::sample_bygroup(1:10, group = grvec, replace = TRUE)
+    expect_true(all(tmp[1:3] >= 0 & tmp[1:3] <= 3))
+    expect_true(all(tmp[4:7] >= 4 & tmp[4:7] <= 7))
+    expect_true(all(tmp[8:10] >= 8 & tmp[8:10] <= 10))
+    
+    # oversampling within group
+    tmp <- quanteda:::sample_bygroup(c(1:2, c(101:102)), 
+                                     group = rep(letters[1:2], each = 2),
+                                     size = 5, replace = TRUE)
+    expect_true(all(tmp[1:5] >= 0 & tmp[1:5] <= 2))
+    expect_true(all(tmp[6:10] >= 100 & tmp[6:10] <= 102))
+    
+    expect_error(
+        quanteda:::sample_bygroup(1:10, group = grvec, size = c(2, 3), replace = TRUE),
+        "size not equal in length to the number of groups"
+    )
+})
+
+test_that("sample_bygroup works with groups of size 1", {
+    grvec <- c(rep("a", 3), rep("b", 1))
+    for (i in seq_len(10)) {
+        tmp <- quanteda:::sample_bygroup(1:4, group = grvec, replace = TRUE)
+        expect_true(all(tmp[1:3] >= 1 & tmp[1:3] <= 3))
+        expect_equal(tmp[4], 4)
+    }
+})

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -145,6 +145,10 @@ test_that("sample_bygroup works with sizes", {
     expect_true(all(tmp[6:10] >= 100 & tmp[6:10] <= 102))
     
     expect_error(
+        quanteda:::sample_bygroup(1:10, group = grvec[1:6], size = c(2, 3), replace = TRUE),
+        "group not equal in length of x"
+    )
+    expect_error(
         quanteda:::sample_bygroup(1:10, group = grvec, size = c(2, 3), replace = TRUE),
         "size not equal in length to the number of groups"
     )


### PR DESCRIPTION
This affects `corpus_sample()` primarily, but also fixes an unforeseen bug from `sample_bygroup()` caused by the unfortunate way `base::sample()` is written, so that `sample(1:2)` is the same as `sample(2)`.

The new behaviour is very useful if we want to say sample documents from a large set for machine learning, e.g. to choose half of the documents in the 2000-text `data_corpus_movies`, we could use:
```r
> corpus_sample(data_corpus_movies, size = 500, by = "Sentiment") %>%
+     docvars("Sentiment") %>%
+     table()
.
neg pos 
500 500

> corpus_sample(data_corpus_movies, size = c(10, 20), by = "Sentiment") %>%
+     docvars("Sentiment") %>%
+     table()
.
neg pos 
 10  20  
```
