### PR TITLE
Fix special

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: quanteda
-Version: 2.0.1
+Version: 2.0.2
 Title: Quantitative Analysis of Textual Data
 Description: A fast, flexible, and comprehensive framework for 
     quantitative text analysis in R.  Provides functionality for corpus management,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -174,6 +174,6 @@ Collate:
     'utils.R'
     'wordstem.R'
     'zzz.R'
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.0
 SystemRequirements: C++11
 Roxygen: list(markdown = TRUE)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# quanteda 2.0.2
+
+## Changes
+
+* Fixed a performance issue causing slowdowns in tokenizing (using the default `what = "word"`) corpora with large numbers of documents that contain social media tags and URLs that needed to be preserved (such a large corpus of Tweets).
+
+
 # quanteda 2.0.1
 
 ## Changes

--- a/man/data-internal.Rd
+++ b/man/data-internal.Rd
@@ -7,7 +7,11 @@
 \alias{data_int_syllables}
 \alias{data_char_wordlists}
 \title{Internal data sets}
-\format{An object of class \code{integer} of length 133245.}
+\format{
+An object of class \code{integer} of length 133245.
+
+An object of class \code{list} of length 2.
+}
 \usage{
 data_int_syllables
 

--- a/man/data_char_sampletext.Rd
+++ b/man/data_char_sampletext.Rd
@@ -4,7 +4,9 @@
 \name{data_char_sampletext}
 \alias{data_char_sampletext}
 \title{A paragraph of text for testing various text-based functions}
-\format{character vector with one element}
+\format{
+character vector with one element
+}
 \source{
 Dáil Éireann Debate,
 \href{http://oireachtasdebates.oireachtas.ie/debates\%20authoring/debateswebpack.nsf/takes/dail2011120700006?opendocument}{Financial Resolution No. 13: General (Resumed).}

--- a/man/data_char_ukimmig2010.Rd
+++ b/man/data_char_ukimmig2010.Rd
@@ -4,7 +4,9 @@
 \name{data_char_ukimmig2010}
 \alias{data_char_ukimmig2010}
 \title{Immigration-related sections of 2010 UK party manifestos}
-\format{A named character vector of plain ASCII texts}
+\format{
+A named character vector of plain ASCII texts
+}
 \usage{
 data_char_ukimmig2010
 }

--- a/man/data_corpus_inaugural.Rd
+++ b/man/data_corpus_inaugural.Rd
@@ -4,12 +4,14 @@
 \name{data_corpus_inaugural}
 \alias{data_corpus_inaugural}
 \title{US presidential inaugural address texts}
-\format{a \link{corpus} object with the following docvars:
+\format{
+a \link{corpus} object with the following docvars:
 \itemize{
 \item \code{Year} a four-digit integer year
 \item \code{President} character; President's last name
 \item \code{FirstName} character; President's first name (and possibly middle initial)
-}}
+}
+}
 \source{
 \url{https://archive.org/details/Inaugural-Address-Corpus-1789-2009} and
 \url{http://www.presidency.ucsb.edu/inaugurals.php}.

--- a/man/data_dfm_lbgexample.Rd
+++ b/man/data_dfm_lbgexample.Rd
@@ -5,7 +5,9 @@
 \alias{data_dfm_lbgexample}
 \alias{data_dfm_LBGexample}
 \title{dfm from data in Table 1 of Laver, Benoit, and Garry (2003)}
-\format{A \link{dfm} object with 6 documents and 37 features.}
+\format{
+A \link{dfm} object with 6 documents and 37 features.
+}
 \usage{
 data_dfm_lbgexample
 }

--- a/man/data_dictionary_LSD2015.Rd
+++ b/man/data_dictionary_LSD2015.Rd
@@ -4,13 +4,15 @@
 \name{data_dictionary_LSD2015}
 \alias{data_dictionary_LSD2015}
 \title{Lexicoder Sentiment Dictionary (2015)}
-\format{A \link{dictionary} of four keys containing glob-style \link[=valuetype]{pattern matches}.
+\format{
+A \link{dictionary} of four keys containing glob-style \link[=valuetype]{pattern matches}.
 \describe{
 \item{\code{negative}}{2,858 word patterns indicating negative sentiment}
 \item{\code{positive}}{1,709 word patterns indicating positive sentiment}
 \item{\code{neg_positive}}{1,721 word patterns indicating a positive word preceded by a negation (used to convey negative sentiment)}
 \item{\code{neg_negative}}{2,860 word patterns indicating a negative word preceded by a negation (used to convey positive sentiment)}
-}}
+}
+}
 \usage{
 data_dictionary_LSD2015
 }


### PR DESCRIPTION
This PR is do address the [huge slowdown](https://stackoverflow.com/questions/60987472/building-document-feature-matrix-quanteda-with-twitter-data-takes-only-a-few-m) caused by the functions to preserve and restore URLs and tags. 

It was taking over 500 sec to tokenize 100k twitter posts, but it becomes 10 sec for 100k and 100 sec for 1m with this patch. 

```
> microbenchmark::microbenchmark(
+     "10k" = tokens(head(corp$text, 10000)),
+     "100k" = tokens(head(corp$text, 100000)),
+     "1m" = tokens(head(corp$text, 1000000)),
+     times = 5, unit = "s"
+ )
Unit: seconds
 expr        min         lq      mean      median          uq       max neval
  10k  0.8025744  0.8268469  1.001053   0.8357416   0.8714707   1.66863     5
 100k  7.0850760  9.3038414  9.273580   9.4945126  10.1048823  10.37959     5
   1m 94.0671629 96.4609353 98.565605 100.4316214 100.7799006 101.08841     5
```

We might need to update CRAN...