### PR TITLE
Fix total document report n

### DIFF
--- a/R/corpus-methods-base.R
+++ b/R/corpus-methods-base.R
@@ -62,12 +62,13 @@ is.corpus <- function(x) {
 #' sumcorp$Types / sumcorp$Tokens # crude type-token ratio
 summary.corpus <- function(object, n = 100, tolower = FALSE, showmeta = TRUE, ...) {
     object <- as.corpus(object)
+    ndoc_all <- ndoc(object)
     object <- head(object, n)
     result <- summarize_texts(texts(object), tolower = tolower, ...)
     if (showmeta)
         result <- cbind(result, docvars(object))
     attr(result, "ndoc_show") <- n
-    attr(result, "ndoc_all") <- ndoc(object)
+    attr(result, "ndoc_all") <- ndoc_all
     class(result) <- c("summary.corpus", "data.frame")
     return(result)
 }


### PR DESCRIPTION
Former `summary.corpus()` behaviour restored, now gets the total n before the `head()` truncates the document vector.

Fixes #1785