### PR TITLE
Fix #1705 relating to tidytext dictionary changes

### DIFF
--- a/tests/testthat/test-as.dictionary.R
+++ b/tests/testthat/test-as.dictionary.R
@@ -61,14 +61,7 @@ test_that("as.dictionary function works for tidytext sentiment", {
     skip_if_not_installed("tidytext")
     data(sentiments, package = "tidytext")
     expect_true(
-        is.dictionary(as.dictionary(subset(sentiments, lexicon == "nrc")))
-    )
-    expect_true(
-        is.dictionary(as.dictionary(subset(sentiments, lexicon == "bing")))
-    )
-    expect_warning(
-        as.dictionary(sentiments, format = "tidytext"),
-        "you may be mixing different dictionaries"
+        is.dictionary(as.dictionary(sentiments))
     )
 })
 


### PR DESCRIPTION
Fixes breaking tests in `test-as.dictionary.R` relating to changes in the sentiment dictionaries included with **tidytext**.

Fixes #1705