### PR TITLE
Restore remove_twitter to deprecated rather than defunct status

### DIFF
--- a/R/tokens.R
+++ b/R/tokens.R
@@ -246,7 +246,9 @@ tokens.corpus <- function(x,
         dots$remove_hyphens <- NULL
     }
     if ("remove_twitter" %in% names(dots)) {
-        .Defunct(msg = "'remove_twitter' is defunct, use 'what = \"word2\"' instead.")
+        .Deprecated(msg = "'remove_twitter' is deprecated; for FALSE, use 'what = \"word2\"' instead.")
+        if (dots$remove_twitter == FALSE && what == "word") what <- "word2"
+        dots$remove_twitter <- NULL
     }
     check_dots(dots, c(names(formals(tokens))))
 
@@ -328,7 +330,8 @@ tokens.tokens <-  function(x,
 
     }
     if ("remove_twitter" %in% names(dots)) {
-        .Defunct(msg = "'remove_twitter' is defunct, use 'what = \"word2\"' instead.")
+        .Deprecated(msg = "'remove_twitter' is deprecated and inactive for tokens.tokens()")
+        dots$remove_twitter <- NULL    
     }
     check_dots(dots, c(names(formals(tokens))))
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -17,7 +17,12 @@
 
 No ERRORs, NOTEs, or WARNINGs produced.
 
-
 ## Downstream dependencies
 
-The **RNewsflow** package... had a problem in executing an example but I fixed this in a pull request to that package (https://github.com/kasperwelbers/RNewsflow/pull/4) that has now been merged.  The maintainer Kasper Welbers (kasperwelbers@gmail.com) is planning to refresh the CRAN version today.
+**tosca**:  This package errors on a test but I notified the maintainers and actuall fixed this code in a pull request that was merged into the **tosca** master branch on 21 December 2019: https://github.com/Docma-TU/tosca/commit/dae6ed5bb7457a65693d130dfeb6388b75ae27b4 (21 December 2019).  They simply need to resubmit the updated (and passing, on GitHub) package to CRAN.
+
+**tidytext**:  We fixed the breaking changes in a pull request accepted on 7 December 2019 (https://github.com/juliasilge/tidytext/pull/160), and this is fixed now in the GitHub master.  They simply need to resubmit the updated (and passing, on GitHub) package to CRAN.
+
+**preText**:  The split of some of the functions previously in **quanteda** into a new **quanteda.textmodels** package meant that **preText** needed its namespace references to these functions updated.  I've issued a pull request (https://github.com/matthewjdenny/preText/pull/9) to fix this, and suggested that the maintainer refresh this package on CRAN as soon as **quanteda.textmodels** is accepted and published.
+
+**sentometrics**: This package has lots of problems with quanteda v2 and we are busy trying to fix them.

--- a/tests/testthat/test-tokens.R
+++ b/tests/testthat/test-tokens.R
@@ -175,17 +175,38 @@ test_that("deprecated remove_ arguments work", {
 })
 
 test_that("defunct remove_twitter warning works", {
+    # character
     txt <- "they: #stretched, @ @@ in,, a # ## never-ending @line."
-    toks <- tokens(txt)
-    expect_error(
+    expect_warning(
         tokens(txt, remove_twitter = TRUE),
-        "'remove_twitter' is defunct, use 'what = \"word2\"' instead.",
-        class = "defunctError", fixed = TRUE
+        "'remove_twitter' is deprecated; for FALSE, use 'what = \"word2\"' instead.",
+        fixed = TRUE
     )
-    expect_error(
+    expect_warning(
+        tokens(txt, remove_twitter = FALSE),
+        "'remove_twitter' is deprecated; for FALSE, use 'what = \"word2\"' instead.",
+        fixed = TRUE
+    )
+    expect_identical(
+        suppressWarnings(as.list(tokens(txt, remove_twitter = FALSE, remove_punct = TRUE))),
+        list(text1 = c("they", "#stretched", "in", "a", "never-ending", "@line"))
+    )
+    expect_identical(
+        suppressWarnings(tokens(txt, remove_twitter = FALSE, remove_punct = TRUE)),
+        tokens(txt, what = "word2", remove_punct = TRUE)
+    )
+    
+    # tokens
+    toks <- tokens(txt)
+    expect_warning(
         tokens(toks, remove_twitter = TRUE),
-        "'remove_twitter' is defunct, use 'what = \"word2\"' instead.",
-        class = "defunctError", fixed = TRUE
+        "'remove_twitter' is deprecated and inactive for tokens.tokens()",
+        fixed = TRUE
+    )
+    expect_warning(
+        tokens(toks, remove_twitter = FALSE),
+        "'remove_twitter' is deprecated and inactive for tokens.tokens()",
+        fixed = TRUE
     )
 })
 


### PR DESCRIPTION
Necessary because otherwise it breaks **clustRcompaR**, which passes this through in `cluster(..., remove_twitter = FALSE)`.

Now works so that it issues a deprecation warning, but implements the old functionality for `remove_twitter = FALSE` by changing the tokenizer type to "word1". So in this PR:

```r
> tokens("@username #hashtag test.", remove_twitter = FALSE)
Tokens consisting of 1 document.
text1 :
[1] "@username" "#hashtag"  "test"      "."        

Warning message:
'remove_twitter' is deprecated; for FALSE, use 'what = "word2"' instead. 

> tokens(tokens("@username #hashtag test."), remove_twitter = FALSE)
Tokens consisting of 1 document.
text1 :
[1] "@"        "username" "#"        "hashtag"  "test"     "."       

Warning message:
'remove_twitter' is deprecated and inactive for tokens.tokens() 
```

I will notify the maintainers of **clustRcompaR** to change their function (or just submit a PR).

Fixes #1875 