### PR TITLE
Dev non ascii tags

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ## Changes
 
 * Fixed a performance issue causing slowdowns in tokenizing (using the default `what = "word"`) corpora with large numbers of documents that contain social media tags and URLs that needed to be preserved (such a large corpus of Tweets).
+* Updated the (default) "word" tokenizer to preserve hashtags and usernames better with non-ASCII text, and made these patterns user-configurable in `quanteda_options()`.  The following are now preserved: `#政治` as well as Weibo-style hashtags such as `#英国首相#".
 
 
 # quanteda 2.0.1

--- a/R/quanteda_options.R
+++ b/R/quanteda_options.R
@@ -27,7 +27,9 @@
 #' created by matrix factorization} 
 #' \item{`language_stemmer`}{character; language option for [char_wordstem], 
 #' [tokens_wordstem], and [dfm_wordstem]} 
-#' }
+#' \item{`pattern_hashtag`}{character; regex pattern to avoid segmenting hashtags} 
+#' \item{`pattern_username`}{character; regex pattern to avoid segmenting social
+#' media usernames and email addresses} }
 #' @return When called using a `key = value` pair (where `key` can be
 #' a label or quoted character name)), the option is set and `TRUE` is
 #' returned invisibly.
@@ -151,6 +153,8 @@ get_options_default <- function(){
                  base_docname = "text",
                  base_featname = "feat",
                  base_compname = "comp",
-                 language_stemmer = "english")
+                 language_stemmer = "english",
+                 pattern_hashtag = "#\\w+|#\\w+#",
+                 pattern_username = "@")
     return(opts)
 }

--- a/R/quanteda_options.R
+++ b/R/quanteda_options.R
@@ -154,7 +154,7 @@ get_options_default <- function(){
                  base_featname = "feat",
                  base_compname = "comp",
                  language_stemmer = "english",
-                 pattern_hashtag = "#\\w+|#\\w+#",
+                 pattern_hashtag = "#\\w+#?",
                  pattern_username = "@")
     return(opts)
 }

--- a/R/quanteda_options.R
+++ b/R/quanteda_options.R
@@ -27,9 +27,9 @@
 #' created by matrix factorization} 
 #' \item{`language_stemmer`}{character; language option for [char_wordstem], 
 #' [tokens_wordstem], and [dfm_wordstem]} 
-#' \item{`pattern_hashtag`}{character; regex pattern to avoid segmenting hashtags} 
-#' \item{`pattern_username`}{character; regex pattern to avoid segmenting social
-#' media usernames and email addresses} }
+#' \item{`pattern_hashtag`, `pattern_username`}{character; regex patterns for
+#' (social media) hashtags and usernames respectively, used to avoid segmenting
+#' these in the default internal "word" tokenizer}}
 #' @return When called using a `key = value` pair (where `key` can be
 #' a label or quoted character name)), the option is set and `TRUE` is
 #' returned invisibly.

--- a/R/tokenizers.R
+++ b/R/tokenizers.R
@@ -56,7 +56,8 @@ preserve_special <- function(x, split_hyphens = TRUE, split_tags = TRUE, verbose
     x <- as.character(x)
     
     hyphen <- "[\\p{Pd}]"
-    tag <- "[#@]\\w+"
+    username <- "@[a-zA-Z0-9_]{1,15}"
+    hashtag <- "#\\w+"
     url <- "https?:\\/\\/(www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-z]{2,4}\\b([-a-zA-Z0-9@:%_\\+.~#?&//=]*)"
     
     regex <- character()
@@ -66,7 +67,7 @@ preserve_special <- function(x, split_hyphens = TRUE, split_tags = TRUE, verbose
     }
     if (!split_tags) {
         if (verbose) catm(" ...preserving social media tags (#, @)\n")
-        regex <- c(regex, tag)
+        regex <- c(regex, username, hashtag)
     }
     regex <- c(regex, url)
     

--- a/R/tokenizers.R
+++ b/R/tokenizers.R
@@ -56,7 +56,7 @@ preserve_special <- function(x, split_hyphens = TRUE, split_tags = TRUE, verbose
     x <- as.character(x)
     
     hyphen <- "[\\p{Pd}]"
-    tag <- "[#@]"
+    tag <- "[#@]\\w+"
     url <- "https?:\\/\\/(www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-z]{2,4}\\b([-a-zA-Z0-9@:%_\\+.~#?&//=]*)"
     
     regex <- character()
@@ -102,11 +102,11 @@ restore_special <- function(x, special) {
     pos <- fastmatch::fmatch(names(index), special)
     for (i in seq_along(index)) {
         types[index[[i]]] <- stri_replace_all_fixed(
-                                types[index[[i]]], 
-                                special[pos[i]], 
-                                names(special)[pos[i]],
-                                vectorize_all = FALSE
-                             )
+            types[index[[i]]], 
+            special[pos[i]], 
+            names(special)[pos[i]],
+            vectorize_all = FALSE
+        )
     }
     
     if (!identical(types, types(x))) {

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -385,6 +385,7 @@ vol
 Vol
 Volk
 Wei
+Weibo
 Werman
 Wien
 Wilks

--- a/man/quanteda_options.Rd
+++ b/man/quanteda_options.Rd
@@ -52,7 +52,9 @@ through an operation that adds features}
 created by matrix factorization}
 \item{\code{language_stemmer}}{character; language option for \link{char_wordstem},
 \link{tokens_wordstem}, and \link{dfm_wordstem}}
-}
+\item{\code{pattern_hashtag}}{character; regex pattern to avoid segmenting hashtags}
+\item{\code{pattern_username}}{character; regex pattern to avoid segmenting social
+media usernames and email addresses} }
 }
 \examples{
 (opt <- quanteda_options())

--- a/man/quanteda_options.Rd
+++ b/man/quanteda_options.Rd
@@ -52,9 +52,9 @@ through an operation that adds features}
 created by matrix factorization}
 \item{\code{language_stemmer}}{character; language option for \link{char_wordstem},
 \link{tokens_wordstem}, and \link{dfm_wordstem}}
-\item{\code{pattern_hashtag}}{character; regex pattern to avoid segmenting hashtags}
-\item{\code{pattern_username}}{character; regex pattern to avoid segmenting social
-media usernames and email addresses} }
+\item{\code{pattern_hashtag}, \code{pattern_username}}{character; regex patterns for
+(social media) hashtags and usernames respectively, used to avoid segmenting
+these in the default internal "word" tokenizer}}
 }
 \examples{
 (opt <- quanteda_options())

--- a/tests/testthat/test-tokens.R
+++ b/tests/testthat/test-tokens.R
@@ -1075,7 +1075,7 @@ test_that("tokenizing Japanese with URLs works", {
     )
 })
 
-test_that("tokenizing Japanese hashtags", {
+test_that("tokenizing Japanese hashtags works", {
     txt <- c(d1 = "オリンピック延期決定！ #政治 #安部政権")
     expect_identical(
         as.list(tokens(txt, what = "word")),
@@ -1083,7 +1083,24 @@ test_that("tokenizing Japanese hashtags", {
     )
 })
 
-test_that("preserve_special works", {
+test_that("emails address is preserved", {
+    txt <- c(d1 = "support@quanteda.io @quanteda")
+    expect_identical(
+        as.list(tokens(txt, what = "word")),
+        list(d1 = c("support@quanteda.io", "@quanteda"))
+    )
+})
+
+test_that("longer tags are preserved", {
+    txt <- c(d1 = "#quanteda #q-x #q_y #q")
+    expect_identical(
+        as.list(tokens(txt, what = "word")),
+        list(d1 = c("#quanteda", "#q-x", "#q_y", "#q"))
+    )
+})
+
+
+tet_that("preold serve_special works", {
     txt <- "This @username used this #hashtag."
     expect_identical(
         quanteda:::preserve_special1(txt, split_tags = FALSE),

--- a/tests/testthat/test-tokens.R
+++ b/tests/testthat/test-tokens.R
@@ -1075,6 +1075,14 @@ test_that("tokenizing Japanese with URLs works", {
     )
 })
 
+test_that("tokenizing Japanese hashtags", {
+    txt <- c(d1 = "オリンピック延期決定！ #政治 #安部政権")
+    expect_identical(
+        as.list(tokens(txt, what = "word")),
+        list(d1 = c("オリンピック", "延期", "決定", "！", "#政治", "#安部政権"))
+    )
+})
+
 test_that("preserve_special works", {
     txt <- "This @username used this #hashtag."
     expect_identical(

--- a/tests/testthat/test-tokens.R
+++ b/tests/testthat/test-tokens.R
@@ -1100,10 +1100,10 @@ test_that("emails address is preserved", {
 })
 
 test_that("longer tags are preserved", {
-    txt <- c(d1 = "#quanteda #q-x #q_y #q")
+    txt <- c(d1 = "#quanteda #q-x #q_y #q")q100 #
     expect_identical(
         as.list(tokens(txt, what = "word")),
-        list(d1 = c("#quanteda", "#q-x", "#q_y", "#q"))
+        list(d1 = c("#quanteda", "#q-x", "#q_y", "#q"#q100", "))
     )
 })
 

--- a/tests/testthat/test-tokens.R
+++ b/tests/testthat/test-tokens.R
@@ -1099,11 +1099,11 @@ test_that("emails address is preserved", {
     )
 })
 
-test_that("longer tags are preserved", {
-    txt <- c(d1 = "#quanteda #q-x #q_y #q")q100 #
+test_that("hashtags are preserved", {
+    txt <- c(d1 = "#quanteda #q-x #q_y #q100 #q")
     expect_identical(
         as.list(tokens(txt, what = "word")),
-        list(d1 = c("#quanteda", "#q-x", "#q_y", "#q"#q100", "))
+        list(d1 = c("#quanteda", "#q-x", "#q_y", "#q100", "#q"))
     )
 })
 

--- a/tests/testthat/test-tokens.R
+++ b/tests/testthat/test-tokens.R
@@ -1075,11 +1075,19 @@ test_that("tokenizing Japanese with URLs works", {
     )
 })
 
-test_that("tokenizing Japanese hashtags works", {
+test_that("Non-ASCII hashtags are preserved", {
     txt <- c(d1 = "オリンピック延期決定！ #政治 #安部政権")
     expect_identical(
         as.list(tokens(txt, what = "word")),
         list(d1 = c("オリンピック", "延期", "決定", "！", "#政治", "#安部政権"))
+    )
+})
+
+test_that("Weibo-style hashtags are preserved", {
+    txt <- c(d1 = "#英国首相#仍在ICU")
+    expect_identical(
+        as.list(tokens(txt, what = "word")),
+        list(d1 = c("#英国首相#", "仍在", "ICU"))
     )
 })
 
@@ -1099,8 +1107,7 @@ test_that("longer tags are preserved", {
     )
 })
 
-
-tet_that("preold serve_special works", {
+test_that("old preserve_special works", {
     txt <- "This @username used this #hashtag."
     expect_identical(
         quanteda:::preserve_special1(txt, split_tags = FALSE),

--- a/tests/testthat/test-tokens_segment.R
+++ b/tests/testthat/test-tokens_segment.R
@@ -126,39 +126,43 @@ test_that("tokens_segment works when removing punctuation match, remove_delimite
 
 
 test_that("tokens_segment works with tags", {
-    corp <- corpus(c(d1 = "##TEST One two ##TEST2 Three",
-                     d2 = "##TEST3 Four"),
+    corp <- corpus(c(d1 = "__TEST__ One two __TEST2__ Three",
+                     d2 = "__TEST3__ Four"),
                    docvars = data.frame(test = c("A", "B"), stringsAsFactors = FALSE))
     toks <- tokens(corp, what = "word")
-    toks_seg1 <- tokens_segment(toks, "##[A-Z0-9]+", valuetype = "regex",
+    toks_seg1 <- tokens_segment(toks, "__[A-Z0-9]+__", valuetype = "regex",
                                 pattern_position = "before", extract_pattern = TRUE, use_docvars = TRUE)
     vars1 <- docvars(toks_seg1)
     expect_equal(vars1$test, c("A", "A", "B"))
-    expect_equal(vars1$pattern, c("##TEST", "##TEST2", "##TEST3"))
+    expect_equal(vars1$pattern, c("__TEST__", "__TEST2__", "__TEST3__"))
     expect_equal(as.list(toks_seg1),
                  list(d1.1 = c("One", "two"), d1.2 = "Three", d2.1 = "Four"))
 
-    toks_seg2 <- tokens_segment(toks, "##[A-Z0-9]+", valuetype = "regex",
+    toks_seg2 <- tokens_segment(toks, "__[A-Z0-9]+__", valuetype = "regex",
                                 pattern_position = "before", extract_pattern = FALSE, use_docvars = TRUE)
     vars2 <- docvars(toks_seg2)
     expect_equal(vars2$test, c("A", "A", "B"))
     expect_equal(vars2$pattern, NULL)
     expect_equal(as.list(toks_seg2),
-                 list(d1.1 = c("##TEST", "One", "two"), d1.2 = c("##TEST2", "Three"), d2.1 = c("##TEST3", "Four")))
+                 list(d1.1 = c("__TEST__", "One", "two"), 
+                      d1.2 = c("__TEST2__", "Three"), 
+                      d2.1 = c("__TEST3__", "Four")))
 
-    toks_seg3 <- tokens_segment(toks, "##[A-Z0-9]+", valuetype = "regex",
+    toks_seg3 <- tokens_segment(toks, "__[A-Z0-9]+__", valuetype = "regex",
                                 pattern_position = "before", extract_pattern = TRUE, use_docvars = FALSE)
     vars3 <- docvars(toks_seg3)
     expect_equal(vars3$test, NULL)
-    expect_equal(vars3$pattern, c("##TEST", "##TEST2", "##TEST3"))
+    expect_equal(vars3$pattern, c("__TEST__", "__TEST2__", "__TEST3__"))
     expect_equal(as.list(toks_seg3),
                  list(d1.1 = c("One", "two"), d1.2 = "Three", d2.1 = "Four"))
 
-    toks_seg4 <- tokens_segment(toks, "##[A-Z0-9]+", valuetype = "regex",
+    toks_seg4 <- tokens_segment(toks, "__[A-Z0-9]+__", valuetype = "regex",
                                 pattern_position = "before", extract_pattern = FALSE, use_docvars = FALSE)
     vars4 <- docvars(toks_seg4)
     expect_equal(vars4$test, NULL)
     expect_equal(vars4$pattern, NULL)
     expect_equal(as.list(toks_seg4),
-                 list(d1.1 = c("##TEST", "One", "two"), d1.2 = c("##TEST2", "Three"), d2.1 = c("##TEST3", "Four")))
+                 list(d1.1 = c("__TEST__", "One", "two"), 
+                      d1.2 = c("__TEST2__", "Three"), 
+                      d2.1 = c("__TEST3__", "Four")))
 })


### PR DESCRIPTION
Exploiting the faster hashtag substitution mechanism, this PR improves tokenization of CJK Twitter posts. 

In the master branch:
```r
> txt <- "オリンピック延期決定！ #政治 #安部政権"
> tokens(txt)
Tokens consisting of 1 document.
text1 :
[1] "オリンピック" "延期"         "決定"         "！"           "#"            "政治"        
[7] "#"            "安部"         "政権" 
```

In this branch:
```r
> txt <- "オリンピック延期決定！ #政治 #安部政権"
> tokens(txt)
Tokens consisting of 1 document.
text1 :
[1] "オリンピック" "延期"         "決定"         "！"           "#政治"        "#安部政権"   
```

There is no performance change (or slight improvement).

Comparison with `word1`
```
Unit: seconds
     expr       min        lq      mean    median        uq       max neval
      10k  1.058817  1.085394  1.180548  1.130297  1.252658  1.375576     5
     100k 10.406045 11.509046 12.447843 11.944009 12.407928 15.972186     5
  10k_old  1.082421  1.167748  1.282931  1.228341  1.336366  1.599778     5
 100k_old 11.863555 11.902684 12.993151 12.737702 14.171775 14.290039     5
