### PR TITLE
Fix #1903

### DIFF
--- a/R/dfm-classes.R
+++ b/R/dfm-classes.R
@@ -42,7 +42,12 @@ setClass("dfm",
 #' @rdname dfm-class
 setMethod("t",
           signature = (x = "dfm"),
-          function(x) as.dfm(t(as(x, "dgCMatrix"))))
+          function(x) { 
+              dnames <- names(x@Dimnames)
+              x <- as.dfm(t(as(x, "dgCMatrix")))
+              names(x@Dimnames) <- rev(dnames)
+              return(x)
+          })
 
 #' @method colSums dfm
 #' @rdname dfm-class

--- a/tests/testthat/test-dfm.R
+++ b/tests/testthat/test-dfm.R
@@ -1099,3 +1099,12 @@ test_that("dfm_sort works as expected", {
 #         fixed = TRUE
 #     )
 # })
+
+test_that("test dfm transpose for #1903", {
+    dfmat <- dfm(c(d1 = "one two three", d2 = "two two three"))
+    expect_equal(
+        names(dimnames(t(dfmat))),
+        c("features", "docs")
+    )
+})
+

--- a/tests/testthat/test-dfm.R
+++ b/tests/testthat/test-dfm.R
@@ -1102,9 +1102,22 @@ test_that("dfm_sort works as expected", {
 
 test_that("test dfm transpose for #1903", {
     dfmat <- dfm(c(d1 = "one two three", d2 = "two two three"))
+    dfmat_t <- t(dfmat)
     expect_equal(
-        names(dimnames(t(dfmat))),
+        names(dimnames(dfmat_t)),
         c("features", "docs")
+    )
+    expect_equal(
+        docnames(dfmat_t), 
+        c("one", "two", "three")
+    )
+    expect_equal(
+        dfmat_t@docvars$docname_,
+        c("one", "two", "three")
+    )
+    expect_equal(
+        names(dfmat_t@meta),
+        c("system", "object", "user")
     )
 })
 


### PR DESCRIPTION
Exchanges the `names(dimnames)` when a dfm is transposed, adds a test.

I initially just made the `t(dfmat)` a plain dgCMatrix but this caused all sorts of things to break, so better to use the current approach and simply fix the dimname names. K.I.S.S.