### PR TITLE
Fix 1820

### DIFF
--- a/R/textstat_simil.R
+++ b/R/textstat_simil.R
@@ -236,6 +236,7 @@ textstat_simil.dfm <- function(x, y = NULL, selection = NULL,
             }
         }
     } else {
+        if (!is.dfm(y)) stop("y must be a dfm matching x in the margin specified")
         y <- as.dfm(y)
     }
     temp <- textstat_proxy(x, y, margin, method,
@@ -350,6 +351,7 @@ textstat_dist.dfm <- function(x, y = NULL, selection = NULL,
             }
         }
     } else {
+        if (!is.dfm(y)) stop("y must be a dfm matching x in the margin specified")
         y <- as.dfm(y)
     }
     temp <- textstat_proxy(x, y, margin, method,

--- a/tests/testthat/test-textstat_dist.R
+++ b/tests/testthat/test-textstat_dist.R
@@ -12,7 +12,10 @@ test_that("test old and new textstat_dist are the same", {
                       textstat_dist_old(mt, margin = "features"),
                       tolerance = 0.01)
     
-    expect_equivalent(textstat_dist(mt, selection = "1985-Reagan") %>% as.matrix(), 
+    suppressWarnings(expect_equivalent(textstat_dist(mt, selection = "1985-Reagan") %>% as.matrix(), 
+                      textstat_dist_old(mt, selection = "1985-Reagan") %>% as.matrix(),
+                      tolerance = 0.01))
+    expect_equivalent(textstat_dist(mt, y = mt["1985-Reagan", ]) %>% as.matrix(), 
                       textstat_dist_old(mt, selection = "1985-Reagan") %>% as.matrix(),
                       tolerance = 0.01)
     
@@ -58,24 +61,33 @@ test_that("dist object has all the attributes", {
     expect_equal(class(attr(d1, "Upper")), "logical")
 })
 
+test_that("y errors if not a dfm", {
+    expect_error(
+        textstat_dist(mt, y = c("mr", "president"), margin = "features"),
+        "y must be a dfm matching x in the margin specified"
+    )
+})
+
 test_that("selection takes integer or logical vector", {
+    suppressWarnings({
     expect_equivalent(textstat_dist(mt, selection = c(2, 5), margin = "features"),
                       textstat_dist(mt, selection = c("mr", "president"), margin = "features"))
     l3 <- featnames(mt) %in% c("mr", "president")
     expect_equivalent(textstat_dist(mt, selection = l3, margin = "features"),
                       textstat_dist(mt, selection = c("mr", "president"), margin = "features"))
+    })
     
-    expect_error(textstat_dist(mt, selection = "xxxx", margin = "features"))
-    expect_error(textstat_dist(mt, selection = 1000, margin = "features"))
+    expect_error(textstat_dist(mt, y = "xxxx", margin = "features"))
+    expect_error(textstat_dist(mt, y = 1000, margin = "features"))
     
-    expect_equivalent(textstat_dist(mt, selection = c(2,4), margin = "documents"),
-                      textstat_dist(mt, selection = c("1985-Reagan", "1993-Clinton"), margin = "documents"))
+    expect_equivalent(textstat_dist(mt, y = mt[c(2, 4), ], margin = "documents"),
+                      textstat_dist(mt, y = mt[c("1985-Reagan", "1993-Clinton"), ], margin = "documents"))
     l4 <- docnames(mt) %in% c("1985-Reagan", "1993-Clinton")
-    expect_equivalent(textstat_dist(mt, selection = l4, margin = "documents"),
-                      textstat_dist(mt, selection = c("1985-Reagan", "1993-Clinton"), margin = "documents"))
+    expect_equivalent(textstat_dist(mt, y = mt[l4, ], margin = "documents"),
+                      textstat_dist(mt, y = mt[c("1985-Reagan", "1993-Clinton"), ], margin = "documents"))
     
-    expect_error(textstat_dist(mt, selection = "nothing", margin = "documents"))
-    expect_error(textstat_dist(mt, selection = 100, margin = "documents"))
+    expect_error(textstat_dist(mt, y = "nothing", margin = "documents"))
+    expect_error(textstat_dist(mt, y = 100, margin = "documents"))
 })
 
 test_that("textstat_dist() returns NA for empty dfm", {
@@ -148,7 +160,8 @@ test_that("textstat_dist() returns NA for zero-variance documents", {
 
 test_that("selection is always on columns (#1549)", {
     mt <- dfm(corpus_subset(data_corpus_inaugural, Year > 1980))
-    expect_equal(
+    suppressWarnings({
+        expect_equal(
         colnames(textstat_dist(mt, margin = "documents", 
                                selection = c("1985-Reagan", "1989-Bush")) %>% as.matrix()), 
         c("1985-Reagan", "1989-Bush")
@@ -165,6 +178,7 @@ test_that("selection is always on columns (#1549)", {
         colnames(textstat_dist(mt, margin = "features", selection = c(4, 6)) %>% as.matrix()), 
         c("mr", "chief")
     )
+    })
 })
 
 test_that("all distances are bounded at 0", {

--- a/tests/testthat/test-textstat_simil.R
+++ b/tests/testthat/test-textstat_simil.R
@@ -12,7 +12,7 @@ test_that("test old and new textstat_simil are the same", {
                       as.matrix(textstat_simil_old(mt, margin = "features")),
                       tolerance = 0.01)
 
-    expect_equivalent(as.matrix(textstat_simil(mt, selection = "1985-Reagan")), 
+    expect_equivalent(as.matrix(textstat_simil(mt, y = mt["1985-Reagan", ])), 
                       as.matrix(textstat_simil_old(mt, selection = "1985-Reagan")),
                       tolerance = 0.01)
     
@@ -44,24 +44,34 @@ test_that("test old and new textstat_simil are the same", {
     
 })
 
+test_that("y errors if not a dfm", {
+    expect_error(
+        textstat_simil(mt, y = c("mr", "president"), margin = "features"),
+        "y must be a dfm matching x in the margin specified"
+    )
+})
+
 test_that("selection takes integer or logical vector", {
-    expect_equivalent(textstat_simil(mt, selection = c(2, 5), margin = "features"),
-                      textstat_simil(mt, selection = c("mr", "president"), margin = "features"))
+    expect_equivalent(textstat_simil(mt, y = mt[, c(2, 5)], margin = "features"),
+                      textstat_simil(mt, y = mt[, c("mr", "president")], margin = "features"))
+    suppressWarnings(expect_equivalent(textstat_simil(mt, y = mt[, c(2, 5)], margin = "features"),
+                      textstat_simil(mt, y = mt[, c("mr", "president")], margin = "features")))
+
     l1 <- featnames(mt) %in% c("mr", "president")
-    expect_equivalent(textstat_simil(mt, selection = l1, margin = "features"),
-                      textstat_simil(mt, selection = c("mr", "president"), margin = "features"))
+    expect_equivalent(textstat_simil(mt, y = mt[, l1], margin = "features"),
+                      textstat_simil(mt, y = mt[, c("mr", "president")], margin = "features"))
     
     expect_error(textstat_simil(mt, "xxxx", margin = "features"))
     expect_error(textstat_simil(mt, 1000, margin = "features"))
     
-    expect_equivalent(textstat_simil(mt, selection = c(2,4), margin = "documents"),
-                      textstat_simil(mt, selection = c("1985-Reagan", "1993-Clinton"), margin = "documents"))
+    expect_equivalent(textstat_simil(mt, y = mt[c(2,4), ], margin = "documents"),
+                      textstat_simil(mt, y = mt[c("1985-Reagan", "1993-Clinton"), ], margin = "documents"))
     l2 <- docnames(mt) %in% c("1985-Reagan", "1993-Clinton")
-    expect_equivalent(textstat_simil(mt, selection = l2, margin = "documents"),
-                      textstat_simil(mt, selection = c("1985-Reagan", "1993-Clinton"), margin = "documents"))
+    expect_equivalent(textstat_simil(mt, y = mt[l2, ], margin = "documents"),
+                      textstat_simil(mt, y = mt[c("1985-Reagan", "1993-Clinton"), ], margin = "documents"))
     
-    expect_error(textstat_simil(mt, selection = "nothing", margin = "documents"))
-    expect_error(textstat_simil(mt, 100, margin = "documents"))
+    expect_error(textstat_simil(mt, y = "nothing", margin = "documents"))
+    expect_error(textstat_simil(mt, y = 100, margin = "documents"))
 })
 
 test_that("textstat_simil() returns NA for empty dfm", {
@@ -158,30 +168,30 @@ test_that("textstat_simil() returns NA for zero-variance documents", {
 
 test_that("selection is always on columns (#1549)", {
     mt <- dfm(corpus_subset(data_corpus_inaugural, Year > 1980))
-    expect_equal(
+    suppressWarnings(expect_equal(
         textstat_simil(mt, margin = "documents", selection = c("1985-Reagan", "1989-Bush")) %>% 
             as.matrix() %>% 
             colnames(), 
         c("1985-Reagan", "1989-Bush")
-    )
-    expect_equal(
+    ))
+    suppressWarnings(expect_equal(
         textstat_simil(mt, margin = "documents", selection = c(2, 3)) %>% 
             as.matrix() %>% 
             colnames(), 
         c("1985-Reagan", "1989-Bush")
-    )
-    expect_equal(
+    ))
+    suppressWarnings(expect_equal(
         textstat_simil(mt, margin = "features", selection = c("justice", "and"))%>% 
             as.matrix() %>% 
             colnames(), 
         c("justice", "and")
-    )
-    expect_equal(
+    ))
+    suppressWarnings(expect_equal(
         textstat_simil(mt, margin = "features", selection = c(4, 6))%>% 
             as.matrix() %>% 
             colnames(), 
         c("mr", "chief")
-    )
+    ))
 })
 
 test_that("all similarities are between 0 and 1", {
@@ -196,12 +206,12 @@ test_that("all similarities are between 0 and 1", {
 })
 
 test_that("textstat_simil is stable across repetitions", {
-    res <- textstat_simil(mt, selection = c(2, 4), 
+    res <- textstat_simil(mt, y = mt[c(2, 4), ], 
                           margin = "documents")
     set.seed(10)
     resv <- list()
     for (i in 1:100) {
-        resv[[i]] <- as.matrix(textstat_simil(mt, selection = 2, 
+        resv[[i]] <- as.matrix(textstat_simil(mt, y = mt[2, ], 
                                               margin = "documents"))
     }
     rescols <- do.call(cbind, resv)
@@ -309,7 +319,7 @@ test_that("as.list.texstat_simil() is robust", {
 })
 
 test_that("as.list.textstat_simil works with features margin", {
-    tstat <- textstat_simil(mt, selection = c("world", "freedom"),
+    tstat <- textstat_simil(mt, y = mt[, c("world", "freedom")],
                             method = "cosine", margin = "features")
     lis <- as.list(tstat, n = 5, diag = FALSE)
     expect_equal(
@@ -319,7 +329,7 @@ test_that("as.list.textstat_simil works with features margin", {
     )
     expect_identical(names(lis), c("world", "freedom"))
 
-    tstat <- textstat_simil(mt, selection = "freedom",
+    tstat <- textstat_simil(mt, y = mt[, "freedom"],
                             method = "cosine", margin = "features")
     lis <- as.list(tstat, n = 5, diag = TRUE)
     expect_equal(
@@ -330,7 +340,7 @@ test_that("as.list.textstat_simil works with features margin", {
 
 test_that("as.data.frame.textstat_simildist works with selection", {
     mt2 <- mt[6:10, ]
-    tstat <- textstat_simil(mt2, selection = c("2017-Trump", "2001-Bush"), method = "cosine")
+    tstat <- textstat_simil(mt2, y = mt[c("2017-Trump", "2001-Bush"), ], method = "cosine")
     
     expect_equal(
         as.character(as.data.frame(tstat, diag = FALSE, upper = FALSE)$document2),
@@ -446,7 +456,7 @@ test_that("test that min_simil coercion to matrix works as expected", {
         tol = .0001
     )
     
-    tstat2 <- textstat_simil(dfmat, selection = c("2009-Obama", "2013-Obama"),
+    tstat2 <- textstat_simil(dfmat, y = dfmat[c("2009-Obama", "2013-Obama"), ],
                              method = "cosine", margin = "documents", min_simil = 0.6)
     expect_equal(
         as.matrix(tstat2)[3:5, 1],
@@ -463,7 +473,8 @@ test_that("test that min_simil coercion to matrix works as expected", {
 
 test_that("y is working in the same way as selection (#1714)", {
     
-    expect_identical(textstat_simil(mt, selection = c("2009-Obama", "2013-Obama"),
+    suppressWarnings({
+        expect_identical(textstat_simil(mt, selection = c("2009-Obama", "2013-Obama"),
                                     margin = "documents"),
                      textstat_simil(mt, mt[c("2009-Obama", "2013-Obama"), ],
                                     margin = "documents"))
@@ -482,6 +493,7 @@ test_that("y is working in the same way as selection (#1714)", {
                                     margin = "features"),
                      textstat_dist(mt, mt[,c("world", "freedom")],
                                     margin = "features"))
+    })
 })
 
 test_that("diag2na is working", {
@@ -504,7 +516,7 @@ test_that("diag2na is working", {
                  matrix(c(1, 2, NA, 4, NA, 6), nrow = 3, 
                         dimnames = list(c("a", "b", "c"), c("c", "b"))))
     
-    mat4 <- forceSymmetric(mat1)
+    mat4 <- Matrix::forceSymmetric(mat1)
     expect_equal(as.matrix(quanteda:::diag2na(as(mat4, "dsTMatrix"))),
                  matrix(c(NA, 4, 7, 4, NA, 8, 7, 8, NA), nrow = 3, 
                         dimnames = list(c("b", "c", "d"), c("b", "c", "d"))))


### PR DESCRIPTION
Adds checking that y is a dfm, and returns an error if not, for `textstat_dist()` and `textstat_simil()`.

Also updates the tests for those functions to use `y` instead of `selection` where appropriate, to avoid the numerous deprecation warnings caused by using the `selection` argument. Suppresses the warnings where appropriate.

Fixes #1820