### PR TITLE
Fix #1755 - add error for empty wordcloud

### DIFF
--- a/R/textplot_wordcloud.R
+++ b/R/textplot_wordcloud.R
@@ -212,6 +212,8 @@ wordcloud <- function(x, min_size, max_size, min_count, max_words,
     
     font <- check_font(font)
     x <- dfm_trim(x, min_termfreq = min_count)
+    # check to see that dfm is not empty
+    if (!sum(x)) stop("No features left after trimming with min_count = ", min_count)
     freq <- Matrix::colSums(x)
     word <- names(freq)
     freq <- unname(freq)

--- a/tests/testthat/test-textplot.R
+++ b/tests/testthat/test-textplot.R
@@ -317,3 +317,11 @@ test_that("phrasal patterns display correctly in textplot_kwic", {
 })
 
 dev.off()
+
+test_that("plotting empty dfms after trimming is caught (#1755)", {
+    dfmat <- dfm(c("Azymuth", "Compass", "GPS", "Zenith"))
+    expect_error(
+        textplot_wordcloud(dfmat, min_count = 2),
+        "No features left after trimming with min_count = 2"
+    )
+})


### PR DESCRIPTION
When no features remain after the default trimming, `textplot_wordcloud()` should halt with an error rather than produce the behaviour shown in #1755.