```
Still scales roughly linearly:
```
Unit: seconds
 expr        min         lq       mean     median         uq        max neval
  10k   1.490942   1.491055   2.171197   2.205988   2.588344   3.079657     5
 100k  12.770201  13.364805  14.380449  14.044716  15.855056  15.867464     5
   1M 139.364657 142.821893 157.616990 154.833618 171.480653 179.584130     5
```   

However, I noticed that the function still does not work with Weibo, because its hashtags are different from Twitter. In the example [#英国首相仍在ICU但未使用呼吸机#](https://s.weibo.com/weibo?q=%23%E8%8B%B1%E5%9B%BD%E9%A6%96%E7%9B%B8%E4%BB%8D%E5%9C%A8ICU%E4%BD%86%E6%9C%AA%E4%BD%BF%E7%94%A8%E5%91%BC%E5%90%B8%E6%9C%BA%23) is the tag.

```
> txt <- "#英国首相仍在ICU但未使用呼吸机#首相好惨，希望都平安，疫情带来的变数太多了"
> tokens(txt)
Tokens consisting of 1 document.
text1 :
 [1] "#英国首相仍在ICU但未使用呼吸机#首相好惨" "，"                                     
 [3] "希望"                                    "都"                                     
 [5] "平安"                                    "，"                                     
 [7] "疫"                                      "情"                                     
 [9] "带来"                                    "的"                                     
[11] "变数"                                    "太多"                                   
[ ... and 1 more ]
```
For social media posts other than Twitter, we can allow user to provide custom patters (`#\\w+#` in this case). 

An example (from out tests for `tokens_segment`) of special tags is `##`. Double hashtags have been preserved because them were treated in the same way as single tashtags, but users should provide a pattern to preserve them (`##\\w+`).
```
> tokens("##TEST One two ##TEST2 Three")
Tokens consisting of 1 document.
text1 :
[1] "#"      "#TEST"  "One"    "two"    "#"      "#TEST2" "Three" 
```

