### PR TITLE
Add Yule's I to textstat_lexdiv()

### DIFF
--- a/R/textstat_lexdiv.R
+++ b/R/textstat_lexdiv.R
@@ -34,6 +34,9 @@
 #'   \item{\code{"K"}:}{Yule's \emph{K}  (Yule, 1944, as presented in Tweedie &
 #'   Baayen, 1998, Eq. 16) is calculated by: \deqn{K = 10^4 \times
 #'   \left[ -\frac{1}{N} + \sum_{i=1}^{V} f_v(i, N) \left( \frac{i}{N} \right)^2 \right] }}
+#'
+#'   \item{\code{"I"}:}{Yule's \emph{I}  (Yule, 1944) is calculated by: \deqn{I = \frac{V^2}{M_2 - V}}
+#'   \deqn{M_2 = \sum_{i=1}^{V} i^2 * f_v(i, N)}
 #'   
 #'   \item{\code{"D"}:}{Simpson's \emph{D}  (Simpson 1949, as presented in
 #'   Tweedie & Baayen, 1998, Eq. 17) is calculated by:
@@ -142,7 +145,7 @@
 #' toks <- tokens(corpus_subset(data_corpus_inaugural, Year > 2000))
 #' textstat_lexdiv(toks, c("CTTR", "TTR", "MATTR"), MATTR_window = 100)
 textstat_lexdiv <- function(x,
-                            measure = c("TTR", "C", "R", "CTTR", "U", "S", "K", "D",
+                            measure = c("TTR", "C", "R", "CTTR", "U", "S", "K", "I","D",
                                         "Vm", "Maas", "MATTR", "MSTTR", "all"),
                             remove_numbers = TRUE, remove_punct = TRUE,
                             remove_symbols = TRUE, remove_hyphens = FALSE,
@@ -160,7 +163,7 @@ textstat_lexdiv.default <- function(x, ...) {
 
 #' @export
 textstat_lexdiv.dfm <- function(x,
-                                measure = c("TTR", "C", "R", "CTTR", "U", "S", "K", "D",
+                                measure = c("TTR", "C", "R", "CTTR", "U", "S", "K", "I", "D",
                                             "Vm", "Maas", "all"),
                                 remove_numbers = TRUE, remove_punct = TRUE,
                                 remove_symbols = TRUE, remove_hyphens = FALSE,
@@ -204,7 +207,7 @@ textstat_lexdiv.dfm <- function(x,
 #' @export
 textstat_lexdiv.tokens <-
     function(x,
-             measure = c("TTR", "C", "R", "CTTR", "U", "S", "K", "D",
+             measure = c("TTR", "C", "R", "CTTR", "U", "S", "K", "I", "D",
                          "Vm", "Maas", "MATTR", "MSTTR", "all"),
              remove_numbers = TRUE, remove_punct = TRUE,
              remove_symbols = TRUE, remove_hyphens = FALSE,
@@ -279,7 +282,7 @@ NULL
 compute_lexdiv_dfm_stats <- function(x, measure = NULL, log.base = 10) {
 
     n_tokens <- n_types <- TTR <- C <- R <- CTTR <- U <- S <- Maas <-
-        lgV0 <- lgeV0 <- K <- D <- Vm <- NULL
+        lgV0 <- lgeV0 <- K <- D <- Vm <- I <- NULL
     temp <- data.table(n_tokens = ntoken(x), n_types = ntype(x))
 
     if ("TTR" %in% measure)
@@ -302,9 +305,9 @@ compute_lexdiv_dfm_stats <- function(x, measure = NULL, log.base = 10) {
         temp[, S := log(log(n_types, base = log.base), base = log.base) /
                     log(log(n_tokens, base = log.base), base = log.base)]
 
-    # computations for K, D, Vm
+    # computations for K, D, Vm, I
     # produces a list of data.frames that will be used for computing the measures
-    if (length(intersect(c("K", "D", "Vm"), measure))) {
+    if (length(intersect(c("K", "D", "Vm", "I"), measure))) {
         ViN <- lapply(docnames(x), function(y) {
             result <- as.data.frame(table(colSums(x[y, ])), stringsAsFactors = FALSE)
             names(result) <- c("i", "ViN")
@@ -317,7 +320,14 @@ compute_lexdiv_dfm_stats <- function(x, measure = NULL, log.base = 10) {
 
     if ("K" %in% measure)
         temp[, K := 10 ^ 4 * vapply(ViN, function(y) sum(y$ViN * (y$i / y$n_tokens) ^ 2), numeric(1))]
-
+    if ("I" %in% measure) {
+        M_2 <- vapply(ViN, function(y) sum(y$ViN * y$i^2), numeric(1))
+        M_1 <- temp$n_types
+        yule_i <- (M_1 ^ 2) / (M_2 - M_1)
+        yule_i[yule_i== Inf] <- 0
+        temp[, I := yule_i]
+    }
+    
     if ("D" %in% measure)
         temp[, D := vapply(ViN,
                            function(y) sum(y$ViN * (y$i / y$n_tokens) * ( (y$i - 1) / (y$n_tokens - 1)) ),

--- a/man/textstat_lexdiv.Rd
+++ b/man/textstat_lexdiv.Rd
@@ -5,9 +5,10 @@
 \title{Calculate lexical diversity}
 \usage{
 textstat_lexdiv(x, measure = c("TTR", "C", "R", "CTTR", "U", "S", "K",
-  "D", "Vm", "Maas", "MATTR", "MSTTR", "all"), remove_numbers = TRUE,
-  remove_punct = TRUE, remove_symbols = TRUE, remove_hyphens = FALSE,
-  log.base = 10, MATTR_window = 100L, MSTTR_segment = 100L, ...)
+  "I", "D", "Vm", "Maas", "MATTR", "MSTTR", "all"),
+  remove_numbers = TRUE, remove_punct = TRUE, remove_symbols = TRUE,
+  remove_hyphens = FALSE, log.base = 10, MATTR_window = 100L,
+  MSTTR_segment = 100L, ...)
 }
 \arguments{
 \item{x}{an \link{dfm} or \link{tokens} input object for whose documents
@@ -49,70 +50,6 @@ Calculate the lexical diversity of text(s).
 \details{
 \code{textstat_lexdiv} calculates the lexical diversity of documents
   using a variety of indices.
-
-In the following formulas, \eqn{N} refers to the total number of
-  tokens, \eqn{V} to the number of types, and \eqn{f_v(i, N)} to the numbers
-  of types occurring \eqn{i} times in a sample of length \eqn{N}.
-  \describe{
-     
-  \item{\code{"TTR"}:}{The ordinary \emph{Type-Token Ratio}: \deqn{TTR =
-  \frac{V}{N}}{TTR =  V / N}}
-  
-  \item{\code{"C"}:}{Herdan's \emph{C} (Herdan, 1960, as cited in Tweedie & 
-  Baayen, 1998; sometimes referred to as \emph{LogTTR}): \deqn{C = 
-  \frac{\log{V}}{\log{N}}}{C = log(V) / log(N)}}
-  
-  \item{\code{"R"}:}{Guiraud's \emph{Root TTR} (Guiraud, 1954, as cited in 
-  Tweedie & Baayen, 1998): \deqn{R = \frac{V}{\sqrt{N}}}{R = V / sqrt(N)}}
-  
-  \item{\code{"CTTR"}:}{Carroll's \emph{Corrected TTR}: \deqn{CTTR = 
-  \frac{V}{\sqrt{2N}}}{CTTR = V / sqrt(2N)}}
-  
-  \item{\code{"U"}:}{Dugast's \emph{Uber Index}  (Dugast, 1978, as cited in 
-  Tweedie & Baayen, 1998): \deqn{U = \frac{(\log{N})^2}{\log{N} - \log{V}}}{U
-  = log(N)^2 / log(N) - log(V)}}
-  
-  \item{\code{"S"}:}{Summer's index: \deqn{S = 
-  \frac{\log{\log{V}}}{\log{\log{N}}}}{S = log(log(V)) / log(log(N))}}
-  
-  \item{\code{"K"}:}{Yule's \emph{K}  (Yule, 1944, as presented in Tweedie &
-  Baayen, 1998, Eq. 16) is calculated by: \deqn{K = 10^4 \times
-  \left[ -\frac{1}{N} + \sum_{i=1}^{V} f_v(i, N) \left( \frac{i}{N} \right)^2 \right] }}
-  
-  \item{\code{"D"}:}{Simpson's \emph{D}  (Simpson 1949, as presented in
-  Tweedie & Baayen, 1998, Eq. 17) is calculated by:
-  \deqn{D = \sum_{i=1}^{V} f_v(i, N) \frac{i}{N} \frac{i-1}{N-1}}}
-
-  \item{\code{"Vm"}:}{Herdan's \eqn{V_m}  (Herdan 1955, as presented in
-  Tweedie & Baayen, 1998, Eq. 18) is calculated by:
-  \deqn{V_m = \sqrt{ \sum_{i=1}^{V} f_v(i, N) (i/N)^2 - \frac{i}{V} }}}
-
-  \item{\code{"Maas"}:}{Maas' indices (\eqn{a}, \eqn{\log{V_0}} & 
-  \eqn{\log{}_{e}{V_0}}): \deqn{a^2 = \frac{\log{N} -
-  \log{V}}{\log{N}^2}}{a^2 = log(N) - log(V) / log(N)^2} \deqn{\log{V_0} =
-  \frac{\log{V}}{\sqrt{1 - \frac{\log{V}}{\log{N}}^2}}}{log(V0) = log(V) /
-  sqrt(1 - (log(V) / log(N)^2))} The measure was derived from a formula by
-  Mueller (1969, as cited in Maas, 1972). \eqn{\log{}_{e}{V_0}} is equivalent
-  to \eqn{\log{V_0}}, only with \eqn{e} as the base for the logarithms. Also
-  calculated are \eqn{a}, \eqn{\log{V_0}} (both not the same as before) and
-  \eqn{V'} as measures of relative vocabulary growth while the text
-  progresses. To calculate these measures, the first half of the text and the
-  full text will be examined (see Maas, 1972, p. 67 ff. for details).  Note:
-  for the current method (for a dfm) there is no computation on separate
-  halves of the text.}
-  
-  \item{\code{"MATTR"}:}{The Moving-Average Type-Token Ratio (Covington &
-  McFall, 2010) calculates TTRs for a moving window of tokens from the first to the last token, computing a TTR for each window. 
-  The MATTR is the mean of the TTRs of each window.}
-  
-  \item{\code{"MSTTR"}:}{Mean Segmental Type-Token Ratio (sometimes referred
-  to as \emph{Split TTR}) splits the tokens into segments of the given size,
-  TTR for each segment is calculated and the mean of these values returned.
-  When this value is < 1.0, it splits the tokens into equal, non-overlapping
-  sections of that size.  When this value is > 1, it defines the segments as
-  windows of that size. Tokens at the end which do not make a full segment
-  are ignored.}
-  }
 }
 \examples{
 txt <- c("Anyway, like I was sayin', shrimp is the fruit of the sea. You can

--- a/tests/testthat/test-textstat_lexdiv.R
+++ b/tests/testthat/test-textstat_lexdiv.R
@@ -54,6 +54,17 @@ test_that("textstat_lexdiv Maas works correct", {
     )
 })
 
+test_that("textstat_lexdiv I works correct", {
+    mydfm <- dfm(c(d1 = "a b c",
+                   d2 = "a a b b c"))
+    expect_equivalent(
+        textstat_lexdiv(mydfm, "I")$I[1], 0, tolerance = 0.01
+    )
+    expect_equivalent(
+        textstat_lexdiv(mydfm, "I")$I[2], (3^2) / ((1 + 2 * 2^2) - 3), tolerance = 0.01
+    )
+})
+
 test_that("textstat_lexdiv works with a single document dfm (#706)", {
     mytxt <- "one one two one one two one"
     mydfm <- dfm(mytxt)


### PR DESCRIPTION
Yule's I is another textual diversity measure. Although it is similar to Yule'K, it is not the same. It has recently been used in the article by Tolochko & Boomgaarden (2019).

Tolochko, P., & Boomgaarden, H. G. (2019). Determining Political Text Complexity: Conceptualizations, Measurements, and Application. International Journal of Communication, 13, 21.