### PR TITLE
Fix a bug in classing symmetric matrices

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # quanteda 1.5.1
 
 * Fix a bug that affects the new `textstat_dist()` and `textstat_simil()` (#1730)
+* fix a bug in how `textstat_dist()` and `textstat_simil()` class symmetric matrices.
 
 # quanteda 1.5.0
 

--- a/R/textstat_simil.R
+++ b/R/textstat_simil.R
@@ -242,8 +242,8 @@ textstat_simil.dfm <- function(x, y = NULL, selection = NULL,
                            min_proxy = min_simil, use_na = TRUE)
 
     if (is.null(min_simil)) {
-        if (is.null(y)) {
-            temp <- as(forceSymmetric(temp), "dsyMatrix")
+        if (isSymmetric(temp)) {
+            temp <- as(temp, "dgeMatrix")
             return(new("textstat_simil_symm", as(temp, "dspMatrix"),
                        method = method, margin = margin,
                        type = "textstat_simil"))
@@ -253,7 +253,7 @@ textstat_simil.dfm <- function(x, y = NULL, selection = NULL,
                        type = "textstat_simil"))
         }
     } else {
-        if (is.null(y)) {
+        if (isSymmetric(temp)) {
             return(new("textstat_simil_symm_sparse", temp,
                        method = method, margin = margin,
                        type = "textstat_simil",
@@ -355,8 +355,8 @@ textstat_dist.dfm <- function(x, y = NULL, selection = NULL,
     temp <- textstat_proxy(x, y, margin, method,
                            p = p, use_na = TRUE)
 
-    if (is.null(y)) {
-        temp <- as(forceSymmetric(temp), "dsyMatrix")
+    if (isSymmetric(temp)) {
+        temp <- as(temp, "dgeMatrix")
         return(new("textstat_dist_symm", as(temp, "dspMatrix"),
                    method = method, margin = margin,
                    type = "textstat_dist"))
@@ -589,7 +589,7 @@ make_na_matrix <- function(dims, row = NULL, col = NULL) {
     }
     Matrix::sparseMatrix(
         i = i, j = j, x = NA,
-        dims = dims
+        dims = dims, giveCsparse = FALSE
     )
 }
 

--- a/R/textstat_simil.R
+++ b/R/textstat_simil.R
@@ -243,7 +243,7 @@ textstat_simil.dfm <- function(x, y = NULL, selection = NULL,
 
     if (is.null(min_simil)) {
         if (isSymmetric(temp)) {
-            temp <- as(temp, "dgeMatrix")
+            temp <- as(temp, "dsyMatrix")
             return(new("textstat_simil_symm", as(temp, "dspMatrix"),
                        method = method, margin = margin,
                        type = "textstat_simil"))
@@ -356,7 +356,7 @@ textstat_dist.dfm <- function(x, y = NULL, selection = NULL,
                            p = p, use_na = TRUE)
 
     if (isSymmetric(temp)) {
-        temp <- as(temp, "dgeMatrix")
+        temp <- as(temp, "dsyMatrix")
         return(new("textstat_dist_symm", as(temp, "dspMatrix"),
                    method = method, margin = margin,
                    type = "textstat_dist"))

--- a/R/textstat_simil.R
+++ b/R/textstat_simil.R
@@ -242,7 +242,7 @@ textstat_simil.dfm <- function(x, y = NULL, selection = NULL,
                            min_proxy = min_simil, use_na = TRUE)
 
     if (is.null(min_simil)) {
-        if (isSymmetric(temp)) {
+        if (is(temp, "dsTMatrix")) {
             temp <- as(temp, "dsyMatrix")
             return(new("textstat_simil_symm", as(temp, "dspMatrix"),
                        method = method, margin = margin,
@@ -253,7 +253,7 @@ textstat_simil.dfm <- function(x, y = NULL, selection = NULL,
                        type = "textstat_simil"))
         }
     } else {
-        if (isSymmetric(temp)) {
+        if (is(temp, "dsTMatrix")) {
             return(new("textstat_simil_symm_sparse", temp,
                        method = method, margin = margin,
                        type = "textstat_simil",
@@ -355,7 +355,7 @@ textstat_dist.dfm <- function(x, y = NULL, selection = NULL,
     temp <- textstat_proxy(x, y, margin, method,
                            p = p, use_na = TRUE)
 
-    if (isSymmetric(temp)) {
+    if (is(temp, "dsTMatrix")) {
         temp <- as(temp, "dsyMatrix")
         return(new("textstat_dist_symm", as(temp, "dspMatrix"),
                    method = method, margin = margin,
@@ -588,8 +588,7 @@ make_na_matrix <- function(dims, row = NULL, col = NULL) {
         j <- c(j, rep(col, dims[1]))
     }
     Matrix::sparseMatrix(
-        i = i, j = j, x = NA,
+        i = i, j = j, x = as.double(NA),
         dims = dims, giveCsparse = FALSE
     )
 }
-

--- a/tests/testthat/test-textstat_simil.R
+++ b/tests/testthat/test-textstat_simil.R
@@ -521,40 +521,40 @@ test_that("make_na_matrix is working", {
     
     expect_equal(
         as.matrix(quanteda:::make_na_matrix(c(5, 4), row = 2L:3L)),
-        matrix(c(c(FALSE, NA, NA, FALSE, FALSE),
-                 c(FALSE, NA, NA, FALSE, FALSE),
-                 c(FALSE, NA, NA, FALSE, FALSE),
-                 c(FALSE, NA, NA, FALSE, FALSE)), nrow = 5)
+        matrix(c(c(0, NA, NA, 0, 0),
+                 c(0, NA, NA, 0, 0),
+                 c(0, NA, NA, 0, 0),
+                 c(0, NA, NA, 0, 0)), nrow = 5)
     )
     
     expect_equal(
         as.matrix(quanteda:::make_na_matrix(c(5, 4), col = 3L)),
-        matrix(c(c(FALSE, FALSE, FALSE, FALSE, FALSE),
-                 c(FALSE, FALSE, FALSE, FALSE, FALSE),
+        matrix(c(c(0, 0, 0, 0, 0),
+                 c(0, 0, 0, 0, 0),
                  rep(NA, 5),
-                 c(FALSE, FALSE, FALSE, FALSE, FALSE)), nrow = 5)
+                 c(0, 0, 0, 0, 0)), nrow = 5)
     )
     
     expect_equal(
         as.matrix(quanteda:::make_na_matrix(c(5, 4), col = 1L:2L, row = 2L:3L)),
         matrix(c(rep(NA, 5), rep(NA, 5),
-                 c(FALSE, NA, NA, FALSE, FALSE),
-                 c(FALSE, NA, NA, FALSE, FALSE)), nrow = 5)
+                 c(0, NA, NA, 0, 0),
+                 c(0, NA, NA, 0, 0)), nrow = 5)
     )
     
     expect_equal(
         as.matrix(quanteda:::make_na_matrix(c(5, 4), 2L:3L, c(1L:2L))),
         matrix(c(rep(NA, 5), rep(NA, 5),
-               c(FALSE, NA, NA, FALSE, FALSE),
-               c(FALSE, NA, NA, FALSE, FALSE)), nrow = 5)
+               c(0, NA, NA, 0, 0),
+               c(0, NA, NA, 0, 0)), nrow = 5)
     )
     
     expect_equal(
         as.matrix(quanteda:::make_na_matrix(c(5,4), 1L, 3L)),
-        matrix(c(c(NA, FALSE, FALSE, FALSE, FALSE),
-                 c(NA, FALSE, FALSE, FALSE, FALSE),
+        matrix(c(c(NA, 0, 0, 0, 0),
+                 c(NA, 0, 0, 0, 0),
                  rep(NA, 5),
-                 c(NA, FALSE, FALSE, FALSE, FALSE)), nrow = 5)
+                 c(NA, 0, 0, 0, 0)), nrow = 5)
     )
 
 })

--- a/tests/testthat/test-textstat_simil.R
+++ b/tests/testthat/test-textstat_simil.R
@@ -559,3 +559,27 @@ test_that("make_na_matrix is working", {
 
 })
 
+test_that("symmetric class is correctly given", {
+    
+    dist1 <- textstat_dist(mt)
+    expect_identical(
+        Matrix::tril(dist1),
+        t(Matrix::triu(dist1))
+    )
+    dist2 <- textstat_dist(mt, mt)
+    expect_identical(
+        Matrix::tril(dist2),
+        t(Matrix::triu(dist2))
+    )
+    siml1 <- textstat_simil(mt)
+    expect_identical(
+        Matrix::tril(siml1),
+        t(Matrix::triu(siml1))
+    )
+    siml2 <- textstat_simil(mt, mt)
+    expect_identical(
+        Matrix::tril(siml2),
+        t(Matrix::triu(siml2))
+    )
+})
+


### PR DESCRIPTION
There was disagreement between `textstat_simil()` and `proxyC::simil()` in classing symmetric outputs. This bug could cause not only misleading result but also nasty crash.