### PR TITLE
Fix alpha

### DIFF
--- a/R/textplot_scale1d.R
+++ b/R/textplot_scale1d.R
@@ -259,7 +259,7 @@ textplot_scale1d_features <- function(x, weight, featlabels,
                           psi = weight,
                           beta = x)
     p <- ggplot(data = results, aes(x = beta, y = psi, label = feature)) + 
-        geom_text(colour = "grey70") +
+        geom_text(colour = "grey70", alpha = alpha) +
         geom_text(aes(beta, psi, label = feature), 
                   data = results[results$feature %in% highlighted,],
                   color = highlighted_color) +


### PR DESCRIPTION
`alpha` argument was not working.

## Master

```r
textplot_scale1d(tmod2, margin = "features", alpha = 0.1,
                 highlighted = c("government", "global", "children",
                                 "bank", "economy", "the", "citizenship",
                                 "productivity", "deficit"))
```
![alpha01](https://user-images.githubusercontent.com/6572963/71423794-033fa100-268c-11ea-8379-7ff234a63bed.png)
```r
textplot_scale1d(tmod2, margin = "features", alpha = 0.9,
                 highlighted = c("government", "global", "children",
                                 "bank", "economy", "the", "citizenship",
                                 "productivity", "deficit"))
```
![alpha09](https://user-images.githubusercontent.com/6572963/71423801-0dfa3600-268c-11ea-8f1d-fd7348762364.png)

## This branch

```r
textplot_scale1d(tmod2, margin = "features", alpha = 0.1,
                 highlighted = c("government", "global", "children",
                                 "bank", "economy", "the", "citizenship",
                                 "productivity", "deficit"))
```
![alpha01fixed](https://user-images.githubusercontent.com/6572963/71423795-033fa100-268c-11ea-847c-7edf34449bb5.png)


```r
textplot_scale1d(tmod2, margin = "features", alpha = 0.9,
                 highlighted = c("government", "global", "children",
                                 "bank", "economy", "the", "citizenship",
                                 "productivity", "deficit"))
```
![alpha09fixed](https://user-images.githubusercontent.com/6572963/71423841-6af5ec00-268c-11ea-801c-6cc29107b928.png)
