### PR TITLE
Fix printing error for corpus summary

### DIFF
--- a/R/corpus-methods-base.R
+++ b/R/corpus-methods-base.R
@@ -45,7 +45,7 @@ print.corpus <- function(x, ndoc = quanteda_options("print_corpus_max_ndoc"),
     }
     
     ndoc_rem <- ndoc(x) - ndoc
-    if (show.summary && ndoc_rem > 0)
+    if (show.summary && ndoc_rem > 0 && ndoc != 0)
         cat("and ", ndoc_rem, " more document", 
             if (ndoc_rem > 1) "s", ".\n", sep = "")
 }

--- a/tests/testthat/test-corpus.R
+++ b/tests/testthat/test-corpus.R
@@ -495,8 +495,7 @@ test_that("corpus printing works with new textual summary", {
     )
     expect_output(
         print(data_corpus_irishbudget2010, ndoc = 2, nchar = 10, show.summary = TRUE),
-        "Corpus consisting of 14 documents and 6 docvars\\.\n [Lenihan, Brian (FF)] When I pre ...\n[Bruton, Richard (FG)] This draco ...\nand 12 more documents.", 
-        fixed = TRUE
+        "^Corpus consisting of 14 documents and 6 docvars\\.\\n \\[Lenihan, Brian \\(FF\\)\\] When I pre ...\\n\\[Bruton, Richard \\(FG\\)\\] This draco \\.\\.\\.\\nand 12 more documents\\.$"
     )
     expect_output(
         print(data_corpus_irishbudget2010, ndoc = 2, nchar = 10, show.summary = FALSE),

--- a/tests/testthat/test-corpus.R
+++ b/tests/testthat/test-corpus.R
@@ -491,35 +491,32 @@ test_that("corpus printing works with new textual summary", {
     )
     expect_output(
         print(data_corpus_irishbudget2010, ndoc = 0, nchar = 0, show.summary = TRUE),
-        "Corpus consisting of 14 documents and 6 docvars.", 
-        fixed = TRUE
+        "^Corpus consisting of 14 documents and 6 docvars\\.$", 
     )
     expect_output(
         print(data_corpus_irishbudget2010, ndoc = 2, nchar = 10, show.summary = TRUE),
-        "Corpus consisting of 14 documents and 6 docvars.\n [Lenihan, Brian (FF)] When I pre ...\n[Bruton, Richard (FG)] This draco ...\nand 12 more documents.", 
+        "Corpus consisting of 14 documents and 6 docvars\\.\n [Lenihan, Brian (FF)] When I pre ...\n[Bruton, Richard (FG)] This draco ...\nand 12 more documents.", 
         fixed = TRUE
     )
     expect_output(
         print(data_corpus_irishbudget2010, ndoc = 2, nchar = 10, show.summary = FALSE),
-        " [Lenihan, Brian (FF)] When I pre ...\n[Bruton, Richard (FG)] This draco ...", 
-        fixed = TRUE
+        "^ \\[Lenihan, Brian \\(FF\\)\\] When I pre \\.\\.\\.\\n\\[Bruton, Richard \\(FG\\)\\] This draco \\.\\.\\.$"
     )
     expect_output(
         print(data_corpus_irishbudget2010[1:2], ndoc = 3, nchar = 10, show.summary = TRUE),
-        "Corpus consisting of 2 documents and 6 docvars.\n [Lenihan, Brian (FF)] When I pre ...\n[Bruton, Richard (FG)] This draco ...", 
-        fixed = TRUE
+        "^Corpus consisting of 2 documents and 6 docvars\\.\\n \\[Lenihan, Brian \\(FF\\)\\] When I pre \\.\\.\\.\\n\\[Bruton, Richard \\(FG\\)\\] This draco \\.\\.\\.$"
     )
     expect_output(
         print(corpus("a b c d"), ndoc = -1, nchar = 2),
-        "Corpus consisting of 1 document.\n[text1] a  ...", fixed = TRUE
+        "^Corpus consisting of 1 document\\.\\\n\\[text1\\] a  \\.\\.\\.$"
     )
     expect_output(
       print(corpus("a b c d"), ndoc = -1, nchar = 10),
-      "Corpus consisting of 1 document.\n[text1] a b c d", fixed = TRUE
+      "^Corpus consisting of 1 document\\.\\\n\\[text1\\] a b c d \\.\\.\\.$"
     )
     expect_output(
         print(corpus("a b c d"), ndoc = -1, nchar = -1),
-        "Corpus consisting of 1 document.\n[text1] a b c d", fixed = TRUE
+        "^Corpus consisting of 1 document.\\n\\[text1\\] a b c d$"
     )
 })
 


### PR DESCRIPTION
- Fixes an error where the remaining document message was triggered even when there were no document-specific items printed.
- Increases the stringency of tests to include the entire output, not just a fixed match on the first part of the output.  (This is why we did not catch this error to begin with.)