### PR TITLE
Increase codecov

### DIFF
--- a/R/dfm.R
+++ b/R/dfm.R
@@ -123,7 +123,6 @@ dfm <- function(x,
 
     dfm_env$START_TIME <- proc.time()
     object_class <- class(x)[1]
-    if (object_class == "dfmSparse") object_class <- "dfm"
     if (verbose) message("Creating a dfm from a ", object_class, " input...")
     UseMethod("dfm")
 }
@@ -212,9 +211,9 @@ dfm.tokens <- function(x,
     valuetype <- match.arg(valuetype)
 
     # set document names if none
-    if (is.null(names(x))) {
-        names(x) <- paste0(quanteda_options("base_docname"), seq_along(x))
-    }
+    # if (is.null(names(x))) {
+    #     names(x) <- paste0(quanteda_options("base_docname"), seq_along(x))
+    # }
 
     # call tokens only if options given
     if (length(intersect(names(list(...)), names(formals("tokens"))))) {
@@ -271,9 +270,10 @@ dfm.tokens <- function(x,
                            verbose = verbose)
     }
 
+    language <- quanteda_options("language_stemmer")
     if (stem) {
-        if (verbose) catm(" ...stemming words\n")
-        x <- tokens_wordstem(x)
+        if (verbose) catm(" ...stemming types (", stri_trans_totitle(language), ")\n", sep = "")
+        x <- tokens_wordstem(x, language = language)
     }
 
     # compile the dfm
@@ -346,7 +346,7 @@ dfm.dfm <- function(x,
         if (!is.null(remove) & !is.null(select))
             stop("only one of select and remove may be supplied at once")
         if (verbose) catm(" ...")
-        # if ngrams > 1 and remove or selct is specified, then convert these
+        # if ngrams > 1 and remove or select is specified, then convert these
         # into a regex that will remove any ngram containing one of the words
         # if (!identical(field_object(attrs, "ngram"), 1L)) {
         #     remove <- make_ngram_pattern(remove, valuetype,
@@ -370,7 +370,7 @@ dfm.dfm <- function(x,
     if (stem) {
         if (verbose)
             catm(" ...stemming features (", stri_trans_totitle(language),
-                 ")\n", sep = "")
+                 ")", sep = "")
         nfeat_org <- nfeat(x)
         x <- dfm_wordstem(x, language)
         if (verbose)
@@ -400,15 +400,15 @@ dfm.dfm <- function(x,
 ####
 
 ## convert patterns (remove and select) to ngram regular expressions
-make_ngram_pattern <- function(features, valuetype, concatenator) {
-    if (valuetype == "glob") {
-        features <- stri_replace_all_regex(features, "\\*", ".*")
-        features <- stri_replace_all_regex(features, "\\?", ".{1}")
-    }
-    features <- paste0("(\\b|(\\w+", concatenator, ")+)",
-                       features, "(\\b|(", concatenator, "\\w+)+)")
-    features
-}
+# make_ngram_pattern <- function(features, valuetype, concatenator) {
+#     if (valuetype == "glob") {
+#         features <- stri_replace_all_regex(features, "\\*", ".*")
+#         features <- stri_replace_all_regex(features, "\\?", ".{1}")
+#     }
+#     features <- paste0("(\\b|(\\w+", concatenator, ")+)",
+#                        features, "(\\b|(", concatenator, "\\w+)+)")
+#     features
+# }
 
 # create an empty dfm for given features and documents
 make_null_dfm <- function(feature = NULL, document = NULL) {
@@ -437,17 +437,17 @@ pad_dfm <- function(x, feature) {
 }
 
 # foce dfm conformat for prediction with new data
-force_conformance <- function(x, feature, force) {
-    if (force) {
-        n <- length(featnames(x)) - length(intersect(featnames(x), feature))
-        if (n)
-            warning(n, " feature", if (n == 1) "" else "s",
-                    " in newdata not used in prediction.",
-                    call. = FALSE, noBreaks. = TRUE)
-        return(dfm_match(x, feature))
-    } else {
-        if (!identical(featnames(x), feature))
-            stop("newdata's feature set is not conformant to model terms.")
-        return(x)
-    }
-}
+# force_conformance <- function(x, feature, force) {
+#     if (force) {
+#         n <- length(featnames(x)) - length(intersect(featnames(x), feature))
+#         if (n)
+#             warning(n, " feature", if (n == 1) "" else "s",
+#                     " in newdata not used in prediction.",
+#                     call. = FALSE, noBreaks. = TRUE)
+#         return(dfm_match(x, feature))
+#     } else {
+#         if (!identical(featnames(x), feature))
+#             stop("newdata's feature set is not conformant to model terms.")
+#         return(x)
+#     }
+# }

--- a/tests/testthat/test-corpus.R
+++ b/tests/testthat/test-corpus.R
@@ -468,27 +468,7 @@ test_that("upgrade_corpus is working", {
     expect_true(is.factor(attr(corp3, "docvars")[["docid_"]]))
 })
 
-test_that("metadoc works but raise deprecation warning", {
-    corp <- corpus(c("aa bb cc", "ccc dd"))
-    suppressWarnings(expect_equal(colnames(metadoc(corp)), character()))
-    suppressWarnings(metadoc(corp, "var1") <- c(1, 5))
-    suppressWarnings(metadoc(corp, "var2") <- c("T", "F"))
-    suppressWarnings(expect_equal(colnames(metadoc(corp)), c("_var1", "_var2")))
-    expect_warning(metadoc(corp), "metadoc is deprecated")
-})
-
-test_that("metadoc works but raise deprecation warning", {
-    expect_error(
-        corpus(c("aa bb cc", "ccc dd"), docnames = c("text1", "text1"),
-               "docnames must be unique")
-    )
-    expect_silent(
-        corpus(c("aa bb cc", "ccc dd"), docnames = c("text1", "text1"), unique_docnames = FALSE)
-    )
-})
-
 test_that("raise error when docnames or docvars are invalid", {
-
     expect_error(
         corpus(c("a b c", "b c d"), docnames = "onedoc"),
         quanteda:::message_error("docnames_mismatch")
@@ -497,7 +477,16 @@ test_that("raise error when docnames or docvars are invalid", {
         corpus(c("a b c", "b c d"), docvars = data.frame(docid_ = c("s1", "s2"))),
         quanteda:::message_error("docvars_invalid")
     )
+})
 
+test_that("docname uniqueness flag works", {
+    expect_error(
+        corpus(c("aa bb cc", "ccc dd"), docnames = c("text1", "text1")),
+        "docnames must be unique"
+    )
+    expect_silent(
+        corpus(c("aa bb cc", "ccc dd"), docnames = c("text1", "text1"), unique_docnames = FALSE)
+    )
 })
 
 test_that("[.corpus out of bounds generates expected error", {

--- a/tests/testthat/test-dfm.R
+++ b/tests/testthat/test-dfm.R
@@ -549,6 +549,10 @@ test_that("cannot supply remove and select in one call (#793)", {
         dfm(toks, select = "one", remove = "two"),
         "only one of select and remove may be supplied at once"
     )
+    expect_error(
+        dfm(dfm(toks), select = "one", remove = "two"),
+        "only one of select and remove may be supplied at once"
+    )
 })
 
 test_that("dfm with selection options produces correct output", {
@@ -1039,12 +1043,24 @@ test_that("dfm verbose = TRUE works as expected", {
         "applying a dictionary consisting of 4 keys"
     )
     expect_message(
+        tmp <- dfm(dfm(data_corpus_inaugural[1:3]), dictionary = data_dictionary_LSD2015, verbose = TRUE),
+        "applying a dictionary consisting of 4 keys"
+    )
+    expect_message(
         tmp <- dfm(data_corpus_inaugural[1:3], groups = "President", verbose = TRUE),
         "grouping texts"
     )
     expect_message(
-        tmp <- dfm(data_corpus_inaugural[1:3], stem = TRUE, verbose = TRUE),
-        "stemming words"
+        tmp <- dfm(data_corpus_inaugural[1:2], stem = TRUE, verbose = TRUE),
+        "stemming types \\(English\\)"
+    )
+    expect_message(
+        tmp <- dfm(dfm(data_corpus_inaugural[1:2]), stem = TRUE, verbose = TRUE),
+        "stemming features \\(English\\)"
+    )
+    expect_message(
+        tmp <- dfm(dfm(data_corpus_inaugural[1:3]), groups = "President", verbose = TRUE),
+        "grouping texts"
     )
     expect_error(
         dfm("one two three", remove = "one", select = "three"),
@@ -1055,3 +1071,31 @@ test_that("dfm verbose = TRUE works as expected", {
     attributes(toks)$types[4] <- NA
     dfm(toks)
 })
+
+test_that("dfm_sort works as expected", {
+    dfmat <- dfm(c(d1 = "z z x y a b", d3 = "x y y y c", d2 = "a z"))
+    expect_identical(
+        featnames(dfm_sort(dfmat, margin = "features", decreasing = TRUE)),
+        c("y", "z", "x", "a", "b", "c")
+    )
+    expect_identical(
+        featnames(dfm_sort(dfmat, margin = "features", decreasing = FALSE)),
+        c("b", "c", "x", "a", "z", "y")
+    )
+    expect_identical(
+        docnames(dfm_sort(dfmat, margin = "documents", decreasing = TRUE)),
+        c("d1", "d3", "d2")
+    )
+    expect_identical(
+        docnames(dfm_sort(dfmat, margin = "documents", decreasing = FALSE)),
+        rev(c("d1", "d3", "d2"))
+    )
+})
+
+# test_that("make_ngram_pattern()", {
+#     expect_equal(
+#         quanteda:::make_ngram_pattern(c("one", "two"), "glob", "_"),
+#         c("(\\b|(\\w+_)+)one(\\b|(_\\w+)+)", "(\\b|(\\w+_)+)two(\\b|(_\\w+)+)"),
+#         fixed = TRUE
+#     )
+# })

--- a/tests/testthat/test-docvars.R
+++ b/tests/testthat/test-docvars.R
@@ -545,3 +545,26 @@ test_that("works correctly in edge cases", {
     expect_error(docvars(corp, "var4") <- 1:3)
 })
 
+
+test_that("metadoc works but raise deprecation warning", {
+    corp <- corpus(c("aa bb cc", "ccc dd"))
+    suppressWarnings(expect_equal(colnames(metadoc(corp)), character()))
+    suppressWarnings(metadoc(corp, "var1") <- c(1, 5))
+    suppressWarnings(metadoc(corp, "var2") <- c("T", "F"))
+    suppressWarnings(expect_equal(colnames(metadoc(corp)), c("_var1", "_var2")))
+    expect_warning(metadoc(corp), "metadoc is deprecated")
+    
+    toks <- tokens(corp)
+    suppressWarnings(expect_equal(colnames(metadoc(toks)), character()))
+    suppressWarnings(metadoc(toks, "var1") <- c(1, 5))
+    suppressWarnings(metadoc(toks, "var2") <- c("T", "F"))
+    suppressWarnings(expect_equal(colnames(metadoc(toks)), c("_var1", "_var2")))
+    expect_warning(metadoc(toks), "metadoc is deprecated")
+    
+    dfmat <- dfm(toks)
+    suppressWarnings(expect_equal(colnames(metadoc(dfmat)), character()))
+    suppressWarnings(metadoc(dfmat, "var1") <- c(1, 5))
+    suppressWarnings(metadoc(dfmat, "var2") <- c("T", "F"))
+    suppressWarnings(expect_equal(colnames(metadoc(dfmat)), c("_var1", "_var2")))
+    expect_warning(metadoc(dfmat), "metadoc is deprecated")
+})

--- a/tests/testthat/test-docvars.R
+++ b/tests/testthat/test-docvars.R
@@ -554,6 +554,7 @@ test_that("metadoc works but raise deprecation warning", {
     suppressWarnings(expect_equal(colnames(metadoc(corp)), c("_var1", "_var2")))
     expect_warning(metadoc(corp), "metadoc is deprecated")
     
+    corp <- corpus(c("aa bb cc", "ccc dd"))
     toks <- tokens(corp)
     suppressWarnings(expect_equal(colnames(metadoc(toks)), character()))
     suppressWarnings(metadoc(toks, "var1") <- c(1, 5))
@@ -561,7 +562,8 @@ test_that("metadoc works but raise deprecation warning", {
     suppressWarnings(expect_equal(colnames(metadoc(toks)), c("_var1", "_var2")))
     expect_warning(metadoc(toks), "metadoc is deprecated")
     
-    dfmat <- dfm(toks)
+    corp <- corpus(c("aa bb cc", "ccc dd"))
+    dfmat <- dfm(corp)
     suppressWarnings(expect_equal(colnames(metadoc(dfmat)), character()))
     suppressWarnings(metadoc(dfmat, "var1") <- c(1, 5))
     suppressWarnings(metadoc(dfmat, "var2") <- c("T", "F"))

--- a/tests/testthat/test-textplot.R
+++ b/tests/testthat/test-textplot.R
@@ -127,6 +127,28 @@ test_that("test textplot_wordcloud comparison works", {
     expect_silent(
         textplot_wordcloud(testdfm_grouped, ordered_color = FALSE)
     )
+    expect_error(
+        textplot_wordcloud(dfm(data_corpus_inaugural[1:9]), comparison = TRUE),
+        "Too many documents to plot comparison, use 8 or fewer documents"
+    )
+    
+    dfmsmall <- dfm(data_corpus_inaugural[1:9], groups = "President", remove = stopwords("en"), remove_punct = TRUE) %>%
+        dfm_trim(min_termfreq = 20)
+    expect_silent(textplot_wordcloud(dfmsmall, comparison = TRUE))
+    expect_silent(textplot_wordcloud(dfmsmall, color = 1:5))
+    expect_warning(
+        textplot_wordcloud(dfmsmall, scale = 1:4),
+        "scale is deprecated"
+    )
+    expect_warning(
+        textplot_wordcloud(dfmsmall, random.order = TRUE),
+        "random.order is deprecated; use random_order instead"
+    )
+    expect_warning(
+        textplot_wordcloud(dfmsmall, max.words = 10),
+        "max.words is deprecated; use max_words instead"
+    )
+    
     dev.off()
     expect_error(
         textplot_wordcloud(testdfm, comparison = TRUE),

--- a/tests/testthat/test-textplot_network.R
+++ b/tests/testthat/test-textplot_network.R
@@ -1,7 +1,7 @@
 context("test textplot_network.R")
 
 test_that("test textplot_network", {
-    skip_on_os("linux")
+    #skip_on_os("linux")
     txt <- "A D A C E A D F E B A C E D"
     testfcm <- fcm(txt, context = "window", window = 3, tri = FALSE)
     testdfm <- dfm(txt)
@@ -17,7 +17,7 @@ test_that("test textplot_network", {
 
 
 test_that("test textplot_network works with vectorlized argument", {
-    skip_on_os("linux")
+    #skip_on_os("linux")
     txt <- "A D A C E A D F E B A C E D"
     
     testfcm <- fcm(txt, context = "window", window = 3, tri = FALSE)


### PR DESCRIPTION
I decided to fill in some of the gaps in our code coverage. Not surprisingly, this revealed a few inconsistencies, which I fixed. Example: the verbose report for `dfm.tokens(x, stem = TRUE)`, which unlike the same option for `dfm.dfm()`, did not take the default dictionary from quanteda_options.

I also removed (or commented out) some functions that were untested, because they are no longer used.