### PR TITLE
Improve efficiency of grouping by skipping system variables

### DIFF
--- a/R/dfm_group.R
+++ b/R/dfm_group.R
@@ -30,7 +30,7 @@
 #' @export
 #' @examples
 #' corp <- corpus(c("a a b", "a b c c", "a c d d", "a c c d"),
-#'                    docvars = data.frame(grp = c("grp1", "grp1", "grp2", "grp2")))
+#'                docvars = data.frame(grp = c("grp1", "grp1", "grp2", "grp2")))
 #' dfmat <- dfm(corp)
 #' dfm_group(dfmat, groups = "grp")
 #' dfm_group(dfmat, groups = c(1, 1, 2, 2))

--- a/R/docvars.R
+++ b/R/docvars.R
@@ -142,7 +142,12 @@ subset_docvars <- function(x, i = NULL) {
 
 # Reshape docvars keeping variables that have the same values within groups
 group_docvars <- function(x, group) {
-    l <- is_system(names(x)) | unlist(lapply(x, is_grouped, group), use.names = FALSE)
+    l <- rep(FALSE, length(x))
+    for (i in seq_along(l)) {
+        if (is_system(names(x)[i]) || is_grouped(x[[i]], group)) {
+            l[i] <- TRUE    
+        }
+    }
     result <- x[match(levels(group), group), l, drop = FALSE]
     result[["docname_"]] <- levels(group)
     rownames(result) <- NULL

--- a/man/dfm_group.Rd
+++ b/man/dfm_group.Rd
@@ -47,7 +47,7 @@ functionality to using the \code{"groups"} argument in \code{\link[=dfm]{dfm()}}
 }
 \examples{
 corp <- corpus(c("a a b", "a b c c", "a c d d", "a c c d"),
-                   docvars = data.frame(grp = c("grp1", "grp1", "grp2", "grp2")))
+               docvars = data.frame(grp = c("grp1", "grp1", "grp2", "grp2")))
 dfmat <- dfm(corp)
 dfm_group(dfmat, groups = "grp")
 dfm_group(dfmat, groups = c(1, 1, 2, 2))


### PR DESCRIPTION
Improve efficiency of grouping by skipping system variables. Currently, `group_docvars()` checks all the document variables including including system variables, which must not be dropped in any case.