### PR TITLE
Issue 1632

### DIFF
--- a/R/dfm_group.R
+++ b/R/dfm_group.R
@@ -50,8 +50,9 @@ dfm_group.default <- function(x, groups = NULL, fill = FALSE, force = FALSE) {
 #' @export
 dfm_group.dfm <- function(x, groups = NULL, fill = FALSE, force = FALSE) {
 
-    if (is.null(groups)) return(x)
-    
+    if (is.null(groups))
+        groups <- docid(x)
+
     if (!force && 
         (( (! x@weightTf[["scheme"]] %in% c("count", "prop")) &&
          x@weightDf[["scheme"]] != "unary" ) ||

--- a/R/docnames.R
+++ b/R/docnames.R
@@ -79,3 +79,9 @@ docnames.corpus <- function(x) {
     docvars(x, "_document") <- x@Dimnames$docs <- as.character(value)
     return(x)
 }
+
+#' Internal function to extract docid
+#' @noRd
+docid <- function(x) {
+    docvars(x, "_docid") # TODO should be exported in v2.0
+} 

--- a/R/docnames.R
+++ b/R/docnames.R
@@ -83,5 +83,10 @@ docnames.corpus <- function(x) {
 #' Internal function to extract docid
 #' @noRd
 docid <- function(x) {
-    docvars(x, "_docid") # TODO should be exported in v2.0
+    # docid is missing from some object before v2.0 
+    tryCatch({
+        docvars(x, "_docid") # TODO should be exported in v2.0
+    }, error = function(e) {
+        seq_len(ndoc(x))  
+    })
 } 

--- a/tests/testthat/test-dfm_group.R
+++ b/tests/testthat/test-dfm_group.R
@@ -262,3 +262,14 @@ test_that("group_docvar drops list column (#1553)", {
                                        vec2 = c("a", "b", "c"),
                                        row.names = c(1, 2, 3))))
 })
+
+
+test_that("restore original unit when groups = NULL", {
+    corp <- head(data_corpus_inaugural, 2)
+    corp_sent <- corpus_reshape(corp)
+    dfmt_sent <- dfm(corp_sent)
+    dfmt <- dfm_group(dfmt_sent)
+    expect_equal(ndoc(corp), ndoc(dfmt))
+    expect_equal(ndoc(corp_sent), ndoc(dfmt_sent))
+    expect_equivalent(as.matrix(dfmt), as.matrix(dfm(corp))) # TODO should be equal after v2.0
+})


### PR DESCRIPTION
#1632. I needed to catch errors caused by inconsistency in docvars in current version in `docid()`, but can be better in v2.0.
 