### PR TITLE
Fix #1918

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: quanteda
-Version: 2.0.1
+Version: 2.0.2
 Title: Quantitative Analysis of Textual Data
 Description: A fast, flexible, and comprehensive framework for 
     quantitative text analysis in R.  Provides functionality for corpus management,
@@ -174,6 +174,6 @@ Collate:
     'utils.R'
     'wordstem.R'
     'zzz.R'
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.0
 SystemRequirements: C++11
 Roxygen: list(markdown = TRUE)

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,14 @@
 
 ## Changes
 
+## Bug fixes and stability enhancements
+
+* `convert(x, to = "data.frame")` now outputs the first column as "doc_id" rather than "document" since "document" is a commonly occurring term in many texts. (#1918)
+
+# quanteda 2.0.1
+
+## Changes
+
 * Moved `data_corpus_irishbudget2010` and `data_corpus_dailnoconf1991` to the **quanteda.textmodels** package.
 * Em dashes and double dashes between words, whether surrounded by a space or not, are now converted to " - " to distinguish them from infix hyphens.  (#1889)
 * Verbose output for dfm and tokens creation is now corrected and more consistent.  (#1894)

--- a/R/dfm-classes.R
+++ b/R/dfm-classes.R
@@ -132,20 +132,20 @@ as.matrix.dfm <- function(x, ...) {
 #'   data.frame, defaults `docnames(x)`.  Set to `NULL` to exclude.
 #' @inheritParams base::as.data.frame
 #' @inheritParams base::data.frame
+#' @inheritParams convert
 #' @param ... unused
 #' @method as.data.frame dfm
 #' @keywords internal dfm
 #' @seealso [convert()]
 #' @export
 as.data.frame.dfm <- function(x, row.names = NULL, ..., document = docnames(x),
-                              check.names = FALSE) {
+                              docid_field = "doc_id", check.names = FALSE) {
     .Deprecated("convert(x, to = \"data.frame\")")
-    if (!(is.character(document) || is.null(document)))
-        stop("document must be character or NULL")
-    df <- data.frame(as.matrix(x), row.names = row.names,
-                     check.names = check.names)
-    if (!is.null(document)) df <- cbind(document, df, stringsAsFactors = FALSE)
-    df
+    result <- dfm2dataframe(x, row.names = NULL, ..., document = document,
+                            docid_field = docid_field, check.names = check.names)
+    if (!is.null(row.names))
+        row.names(result) <- row.names
+    result
 }
 
 

--- a/man/as.data.frame.dfm.Rd
+++ b/man/as.data.frame.dfm.Rd
@@ -9,6 +9,7 @@
   row.names = NULL,
   ...,
   document = docnames(x),
+  docid_field = "doc_id",
   check.names = FALSE
 )
 }
@@ -22,6 +23,9 @@
 
 \item{document}{optional first column of mode \code{character} in the
 data.frame, defaults \code{docnames(x)}.  Set to \code{NULL} to exclude.}
+
+\item{docid_field}{character; the name of the column containing document
+names used when \code{to = "data.frame"}.  Unused for other conversions.}
 
 \item{check.names}{logical.  If \code{TRUE} then the names of the
     variables in the data frame are checked to ensure that they are

--- a/man/convert.Rd
+++ b/man/convert.Rd
@@ -14,6 +14,7 @@ convert(x, to, ...)
     "tripletlist"),
   docvars = NULL,
   omit_empty = TRUE,
+  docid_field = "doc_id",
   ...
 )
 
@@ -56,6 +57,9 @@ documents with non-zero counts.  Only affects the "stm" format.}
 from the converted dfm. This is required for some formats (such as STM)
 that do not accept empty documents.  Only used when \code{to = "lda"} or
 \code{to = "topicmodels"}.  For \code{to = "stm"} format, \verb{omit_empty`` is always }TRUE`.}
+
+\item{docid_field}{character; the name of the column containing document
+names used when \code{to = "data.frame"}.  Unused for other conversions.}
 
 \item{pretty}{adds indentation whitespace to JSON output. Can be TRUE/FALSE or a number specifying the number of spaces to indent. See \code{\link[jsonlite]{prettify}}}
 }

--- a/tests/testthat/test-as.dfm.R
+++ b/tests/testthat/test-as.dfm.R
@@ -102,7 +102,7 @@ test_that("as.data.frame for dfm objects", {
     d <- data_dfm_lbgexample[, 1:5]
     expect_equal(
         suppressWarnings(as.data.frame(d)),
-        data.frame(document = docnames(d), as.matrix(d), stringsAsFactors = FALSE, row.names = NULL)
+        data.frame(doc_id = docnames(d), as.matrix(d), stringsAsFactors = FALSE, row.names = NULL)
     )
     expect_equal(
         suppressWarnings(as.data.frame(d, document = NULL)),
@@ -110,7 +110,7 @@ test_that("as.data.frame for dfm objects", {
     )
     expect_equal(
         suppressWarnings(as.data.frame(d, row.names = docnames(d))),
-        data.frame(document = docnames(d), as.matrix(d), stringsAsFactors = FALSE, row.names = docnames(d))
+        data.frame(doc_id = docnames(d), as.matrix(d), stringsAsFactors = FALSE, row.names = docnames(d))
     )
     expect_error(
         suppressWarnings(as.data.frame(d, document = TRUE)),
@@ -124,13 +124,20 @@ test_that("dfm2dataframe same as as.data.frame.dfm", {
         suppressWarnings(as.data.frame(d)),
         convert(d, to = "data.frame")
     )
+    expect_identical(
+        suppressWarnings(as.data.frame(d, document = NULL, 
+                                       row.names = docnames(d))),
+        data.frame(as.matrix(d), stringsAsFactors = FALSE, 
+                   row.names = docnames(d))
+    )
     expect_equal(
         quanteda:::dfm2dataframe(d, document = NULL),
         data.frame(as.matrix(d), stringsAsFactors = FALSE, row.names = NULL)
     )
     expect_equal(
         quanteda:::dfm2dataframe(d, row.names = docnames(d)),
-        data.frame(document = docnames(d), as.matrix(d), stringsAsFactors = FALSE, row.names = docnames(d))
+        data.frame(doc_id = docnames(d), as.matrix(d), stringsAsFactors = FALSE, 
+                   row.names = docnames(d))
     )
     expect_error(
         quanteda:::dfm2dataframe(d, document = TRUE),
@@ -145,19 +152,21 @@ test_that("as.data.frame.dfm handles irregular feature names correctly", {
                  dictionary = dictionary(list("字" = "a", "spe cial" = "the", 
                                               "飛機" = "if", "spec+ial" = "of")))
     expect_equal(
-        names(convert(mydfm, to = "data.frame")),
+        names(convert(mydfm, to = "data.frame", docid_field = "document")),
         c("document", "字", "spe cial", "飛機", "spec+ial")
     )
     expect_equal(
-        suppressWarnings(names(as.data.frame(mydfm, check.names = TRUE))),
+        suppressWarnings(names(as.data.frame(mydfm, check.names = TRUE, 
+                                             docid_field = "document"))),
         c("document", "字", "spe.cial", "飛機", "spec.ial")
     )
     expect_equal(
-        names(quanteda:::dfm2dataframe(mydfm)),
+        names(quanteda:::dfm2dataframe(mydfm, docid_field = "document")),
         c("document", "字", "spe cial", "飛機", "spec+ial")
     )
     expect_equal(
-        names(quanteda:::dfm2dataframe(mydfm, check.names = TRUE)),
+        names(quanteda:::dfm2dataframe(mydfm, check.names = TRUE, 
+                                       docid_field = "document")),
         c("document", "字", "spe.cial", "飛機", "spec.ial")
     )
 })

--- a/tests/testthat/test-convert.R
+++ b/tests/testthat/test-convert.R
@@ -342,3 +342,36 @@ test_that("convert.corpus works", {
 
     })
 
+test_that("convert to = data.frame works", {
+    dfmat <- dfm(c(d1 = "this is a fine document",
+                   d2 = "this is a fine feature"))
+    expect_identical(
+        convert(dfmat, to = "data.frame"),
+        data.frame(
+            doc_id = c("d1", "d2"),
+            this = c(1, 1),
+            is = c(1, 1),
+            a = c(1, 1),
+            fine = c(1, 1),
+            document = c(1, 0),
+            feature = c(0, 1), stringsAsFactors = FALSE
+        )
+    )
+    expect_identical(
+      convert(dfmat, to = "data.frame", docid_field = "__document"),
+      data.frame(
+        "__document" = c("d1", "d2"),
+        this = c(1, 1),
+        is = c(1, 1),
+        a = c(1, 1),
+        fine = c(1, 1),
+        document = c(1, 0),
+        feature = c(0, 1), 
+        stringsAsFactors = FALSE, check.names = FALSE
+      )
+    )
+    expect_error(
+        convert(dfmat, to = "data.frame", docid_field = "document"),
+        "'document' matches a feature in the dfm; use a different docid_field value"
+    )
+})


### PR DESCRIPTION
- Adds a `docid_field = "doc_id"` as the default to `convert(x, to = "data.frame")`
- Checks for collisions with the `docid_field` and a named feature
- Re-implements the deprecated `as.data.frame.dfm()` to use the same internal function as `convert(x, to = "data.frame")`
- Updates tests

Fixes #1918