### PR TITLE
Fix as.corpus() handling of user metadata for pre-v2 corpora

### DIFF
--- a/R/corpus-methods-quanteda.R
+++ b/R/corpus-methods-quanteda.R
@@ -145,7 +145,9 @@ as.corpus.corpuszip <- function(x) {
 # stracture
 upgrade_corpus <- function(x) {
     if (!is_pre2(x)) return(x)
+    metadata <- meta(x)
     x <- unclass(x)
+    
     result <- corpus(x$documents, text_field = "texts")
     attr(result, "docvars") <- upgrade_docvars(x$documents)
     
@@ -154,11 +156,18 @@ upgrade_corpus <- function(x) {
     } else {
         attr(result, "unit") <- "documents"
     }
-    if ("created" %in% names(x$metadata)) {
-        meta_system(result, "created") <- as.POSIXct(x$metadata$created, 
+    
+    if ("created" %in% names(metadata)) {
+        meta_system(result, "created") <- as.POSIXct(metadata$created, 
                                                      format = "%a %b %d %H:%M:%S %Y")
+        metadata$created <- NULL
     } else {
-        meta_system(result, "created") <- as.POSIXlt(Sys.time())
+        meta_system(result, "created") <- Sys.time()
     }
+    
+    # remove any null metadata fields
+    metadata <- metadata[sapply(metadata, function(y) !is.null(y))]
+    meta(result) <- metadata
+    
     return(result)
 }

--- a/R/meta.R
+++ b/R/meta.R
@@ -160,7 +160,7 @@ meta_system <- function(x, field = NULL)
     if (is.null(field) && !missing(value)) {
         attr(x, "meta")$system <- value
     } else {
-        attr(x, "meta")$system[field] <- value
+        attr(x, "meta")$system[[field]] <- value
     }
     return(x)
 }
@@ -170,7 +170,7 @@ meta_system <- function(x, field = NULL)
     if (is.null(field) && !missing(value)) {
         attr(x, "meta")$system <- value
     } else {
-        attr(x, "meta")$system[field] <- value
+        attr(x, "meta")$system[[field]] <- value
     }
     return(x)
 }

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -10,4 +10,3 @@ quanteda_options(reset = TRUE)
 
 test_check("quanteda")
 quanteda_options(ops)
-

--- a/tests/testthat/test-corpus.R
+++ b/tests/testthat/test-corpus.R
@@ -446,6 +446,7 @@ test_that("metacorpus argument works", {
 
 test_that("metadoc works but raise deprecation warning", {
     corp <- corpus(c("aa bb cc", "ccc dd"))
+    expect_warning(metadoc(corp), "metadoc is deprecated")
     expect_equal(colnames(metadoc(corp)), character())
     metadoc(corp, "var1") <- c(1, 5)
     metadoc(corp, "var2") <- c("T", "F")
@@ -487,3 +488,28 @@ test_that("[.corpus out of bounds generates expected error", {
     expect_error(corp1[2], "Subscript out of bounds")
 })
 
+test_that("as.corpus correctly sets metadata on pre-v2 corpus", {
+    load("../data/pre_v2_objects/data_corpus_pre2.rda")
+    expect_identical(
+        meta(as.corpus(data_corpus_pre2), type = "user"),
+        list(source = "Gerhard Peters and John T. Woolley. The American Presidency Project.",
+             notes = "http://www.presidency.ucsb.edu/inaugurals.php")
+    )
+    expect_true(
+        all(c("source", "package-version", "r-version", "system", "directory", "created") %in% 
+                names(meta(as.corpus(data_corpus_pre2), type = "system")))
+    )
+    expect_is(meta(as.corpus(data_corpus_pre2), "created", type = "system"),
+              "POSIXct"
+    )
+    
+    # test when there is no created date
+    data_corpus_pre2 <- unclass(data_corpus_pre2)
+    data_corpus_pre2$metadata$created <- NULL
+    class(data_corpus_pre2) <- c("corpus", class(data_corpus_pre2))
+    meta(as.corpus(data_corpus_pre2), "created", type = "system")
+    expect_identical(
+        substring(as.character(meta(as.corpus(data_corpus_pre2), "created", type = "system")), 1, 10),
+        substring(as.character(Sys.Date()), 1, 10)
+    )
+})

--- a/tests/testthat/test-textstat_simil.R
+++ b/tests/testthat/test-textstat_simil.R
@@ -504,7 +504,7 @@ test_that("diag2na is working", {
                  matrix(c(1, 2, NA, 4, NA, 6), nrow = 3, 
                         dimnames = list(c("a", "b", "c"), c("c", "b"))))
     
-    mat4 <- forceSymmetric(mat1)
+    mat4 <- Matrix::forceSymmetric(mat1)
     expect_equal(as.matrix(quanteda:::diag2na(as(mat4, "dsTMatrix"))),
                  matrix(c(NA, 4, 7, 4, NA, 8, 7, 8, NA), nrow = 3, 
                         dimnames = list(c("b", "c", "d"), c("b", "c", "d"))))


### PR DESCRIPTION
Formerly, the user metadata was not copied for pre-v2 corpora. In addition, the corpus creation date (field `created`) was not correctly set (as a date object).

Fixes #1799