### PR TITLE
Fix test errors for r-devel

### DIFF
--- a/R/convert.R
+++ b/R/convert.R
@@ -249,9 +249,9 @@ dfm2austin <- function(x) {
 dfm2tm <- function(x, weighting = tm::weightTf) {
     attrs <- attributes(x)
     if (!requireNamespace("tm", quietly = TRUE))
-        stop("You must install the tm package installed for this conversion.")
+        stop("You must install the tm package for this conversion.")
     if (!requireNamespace("slam", quietly = TRUE))
-        stop("You must install the slam package installed for this conversion.")
+        stop("You must install the slam package for this conversion.")
 
     if (!(field_object(attrs, "weight_tf")$scheme == "count" && field_object(attrs, "weight_df")$scheme == "unary")) {
         warning("converted DocumentTermMatrix will not have weight attributes set correctly")
@@ -286,7 +286,7 @@ dfm2tm <- function(x, weighting = tm::weightTf) {
 dfm2lda <- function(x, omit_empty = TRUE) {
     x <- as.dfm(x)
     if (!requireNamespace("tm", quietly = TRUE))
-        stop("You must install the slam package installed for this conversion.")
+        stop("You must install the slam package for this conversion.")
     dtm2lda(dfm2dtm(x, omit_empty = omit_empty), omit_empty = omit_empty)
 }
 
@@ -304,7 +304,7 @@ dfm2lda <- function(x, omit_empty = TRUE) {
 #' @keywords internal
 dtm2lda <- function(x, omit_empty = TRUE) {
     if (!requireNamespace("slam", quietly = TRUE))
-        stop("You must install the slam package installed for this conversion.")
+        stop("You must install the slam package for this conversion.")
 
     docs <- vector(mode = "list", length = nrow(x))
     names(docs) <- rownames(x)
@@ -329,11 +329,10 @@ split.matrix <- function(x, f, drop = FALSE, ...) {
 
 #' @rdname convert-wrappers
 dfm2dtm <- function(x, omit_empty = TRUE) {
-
     if (!requireNamespace("tm", quietly = TRUE))
-        stop("You must install the tm package installed for this conversion.")
+        stop("You must install the tm package for this conversion.")
     if (!requireNamespace("slam", quietly = TRUE))
-        stop("You must install the slam package installed for this conversion.")
+        stop("You must install the slam package for this conversion.")
 
     x <- as.dfm(x)
     x <- as(x, "dgTMatrix")
@@ -397,11 +396,11 @@ ijv.to.doc <- function(i, j, v) {
 #' }
 #' @keywords internal
 dfm2lsa <- function(x) {
-    x <- as.matrix(x)
-    result <- apply(x, c(1, 2), as.integer) # convert to integer
-    names(dimnames(result)) <- c("docs", "terms")
-    class(result) <- "textmatrix"
-    t(result)
+    if (!requireNamespace("lsa", quietly = TRUE))
+        stop("You must install the lsa package for this conversion.")
+    x <- t(as.matrix(x))
+    names(dimnames(x))[1] <- "terms"
+    lsa::as.textmatrix(x)
 }
 
 dfm2tripletlist <- function(x) {

--- a/tests/testthat/test-corpus_reshape.R
+++ b/tests/testthat/test-corpus_reshape.R
@@ -2,8 +2,8 @@ context("test corpus_reshape")
 
 test_that("corpus_reshape works for sentences", {
     corp <- corpus(c(textone = "This is a sentence.  Another sentence.  Yet another.", 
-                         texttwo = "Premiere phrase.  Deuxieme phrase."), 
-                         docvars = data.frame(country=c("UK", "USA"), year=c(1990, 2000)))
+                     texttwo = "Premiere phrase.  Deuxieme phrase."), 
+                   docvars = data.frame(country = factor(c("UK", "USA")), year=c(1990, 2000)))
     corp_reshaped <- corpus_reshape(corp, to = "sentences")
     expect_equal(as.character(corp_reshaped)[4], c(texttwo.1 = "Premiere phrase."))
     expect_equal(docvars(corp_reshaped, "country"), factor(c("UK", "UK", "UK", "USA", "USA")))

--- a/tests/testthat/test-tokens_segment.R
+++ b/tests/testthat/test-tokens_segment.R
@@ -4,18 +4,18 @@ test_that("tokens_segment works for sentences", {
     txt <- c(d1 = "Sentence one.  Second sentence is this one!\n
                    Here is the third sentence.",
              d2 = "Only sentence of doc2?  No there is another.")
-    
-    corp <- corpus(txt, docvars = data.frame(title = c("doc1", "doc2")))
+
+    corp <- corpus(txt, docvars = data.frame(title = factor(c("doc1", "doc2"))))
     toks <- tokens(corp)
-    toks_sent <- tokens_segment(toks, "\\p{Sterm}", valuetype = 'regex', pattern_position = 'after')
-    
+    toks_sent <- tokens_segment(toks, "\\p{Sterm}", valuetype = "regex", pattern_position = "after")
+
     expect_equal(ndoc(toks_sent), 5)
-    
-    expect_equal(as.list(toks_sent)[4], 
+
+    expect_equal(as.list(toks_sent)[4],
                  list(d2.1 = c("Only", "sentence", "of", "doc2", "?")))
-    expect_equal(docvars(toks_sent, 'title'),
-                 as.factor(c('doc1', 'doc1', 'doc1', 'doc2', 'doc2')))
-    
+    expect_equal(docvars(toks_sent, "title"),
+                 as.factor(c("doc1", "doc1", "doc1", "doc2", "doc2")))
+
 })
 
 
@@ -23,103 +23,103 @@ test_that("tokens_segment works for delimiter", {
     txt <- c(d1 = "Sentence one.  Second sentence is this one!\n
                    Here is the third sentence.",
              d2 = "Only sentence of doc2?  No there is another.")
-    
-    corp <- corpus(txt, docvars = data.frame(title = c("doc1", "doc2")))
+
+    corp <- corpus(txt, docvars = data.frame(title = factor(c("doc1", "doc2"))))
     toks <- tokens(corp)
-    toks_sent <- tokens_segment(toks, '[.!?]', valuetype = 'regex', pattern_position = 'after')
-    
+    toks_sent <- tokens_segment(toks, "[.!?]", valuetype = "regex", pattern_position = "after")
+
     expect_equal(ndoc(toks_sent), 5)
-    
-    expect_equal(as.list(toks_sent)[1], 
-                 list(d1.1 = c("Sentence", "one", '.')))
-    
-    expect_equal(as.list(toks_sent)[4], 
+
+    expect_equal(as.list(toks_sent)[1],
+                 list(d1.1 = c("Sentence", "one", ".")))
+
+    expect_equal(as.list(toks_sent)[4],
                  list(d2.1 = c("Only", "sentence", "of", "doc2", "?")))
-    
-    expect_equal(docvars(toks_sent, 'title'),
-                 as.factor(c('doc1', 'doc1', 'doc1', 'doc2', 'doc2')))
-    
+
+    expect_equal(docvars(toks_sent, "title"),
+                 as.factor(c("doc1", "doc1", "doc1", "doc2", "doc2")))
+
 })
 
 test_that("tokens_segment works for delimiter with extract_pattern = TRUE", {
     txt <- c(d1 = "Sentence one.  Second sentence is this one!\n
                    Here is the third sentence.",
              d2 = "Only sentence of doc2?  No there is another.")
-    
-    corp <- corpus(txt, docvars = data.frame(title = c("doc1", "doc2")))
+
+    corp <- corpus(txt, docvars = data.frame(title = factor(c("doc1", "doc2"))))
     toks <- tokens(corp)
-    toks_sent <- tokens_segment(toks, '[.!?]', valuetype = 'regex',
-                                  extract_pattern = TRUE, pattern_position = 'after')
-    
+    toks_sent <- tokens_segment(toks, "[.!?]", valuetype = "regex",
+                                  extract_pattern = TRUE, pattern_position = "after")
+
     expect_equal(ndoc(toks_sent), 5)
-    
-    expect_equal(as.list(toks_sent)[1], 
+
+    expect_equal(as.list(toks_sent)[1],
                  list(d1.1 = c("Sentence", "one")))
-    
-    expect_equal(as.list(toks_sent)[4], 
+
+    expect_equal(as.list(toks_sent)[4],
                  list(d2.1 = c("Only", "sentence", "of", "doc2")))
 
-    expect_equal(docvars(toks_sent, 'title'),
-                 as.factor(c('doc1', 'doc1', 'doc1', 'doc2', 'doc2')))
-    
+    expect_equal(docvars(toks_sent, "title"),
+                 as.factor(c("doc1", "doc1", "doc1", "doc2", "doc2")))
+
 })
 
 test_that("tokens_segment includes left-over text", {
     txt <- c("This is the main. this is left-over")
     toks <- tokens(txt)
-    toks_seg1 <- tokens_segment(toks, '[.!?]', valuetype = 'regex',
-                                  extract_pattern = FALSE, pattern_position = 'after')
-    
-    expect_equal(as.list(toks_seg1)[2], 
+    toks_seg1 <- tokens_segment(toks, "[.!?]", valuetype = "regex",
+                                  extract_pattern = FALSE, pattern_position = "after")
+
+    expect_equal(as.list(toks_seg1)[2],
                  list(text1.2 = c("this", "is", "left-over")))
-    
-    toks_seg2 <- tokens_segment(toks, '[.!?]', valuetype = 'regex',
-                                  extract_pattern = FALSE, pattern_position = 'after')
-    
-    expect_equal(as.list(toks_seg2)[2], 
+
+    toks_seg2 <- tokens_segment(toks, "[.!?]", valuetype = "regex",
+                                  extract_pattern = FALSE, pattern_position = "after")
+
+    expect_equal(as.list(toks_seg2)[2],
                  list(text1.2 = c("this", "is", "left-over")))
-    
-    
+
+
 })
 
 test_that("tokens_segment works when removing punctuation match, remove_delimiter tests", {
     toks1 <- tokens(c("This: is a test", "Another test"))
     toks2 <- tokens(c("This is a test", "Another test."))
     toks3 <- tokens(c("This is a test", "Another test"))
-    
+
     # extract_pattern = TRUE
     expect_equal(
-        as.list(tokens_segment(toks1, "^\\p{P}$", valuetype = "regex", 
-                               extract_pattern = TRUE, pattern_position = 'after')),
+        as.list(tokens_segment(toks1, "^\\p{P}$", valuetype = "regex",
+                               extract_pattern = TRUE, pattern_position = "after")),
         list(text1.1 = "This", text1.2 = c("is", "a", "test"), text2.1 = c("Another", "test"))
     )
     expect_equal(
-        as.list(tokens_segment(toks2, "^\\p{P}$", valuetype = "regex", 
-                               extract_pattern = TRUE, pattern_position = 'after')),
+        as.list(tokens_segment(toks2, "^\\p{P}$", valuetype = "regex",
+                               extract_pattern = TRUE, pattern_position = "after")),
         list(text1 = c("This", "is", "a", "test"), text2 = c("Another", "test"))
     )
     expect_equal(
-        as.list(tokens_segment(toks3, "^\\p{P}$", valuetype = "regex", 
-                               extract_pattern = TRUE, pattern_position = 'after')),
+        as.list(tokens_segment(toks3, "^\\p{P}$", valuetype = "regex",
+                               extract_pattern = TRUE, pattern_position = "after")),
         list(text1 = c("This", "is", "a", "test"), text2 = c("Another", "test"))
     )
-    
+
     # extract_pattern = FALSE
     expect_equal(
-        as.list(tokens_segment(toks1, "^\\p{P}$", valuetype = "regex", 
-                               extract_pattern = FALSE, pattern_position = 'after')),
+        as.list(tokens_segment(toks1, "^\\p{P}$", valuetype = "regex",
+                               extract_pattern = FALSE, pattern_position = "after")),
         list(text1.1 = c("This", ":"), text1.2 = c("is", "a", "test"), text2.1 = c("Another", "test"))
     )
     expect_equal(
-        as.list(tokens_segment(toks2, "^\\p{P}$", valuetype = "regex", 
-                               extract_pattern = FALSE, pattern_position = 'after')),
+        as.list(tokens_segment(toks2, "^\\p{P}$", valuetype = "regex",
+                               extract_pattern = FALSE, pattern_position = "after")),
         list(text1 = c("This", "is", "a", "test"), text2 = c("Another", "test", "."))
     )
-    expect_silent(as.list(tokens_segment(toks2, "^\\p{P}$", valuetype = "regex", 
-                                         extract_pattern = FALSE, pattern_position = 'after')))
+    expect_silent(as.list(tokens_segment(toks2, "^\\p{P}$", valuetype = "regex",
+                                         extract_pattern = FALSE, pattern_position = "after")))
     expect_equal(
-        as.list(tokens_segment(toks3,  "^\\p{P}$", valuetype = "regex", 
-                               extract_pattern = FALSE, pattern_position = 'after')),
+        as.list(tokens_segment(toks3,  "^\\p{P}$", valuetype = "regex",
+                               extract_pattern = FALSE, pattern_position = "after")),
         list(text1 = c("This", "is", "a", "test"), text2 = c("Another", "test"))
     )
 })
@@ -130,31 +130,31 @@ test_that("tokens_segment works with tags", {
                      d2 = "##TEST3 Four"),
                    docvars = data.frame(test = c("A", "B"), stringsAsFactors = FALSE))
     toks <- tokens(corp, what = "word")
-    toks_seg1 <- tokens_segment(toks, "##[A-Z0-9]+", valuetype = "regex", 
+    toks_seg1 <- tokens_segment(toks, "##[A-Z0-9]+", valuetype = "regex",
                                 pattern_position = "before", extract_pattern = TRUE, use_docvars = TRUE)
     vars1 <- docvars(toks_seg1)
     expect_equal(vars1$test, c("A", "A", "B"))
     expect_equal(vars1$pattern, c("##TEST", "##TEST2", "##TEST3"))
     expect_equal(as.list(toks_seg1),
                  list(d1.1 = c("One", "two"), d1.2 = "Three", d2.1 = "Four"))
-    
-    toks_seg2 <- tokens_segment(toks, "##[A-Z0-9]+", valuetype = "regex", 
+
+    toks_seg2 <- tokens_segment(toks, "##[A-Z0-9]+", valuetype = "regex",
                                 pattern_position = "before", extract_pattern = FALSE, use_docvars = TRUE)
     vars2 <- docvars(toks_seg2)
     expect_equal(vars2$test, c("A", "A", "B"))
     expect_equal(vars2$pattern, NULL)
     expect_equal(as.list(toks_seg2),
                  list(d1.1 = c("##TEST", "One", "two"), d1.2 = c("##TEST2", "Three"), d2.1 = c("##TEST3", "Four")))
-    
-    toks_seg3 <- tokens_segment(toks, "##[A-Z0-9]+", valuetype = "regex", 
+
+    toks_seg3 <- tokens_segment(toks, "##[A-Z0-9]+", valuetype = "regex",
                                 pattern_position = "before", extract_pattern = TRUE, use_docvars = FALSE)
     vars3 <- docvars(toks_seg3)
     expect_equal(vars3$test, NULL)
     expect_equal(vars3$pattern, c("##TEST", "##TEST2", "##TEST3"))
     expect_equal(as.list(toks_seg3),
                  list(d1.1 = c("One", "two"), d1.2 = "Three", d2.1 = "Four"))
-    
-    toks_seg4 <- tokens_segment(toks, "##[A-Z0-9]+", valuetype = "regex", 
+
+    toks_seg4 <- tokens_segment(toks, "##[A-Z0-9]+", valuetype = "regex",
                                 pattern_position = "before", extract_pattern = FALSE, use_docvars = FALSE)
     vars4 <- docvars(toks_seg4)
     expect_equal(vars4$test, NULL)
@@ -162,4 +162,3 @@ test_that("tokens_segment works with tags", {
     expect_equal(as.list(toks_seg4),
                  list(d1.1 = c("##TEST", "One", "two"), d1.2 = c("##TEST2", "Three"), d2.1 = c("##TEST3", "Four")))
 })
-


### PR DESCRIPTION
These are caused by a change to the default in data.frame in the next major R release, in which `stringsAsFactors = FALSE` by default.

This fixes the tests by forcing factors, but also cleans up something else that was happening with `dfm2lsa()`. I think this was **lsa**'s problem, not ours. In any case, I fixed it by using the `lsa::as.textmatrix()` converter instead of re-engineering it. We could avoid the conversion to dense matrix and back by re-engineering the conversion ourselves, but I will leave this for future work.

Solves #1901.