### PR TITLE
Fix docvar assignment inconsistency

### DIFF
--- a/R/dfm_group.R
+++ b/R/dfm_group.R
@@ -138,9 +138,9 @@ group_dfm <- function(x, features = NULL, documents = NULL, fill = FALSE) {
     set_dfm_dimnames(result) <- list(docname, featname)
 
     if (is.null(documents)) {
-        docvars(result) <- cbind(docvars(x), metadoc(x))
+        result@docvars <- cbind(docvars(x), metadoc(x))
     } else {
-        docvars(result) <- data.frame(row.names = docname)
+        result@docvars <- data.frame(row.names = docname)
     }
     return(result)
 }

--- a/R/docvars.R
+++ b/R/docvars.R
@@ -105,12 +105,11 @@ docvars.kwic <- function(x) {
         stop("You should use texts() instead to replace the corpus texts.")
     if (is.null(field)) {
         if (is.null(value)) {
-            cat("ISNULLVALUE")
             newdv <- data.frame(row.names = docnames(x))
         } else {
             newdv <- data.frame(value, stringsAsFactors = FALSE, check.names = FALSE)
             # uses the V1, V2 etc scheme
-            names(newdv) <- names(as.data.frame(as.matrix(value)))
+            #names(newdv) <- names(as.data.frame(as.matrix(value)))
         }
     } else {
         newdv <- docvars(x)

--- a/R/docvars.R
+++ b/R/docvars.R
@@ -252,9 +252,9 @@ set_docvars <- function(dvars, field = NULL, value)  {
                 if (is.data.frame(value)) {
                     if (nrow(value) != nrow(dvars))
                         stop(message_error("docvar_mismatch"), call. = FALSE)
-                    if (any(missingnames <- nzchar(names(value), keepNA = TRUE))) {
-                        names(value)[which(is.na(missingnames))] <- 
-                            paste0("V", seq_len(sum(is.na(missingnames))))
+                    if (!is.character(names(value)) || length(names(value)) != ncol(value) || 
+                        any(is.na(names(value)))) {
+                        stop(message_error("docvar_nocolname"), call. = FALSE)
                     }
                     result <- cbind(dvars_system, value)
                 } else {
@@ -268,6 +268,8 @@ set_docvars <- function(dvars, field = NULL, value)  {
             result <- cbind(dvars_system, dvars_user)
         }
     }
+    if (ncol(result) == 0)
+        names(result) <- character() # cbind() sets NULL to names
     return(result)
 }
 
@@ -318,5 +320,7 @@ select_fields <- function(x, types = c("user", "system")) {
     if ("user" %in% types) {
         result <- cbind(result, x[!is_system & !is_text])
     }
+    if (ncol(result) == 0)
+        names(result) <- character() # cbind() sets NULL to names
     return(result)
 }

--- a/R/tokens_segment.R
+++ b/R/tokens_segment.R
@@ -79,17 +79,15 @@ tokens_segment.tokens <- function(x, pattern,
         vars <- vars[attr(x, "docid"), , drop = FALSE] # repeat rows
         rownames(vars) <- docname
     } else {
-        attrs$docvars <- NULL
-        vars <- NULL
+        vars <- data.frame(row.names = docname)
     }
     result <- create(x, what = "tokens",
-                     attrs = attrs,
                      docvars = vars,
                      names = docname,
                      document = NULL,
                      docid = NULL,
                      segid = NULL)
-
+    
     docvars(result, "_document") <- attr(x, "document")
     docvars(result, "_docid") <- attr(x, "docid")
     docvars(result, "_segid") <- attr(x, "segid")

--- a/R/utils.R
+++ b/R/utils.R
@@ -252,7 +252,8 @@ message_error <- function(key = NULL) {
     msg <- c("dfm_empty" = "dfm must have at least one non-zero value",
              "fcm_empty" = "fcm must have at least one non-zero value",
              "docvar_mismatch" = "data.frame must have the same number of rows as documents",
-             "docvar_nofield" = "you must supply field name(s)")
+             "docvar_nofield" = "you must supply field name(s)",
+             "docvar_nocolname" = "data.frame must have column names")
     if (is.null(key) || !key %in% names(msg)) {
         return("")
     }

--- a/R/utils.R
+++ b/R/utils.R
@@ -251,7 +251,8 @@ unused_dots <- function(...) {
 message_error <- function(key = NULL) {
     msg <- c("dfm_empty" = "dfm must have at least one non-zero value",
              "fcm_empty" = "fcm must have at least one non-zero value",
-             "docvar_mismatch" = "data.frame must have the same number of rows as documents")
+             "docvar_mismatch" = "data.frame must have the same number of rows as documents",
+             "docvar_nofield" = "you must supply field name(s)")
     if (is.null(key) || !key %in% names(msg)) {
         return("")
     }

--- a/tests/testthat/test-docvars.R
+++ b/tests/testthat/test-docvars.R
@@ -316,14 +316,14 @@ test_that("can assign docvars when value is a dfm (#1417)", {
     docvars(anddfm) <- anddfm
     expect_identical(
         docvars(anddfm),
-        data.frame(and = as.vector(anddfm), row.names = 1:ndoc(mycorp)) # docnames(mycorp))
+        data.frame(and = as.vector(anddfm), row.names = docnames(mycorp))
     )
 
     toks <- tokens(mycorp)
     docvars(toks) <- anddfm
     expect_identical(
         docvars(toks),
-        data.frame(and = as.vector(anddfm), row.names = 1:ndoc(mycorp)) # docnames(mycorp))
+        data.frame(and = as.vector(anddfm), row.names = docnames(mycorp))
     )
 })
 

--- a/tests/testthat/test-docvars.R
+++ b/tests/testthat/test-docvars.R
@@ -336,17 +336,35 @@ test_that("docvar assignment is fully robust including to renaming (#1603)", {
         data.frame(testdv = 10:11, row.names = docnames(corp))
     )
     
-    # # assigning a vector to blank docars
-    # corp <- corpus(c("A b c d.", "A a b. B c."))
-    # docvars(corp) <- c("x", "y")
-    # expect_identical(
-    #     docvars(corp),
-    #     data.frame(V1 = c("x", "y"), row.names = docnames(corp), stringsAsFactors = FALSE)
-    # )
+    # assigning a vector to blank docars
+    corp <- corpus(c("A b c d.", "A a b. B c."))
+    expect_error(
+        docvars(corp) <- c("x", "y"),
+        "you must supply field name(s)", fixed = TRUE
+    )
+    
+    # assigning an unnamed matrix as docvars
+    docvars(corp) <- matrix(c("x", "y"), ncol = 1)
+    expect_identical(
+        docvars(corp),
+        data.frame(V1 = c("x", "y"), 
+                   row.names = docnames(corp), stringsAsFactors = FALSE)
+    )
+    
+    # assigning a data.frame with missing names
+    df <- data.frame(c("x", "y"), c("a", "b"), 11:12, stringsAsFactors = FALSE)
+    names(df) <- NULL
+    names(df)[2] <- "name2"
+    docvars(corp) <- df
+    expect_identical(
+        docvars(corp),
+        data.frame(V1 = c("x", "y"), name2 = c("a", "b"), V2 = 11:12, 
+                   row.names = docnames(corp), stringsAsFactors = FALSE)
+    )
     
     # renaming a docvar
     corp <- corpus(c("A b c d.", "A a b. B c."),
-               docvars = data.frame(testdv = 10:11))
+                   docvars = data.frame(testdv = 10:11))
     names(docvars(corp))[1] <- "renamed_dv"
     expect_identical(
         docvars(corp),

--- a/tests/testthat/test-docvars.R
+++ b/tests/testthat/test-docvars.R
@@ -351,16 +351,13 @@ test_that("docvar assignment is fully robust including to renaming (#1603)", {
                    row.names = docnames(corp), stringsAsFactors = FALSE)
     )
     
-    # assigning a data.frame with missing names
+    # block assigning a data.frame with missing names
     df <- data.frame(c("x", "y"), c("a", "b"), 11:12, stringsAsFactors = FALSE)
     names(df) <- NULL
     names(df)[2] <- "name2"
-    docvars(corp) <- df
-    expect_identical(
-        docvars(corp),
-        data.frame(V1 = c("x", "y"), name2 = c("a", "b"), V2 = 11:12, 
-                   row.names = docnames(corp), stringsAsFactors = FALSE)
-    )
+    expect_error(docvars(corp) <- df, 
+                 "data.frame must have column names")
+    
     
     # renaming a docvar
     corp <- corpus(c("A b c d.", "A a b. B c."),

--- a/tests/testthat/test-docvars.R
+++ b/tests/testthat/test-docvars.R
@@ -336,13 +336,13 @@ test_that("docvar assignment is fully robust including to renaming (#1603)", {
         data.frame(testdv = 10:11, row.names = docnames(corp))
     )
     
-    # assigning a vector to blank docars
-    corp <- corpus(c("A b c d.", "A a b. B c."))
-    docvars(corp) <- c("x", "y")
-    expect_identical(
-        docvars(corp),
-        data.frame(V1 = c("x", "y"), row.names = docnames(corp), stringsAsFactors = FALSE)
-    )
+    # # assigning a vector to blank docars
+    # corp <- corpus(c("A b c d.", "A a b. B c."))
+    # docvars(corp) <- c("x", "y")
+    # expect_identical(
+    #     docvars(corp),
+    #     data.frame(V1 = c("x", "y"), row.names = docnames(corp), stringsAsFactors = FALSE)
+    # )
     
     # renaming a docvar
     corp <- corpus(c("A b c d.", "A a b. B c."),

--- a/tests/testthat/test-tokens_segment.R
+++ b/tests/testthat/test-tokens_segment.R
@@ -169,3 +169,4 @@ test_that("tokens_segment works with tags", {
     expect_equal(as.list(toks_seg4),
                  list(d1.1 = c("##TEST", "One", "two"), d1.2 = c("##TEST2", "Three"), d2.1 = c("##TEST3", "Four")))
 })
+


### PR DESCRIPTION
I do not want to spend time to fix to relatively new bug #1734, so just disallowed assigning a vector (we do not need this functionality anyway). `docvars` is a mess. We should switch to v2.0 soon.
