### PR TITLE
Remove ... from case change functions

### DIFF
--- a/R/casechange-functions.R
+++ b/R/casechange-functions.R
@@ -148,7 +148,7 @@ dfm_tolower <- function(x, keep_acronyms = FALSE) {
 }
 
 #' @export
-dfm_tolower.default <- function(x) {
+dfm_tolower.default <- function(x, keep_acronyms = FALSE) {
     stop(friendly_class_undefined_message(class(x), "dfm_tolower"))
 }
 

--- a/R/casechange-functions.R
+++ b/R/casechange-functions.R
@@ -10,17 +10,17 @@
 #' toks <- tokens(c(txt1 = "b A A", txt2 = "C C a b B"))
 #' tokens_tolower(toks) 
 #' tokens_toupper(toks)
-tokens_tolower <- function(x, keep_acronyms = FALSE, ...) {
+tokens_tolower <- function(x, keep_acronyms = FALSE) {
     UseMethod("tokens_tolower")
 }
 
 #' @export
-tokens_tolower.default <- function(x, keep_acronyms = FALSE, ...) {
+tokens_tolower.default <- function(x, keep_acronyms = FALSE) {
     stop(friendly_class_undefined_message(class(x), "tokens_tolower"))
 }
 
 #' @export
-tokens_tolower.tokens <- function(x, keep_acronyms = FALSE, ...) {
+tokens_tolower.tokens <- function(x, keep_acronyms = FALSE) {
     types(x) <- lowercase_types(types(x), keep_acronyms)
     tokens_recompile(x, gap = FALSE, dup = TRUE)
 }
@@ -38,19 +38,19 @@ lowercase_types <- function(type, keep_acronyms) {
 #' @rdname tokens_tolower
 #' @importFrom stringi stri_trans_toupper
 #' @export
-tokens_toupper <- function(x, ...) {
+tokens_toupper <- function(x) {
     UseMethod("tokens_toupper")
 }
     
 #' @export
-tokens_toupper.default <- function(x, ...) {
+tokens_toupper.default <- function(x) {
     stop(friendly_class_undefined_message(class(x), "tokens_toupper"))
 }
 
 #' @noRd
 #' @export
-tokens_toupper.tokens <- function(x, ...) {
-    types(x) <- char_toupper(types(x), ...)
+tokens_toupper.tokens <- function(x) {
+    types(x) <- char_toupper(types(x))
     tokens_recompile(x, gap = FALSE, dup = TRUE)
 }
 
@@ -67,8 +67,6 @@ tokens_toupper.tokens <- function(x, ...) {
 #'   case-converted
 #' @param keep_acronyms logical; if \code{TRUE}, do not lowercase any 
 #'   all-uppercase words (applies only to \code{*_tolower} functions)
-#' @param ... additional arguments passed to \pkg{stringi} functions, (e.g. 
-#'   \code{\link{stri_trans_tolower}}), such as \code{locale}
 #' @import stringi
 #' @export
 #' @examples
@@ -82,17 +80,17 @@ tokens_toupper.tokens <- function(x, ...) {
 #' char_tolower(txt2)
 #' char_tolower(txt2, keep_acronyms = TRUE)
 #' char_toupper(txt2)
-char_tolower <- function(x, keep_acronyms = FALSE, ...) {
+char_tolower <- function(x, keep_acronyms = FALSE) {
     UseMethod("char_tolower")
 }
 
 #' @export
-char_tolower.default <- function(x, keep_acronyms = FALSE, ...) {
+char_tolower.default <- function(x, keep_acronyms = FALSE) {
     stop(friendly_class_undefined_message(class(x), "char_tolower"))
 }
 
 #' @export
-char_tolower.character <- function(x, keep_acronyms = FALSE, ...) {
+char_tolower.character <- function(x, keep_acronyms = FALSE) {
     name <- names(x)
     if (keep_acronyms) {
         match <- stri_extract_all_regex(x, "\\b(\\p{Uppercase_Letter}(\\p{Uppercase_Letter}|\\d)+)\\b")
@@ -114,19 +112,19 @@ char_tolower.character <- function(x, keep_acronyms = FALSE, ...) {
 
 #' @rdname char_tolower
 #' @export 
-char_toupper <- function(x, ...) {
+char_toupper <- function(x) {
     UseMethod("char_toupper")
 }
 
 #' @export
-char_toupper.default <- function(x, ...) {
+char_toupper.default <- function(x) {
     stop(friendly_class_undefined_message(class(x), "char_toupper"))
 }
 
 #' @export 
-char_toupper.character <- function(x, ...) {
+char_toupper.character <- function(x) {
     name <- names(x)
-    x <- stri_trans_toupper(x, ...)
+    x <- stri_trans_toupper(x)
     names(x) <- name
     return(x)
 }
@@ -145,17 +143,17 @@ char_toupper.character <- function(x, ...) {
 #' dfm_tolower(dfmat) 
 #' dfm_toupper(dfmat)
 #'    
-dfm_tolower <- function(x, keep_acronyms = FALSE, ...) {
+dfm_tolower <- function(x, keep_acronyms = FALSE) {
     UseMethod("dfm_tolower")
 }
 
 #' @export
-dfm_tolower.default <- function(x, ...) {
+dfm_tolower.default <- function(x) {
     stop(friendly_class_undefined_message(class(x), "dfm_tolower"))
 }
 
 #' @export
-dfm_tolower.dfm <- function(x, keep_acronyms = FALSE, ...) {
+dfm_tolower.dfm <- function(x, keep_acronyms = FALSE) {
     x <- as.dfm(x)
     if (!nfeat(x) || !ndoc(x)) return(x)
     set_dfm_featnames(x) <- lowercase_types(featnames(x), keep_acronyms)
@@ -165,20 +163,20 @@ dfm_tolower.dfm <- function(x, keep_acronyms = FALSE, ...) {
 #' @rdname dfm_tolower
 #' @importFrom stringi stri_trans_toupper
 #' @export
-dfm_toupper <- function(x, ...) {
+dfm_toupper <- function(x) {
     UseMethod("dfm_toupper")
 }
 
 #' @export
-dfm_toupper.default <- function(x, ...) {
+dfm_toupper.default <- function(x) {
     stop(friendly_class_undefined_message(class(x), "dfm_toupper"))
 }
 
 #' @export
-dfm_toupper.dfm <- function(x, ...) {
+dfm_toupper.dfm <- function(x) {
     x <- as.dfm(x)
     if (!nfeat(x) || !ndoc(x)) return(x)
-    set_dfm_featnames(x) <- char_toupper(featnames(x), ...)
+    set_dfm_featnames(x) <- char_toupper(featnames(x))
     dfm_compress(x, margin = "features")
 }
 
@@ -195,17 +193,17 @@ dfm_toupper.dfm <- function(x, ...) {
 #' fcmat
 #' fcm_tolower(fcmat) 
 #' fcm_toupper(fcmat)   
-fcm_tolower <- function(x, keep_acronyms = FALSE, ...) {
+fcm_tolower <- function(x, keep_acronyms = FALSE) {
     UseMethod("fcm_tolower")   
 }
 
 #' @export
-fcm_tolower.default <- function(x, keep_acronyms = FALSE, ...) {
+fcm_tolower.default <- function(x, keep_acronyms = FALSE) {
     stop(friendly_class_undefined_message(class(x), "fcm_tolower"))
 }
 
 #' @export
-fcm_tolower.fcm <- function(x, keep_acronyms = FALSE, ...) {
+fcm_tolower.fcm <- function(x, keep_acronyms = FALSE) {
     set_fcm_featnames(x) <- lowercase_types(featnames(x), keep_acronyms)
     fcm_compress(x)
 }
@@ -213,18 +211,17 @@ fcm_tolower.fcm <- function(x, keep_acronyms = FALSE, ...) {
 #' @rdname dfm_tolower
 #' @importFrom stringi stri_trans_toupper
 #' @export
-fcm_toupper <- function(x, ...) {
+fcm_toupper <- function(x) {
     UseMethod("fcm_toupper")   
 }
 
 #' @export
-fcm_toupper.default <- function(x, ...) {
+fcm_toupper.default <- function(x) {
     stop(friendly_class_undefined_message(class(x), "fcm_toupper"))
 }
 
 #' @export
-fcm_toupper.fcm <- function(x, ...) {
-    set_fcm_featnames(x) <- char_toupper(colnames(x), ...)
+fcm_toupper.fcm <- function(x) {
+    set_fcm_featnames(x) <- char_toupper(colnames(x))
     fcm_compress(x)
 }
-

--- a/man/char_tolower.Rd
+++ b/man/char_tolower.Rd
@@ -5,9 +5,9 @@
 \alias{char_toupper}
 \title{Convert the case of character objects}
 \usage{
-char_tolower(x, keep_acronyms = FALSE, ...)
+char_tolower(x, keep_acronyms = FALSE)
 
-char_toupper(x, ...)
+char_toupper(x)
 }
 \arguments{
 \item{x}{the input object whose character/tokens/feature elements will be 
@@ -15,9 +15,6 @@ case-converted}
 
 \item{keep_acronyms}{logical; if \code{TRUE}, do not lowercase any 
 all-uppercase words (applies only to \code{*_tolower} functions)}
-
-\item{...}{additional arguments passed to \pkg{stringi} functions, (e.g. 
-\code{\link{stri_trans_tolower}}), such as \code{locale}}
 }
 \description{
 \code{char_tolower} and \code{char_toupper} are replacements for 

--- a/man/dfm_tolower.Rd
+++ b/man/dfm_tolower.Rd
@@ -7,13 +7,13 @@
 \alias{fcm_toupper}
 \title{Convert the case of the features of a dfm and combine}
 \usage{
-dfm_tolower(x, keep_acronyms = FALSE, ...)
+dfm_tolower(x, keep_acronyms = FALSE)
 
-dfm_toupper(x, ...)
+dfm_toupper(x)
 
-fcm_tolower(x, keep_acronyms = FALSE, ...)
+fcm_tolower(x, keep_acronyms = FALSE)
 
-fcm_toupper(x, ...)
+fcm_toupper(x)
 }
 \arguments{
 \item{x}{the input object whose character/tokens/feature elements will be 
@@ -21,9 +21,6 @@ case-converted}
 
 \item{keep_acronyms}{logical; if \code{TRUE}, do not lowercase any 
 all-uppercase words (applies only to \code{*_tolower} functions)}
-
-\item{...}{additional arguments passed to \pkg{stringi} functions, (e.g. 
-\code{\link{stri_trans_tolower}}), such as \code{locale}}
 }
 \description{
 \code{dfm_tolower} and \code{dfm_toupper} convert the features of the dfm or

--- a/man/tokens_tolower.Rd
+++ b/man/tokens_tolower.Rd
@@ -5,9 +5,9 @@
 \alias{tokens_toupper}
 \title{Convert the case of tokens}
 \usage{
-tokens_tolower(x, keep_acronyms = FALSE, ...)
+tokens_tolower(x, keep_acronyms = FALSE)
 
-tokens_toupper(x, ...)
+tokens_toupper(x)
 }
 \arguments{
 \item{x}{the input object whose character/tokens/feature elements will be 
@@ -15,9 +15,6 @@ case-converted}
 
 \item{keep_acronyms}{logical; if \code{TRUE}, do not lowercase any 
 all-uppercase words (applies only to \code{*_tolower} functions)}
-
-\item{...}{additional arguments passed to \pkg{stringi} functions, (e.g. 
-\code{\link{stri_trans_tolower}}), such as \code{locale}}
 }
 \description{
 \code{tokens_tolower} and \code{tokens_toupper} convert the features of a


### PR DESCRIPTION
Only `locale` was passed through the case change functions, and this was inconsistently applied. Better to remove the unnecessary ellipsis entirely.

Fixes #1710