### PR TITLE
Fix ID shifting of paddings in document without keyword values

### DIFF
--- a/src/tokens_lookup_mt.cpp
+++ b/src/tokens_lookup_mt.cpp
@@ -79,7 +79,11 @@ Text lookup(Text tokens,
             // return shifted tokens in exclusive mode
             Text keys_flat(tokens.size());
             for (std::size_t i = 0; i < tokens.size(); i++) {
-                keys_flat[i] = id_max + tokens[i];
+                if (tokens[i] == 0) {
+                    keys_flat[i] = 0;
+                } else {
+                    keys_flat[i] = id_max + tokens[i];
+                }
             }
             return keys_flat;
         }

--- a/tests/testthat/test-tokens_lookup.R
+++ b/tests/testthat/test-tokens_lookup.R
@@ -145,7 +145,8 @@ test_that("#388 issue about overlapping key values is resolved: regex matches", 
 test_that("non-exclusive lookup is working",{
     
     toks <- tokens(c(d1 = "Mexico signed a new libertarian law with Canada.",
-                     d2 = "Let freedom ring in the United States!"),
+                     d2 = "Let freedom ring in the United States!",
+                     d3 = "Aliens are invading Mars"),
                    remove_punct = TRUE)
     dict <- dictionary(list(country = c("united states", "mexico", "canada"), 
                             "law words" = c('law*', 'constitution'), 
@@ -153,13 +154,15 @@ test_that("non-exclusive lookup is working",{
                             overlap = "United"))
     
     expect_equal(as.list(tokens_lookup(toks, dict, exclusive = FALSE, capkeys = TRUE)),
-                 list(d1=c("COUNTRY", "signed", "a", "new", "FREEDOM", "LAW WORDS", "with", "COUNTRY"),
-                      d2=c("Let", "FREEDOM", "ring", "in", "the", "COUNTRY", "OVERLAP")))
+                 list(d1 = c("COUNTRY", "signed", "a", "new", "FREEDOM", "LAW WORDS", "with", "COUNTRY"),
+                      d2 = c("Let", "FREEDOM", "ring", "in", "the", "COUNTRY", "OVERLAP"),
+                      d3 = c("Aliens", "are", "invading", "Mars")))
     
     toks2 <- tokens_remove(toks, stopwords("en"), padding = TRUE)
     expect_equal(as.list(tokens_lookup(toks2, dict, exclusive = FALSE, capkeys = TRUE)),
-                 list(d1=c("COUNTRY", "signed", "", "new", "FREEDOM", "LAW WORDS", "", "COUNTRY"),
-                      d2=c("Let", "FREEDOM", "ring", "", "", "COUNTRY", "OVERLAP")))
+                 list(d1 = c("COUNTRY", "signed", "", "new", "FREEDOM", "LAW WORDS", "", "COUNTRY"),
+                      d2 = c("Let", "FREEDOM", "ring", "", "", "COUNTRY", "OVERLAP"),
+                      d3 = c("Aliens", "", "invading", "Mars")))
     
 })
 


### PR DESCRIPTION
Further  fix for #1743. Let's marge this before #1772 so that I can marge this to v2.