### PR TITLE
Add omit_empty to convert()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,13 @@
 # quanteda 1.5.1
 
-* Fix a bug that affects the new `textstat_dist()` and `textstat_simil()` (#1730)
-* fix a bug in how `textstat_dist()` and `textstat_simil()` class symmetric matrices.
+## New features
+
+* Added `omit_empty` as an argument to `convert()`, to allow the user to control whether empty documents are excluded from converted dfm objects for certain formats.  (#1660)
+
+## Bug fixes and stability enhancements
+
+* Fixed a bug that affects the new `textstat_dist()` and `textstat_simil()` (#1730)
+* Fixed a bug in how `textstat_dist()` and `textstat_simil()` class symmetric matrices.
 
 # quanteda 1.5.0
 

--- a/man/convert-wrappers.Rd
+++ b/man/convert-wrappers.Rd
@@ -3,18 +3,52 @@
 \name{convert-wrappers}
 \alias{convert-wrappers}
 \alias{as.wfm}
+\alias{as.wfm.dfm}
 \alias{as.DocumentTermMatrix}
+\alias{as.DocumentTermMatrix.dfm}
+\alias{dfm2austin}
+\alias{dfm2tm}
 \alias{dfm2lda}
+\alias{dtm2lda}
+\alias{dfm2dtm}
+\alias{dfm2stm}
 \title{Convenience wrappers for dfm convert}
 \usage{
 as.wfm(x)
 
+\method{as.wfm}{dfm}(x)
+
 as.DocumentTermMatrix(x)
 
-dfm2lda(x)
+\method{as.DocumentTermMatrix}{dfm}(x)
+
+dfm2austin(x)
+
+dfm2tm(x, weighting = tm::weightTf)
+
+dfm2lda(x, omit_empty = TRUE)
+
+dtm2lda(x, omit_empty = TRUE)
+
+dfm2dtm(x, omit_empty = TRUE)
+
+dfm2stm(x, docvars = NULL, omit_empty = TRUE)
 }
 \arguments{
 \item{x}{the dfm to be converted}
+
+\item{weighting}{a \pkg{tm} weight, see \code{\link[tm]{weightTf}}}
+
+\item{omit_empty}{logical; if \code{TRUE}, omit empty documents and features
+from the converted dfm. This is required for some formats (such as STM)
+that do not accept empty documents.  Only used when \code{to = "lda"} or
+\code{to = "topicmodels"}.  For \code{to = "stm"} format, `omit_empty`` is
+always \code{TRUE}.}
+
+\item{docvars}{optional data.frame of document variables used as the
+\code{meta} information in conversion to the \pkg{stm} package format.
+This aids in selecting the document variables only corresponding to the
+documents with non-zero counts.  Only affects the "stm" format.}
 
 \item{...}{additional arguments used only by \code{as.DocumentTermMatrix}}
 }
@@ -47,6 +81,11 @@ are converting.
 of terms in documents used by the \pkg{lda} package (a list with components 
 "documents" and "vocab" as needed by 
   \code{\link[lda]{lda.collapsed.gibbs.sampler}}).
+
+\code{dfm2ldaformat} provides converts a \link{dfm} into the list
+representation of terms in documents used by the \pkg{lda} package (a list
+with components "documents" and "vocab" as needed by
+\code{\link[lda]{lda.collapsed.gibbs.sampler}}).
 }
 \note{
 Additional coercion methods to base R objects are also available: 
@@ -73,5 +112,9 @@ identical(as.DocumentTermMatrix(dfmat), convert(dfmat, to = "tm"))
 identical(quanteda:::dfm2lda(dfmat), convert(dfmat, to = "lda")) 
 }
 
+\dontrun{
+# shortcut conversion to lda package list format
+identical(dfm2ldaformat(dfmat), convert(dfmat, to = "lda")) 
+}
 }
 \keyword{internal}

--- a/man/convert.Rd
+++ b/man/convert.Rd
@@ -5,7 +5,8 @@
 \title{Convert a dfm to a non-quanteda format}
 \usage{
 convert(x, to = c("lda", "tm", "stm", "austin", "topicmodels", "lsa",
-  "matrix", "data.frame", "tripletlist"), docvars = NULL)
+  "matrix", "data.frame", "tripletlist"), docvars = NULL,
+  omit_empty = TRUE)
 }
 \arguments{
 \item{x}{a \link{dfm} to be converted}
@@ -29,7 +30,13 @@ used by the \pkg{lsa} package}
 \item{docvars}{optional data.frame of document variables used as the
 \code{meta} information in conversion to the \pkg{stm} package format.
 This aids in selecting the document variables only corresponding to the
-documents with non-zero counts.}
+documents with non-zero counts.  Only affects the "stm" format.}
+
+\item{omit_empty}{logical; if \code{TRUE}, omit empty documents and features
+from the converted dfm. This is required for some formats (such as STM)
+that do not accept empty documents.  Only used when \code{to = "lda"} or
+\code{to = "topicmodels"}.  For \code{to = "stm"} format, `omit_empty`` is
+always \code{TRUE}.}
 }
 \value{
 A converted object determined by the value of \code{to} (see above). 

--- a/tests/testthat/test-convert.R
+++ b/tests/testthat/test-convert.R
@@ -263,3 +263,32 @@ test_that("triplet converter works", {
 
 })
 
+test_that("omit_empty works as expected (#1600", {
+    dfmat <- as.dfm(matrix(c(1, 0, 2, 0, 
+                             0, 0, 1, 2, 
+                             0, 0, 0, 0, 
+                             1, 2, 3, 4), byrow = TRUE, nrow = 4))
+    expect_equal(
+        dim(convert(dfmat, to = "topicmodels", omit_empty = TRUE)),
+        c(3, 4)
+    )
+    expect_equal(
+        dim(convert(dfmat, to = "topicmodels", omit_empty = FALSE)),
+        c(4, 4)
+    )
+    
+    expect_equal(length(convert(dfmat, to = "lda", omit_empty = TRUE)$documents), 3)
+    expect_equal(length(convert(dfmat, to = "lda", omit_empty = FALSE)$documents), 4)
+
+    expect_error(
+        quanteda:::dfm2stm(dfmat, omit_empty = FALSE),
+        "omit_empty = FALSE not implemented for STM format"
+    )
+
+    expect_warning(convert(dfmat, to = "stm", omit_empty = TRUE), "omit_empty not used")
+    expect_warning(convert(dfmat, to = "tm", omit_empty = TRUE), "omit_empty not used")
+    expect_warning(convert(dfmat, to = "austin", omit_empty = TRUE), "omit_empty not used")
+    expect_warning(convert(dfmat, to = "lsa", omit_empty = TRUE), "omit_empty not used")
+    expect_warning(convert(dfmat, to = "data.frame", omit_empty = TRUE), "omit_empty not used")
+    expect_warning(convert(dfmat, to = "tripletlist", omit_empty = TRUE), "omit_empty not used")
+})


### PR DESCRIPTION
Adds `omit_empty = TRUE` to `convert()`, but this is only active for the "topicmodels" and "lda" formats. It is forced to be TRUE for "stm", and is inactive (equivalent to "FALSE") for everything else.

It might make more sense to make the default 
```
omit_empty = ifelse(!to %in% c("stm", "topicmodels", "lda"), FALSE, TRUE) 
```

Fixes #1660.