### PR TITLE
Replace NNBSP with regular space

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,9 @@
 * Added new methods `char_select()`, `char_keep()`, and `char_remove()` for easy manipulation of character vectors.
 * Added `dictionary_edit()` for easy, interactive editing of dictionaries, plus the functions `char_edit()` and `list_edit()` for editing character and list of character objects.
 
+## Bug fixes
+
+* Fixed a problem caused by Narrow No-Break Space (NNBSP) not being recognized as an intra-token space. (#1934)
 
 # quanteda 2.0.1
 

--- a/R/corpus.R
+++ b/R/corpus.R
@@ -142,12 +142,18 @@ corpus.character <- function(x, docnames = NULL, docvars = NULL,
     # normalize Unicode
     x <- stri_trans_nfc(x)
 
-    # convert the dreaded "curly quotes" to ASCII equivalents
+    # convert the dreaded "curly quotes" to ASCII equivalents;
+    # also:
+    # replace the troublesome Narrow No-Break Space (NNBSP)
+    # (see #1934 or https://github.com/gagolews/stringi/issues/377)
     x <- stri_replace_all_fixed(x,
                                 c("\u201C", "\u201D", "\u201F",
-                                  "\u2018", "\u201B", "\u2019"),
+                                  "\u2018", "\u201B", "\u2019",
+                                  "\u202F"),
                                 c("\"", "\"", "\"",
-                                  "\'", "\'", "\'"), vectorize_all = FALSE)
+                                  "\'", "\'", "\'",
+                                  " "), 
+                                vectorize_all = FALSE)
 
     # replace all hyphens with simple hyphen
     x <- stri_replace_all_fixed(x, c("\u2012", "\u2013", "\u2014", "\u2015", "\u2053"), "--", 

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -218,6 +218,7 @@ ngram
 ngrams
 Nimaldasan
 NLP
+NNBSP
 Nprep
 nscrabble
 nsentence

--- a/tests/testthat/test-tokens.R
+++ b/tests/testthat/test-tokens.R
@@ -1154,3 +1154,28 @@ test_that("remove_numbers functions correctly", {
         c("and", "and", "100bn", "20-year-old", "4ever", "gr8")
     )
 })
+
+test_that("all spaces are correctly recognized", {
+    txt <- c("one\u0020two",  # space
+             "one\u00A0two",  # No-Break Space (NBSP)
+             "one\u1680two",  # Ogham Space Mark
+             "one\u2000two",  # En Quad
+             "one\u2001two",  # Em Quad
+             "one\u2002two",  # En Space
+             "one\u2003two",  # Em Space
+             "one\u2003two",  # En Space
+             "one\u2003two",  # En Space
+             "one\u2004two",  # Three-Per-Em Space
+             "one\u2005two",  # Four-Per-Em Space
+             "one\u2006two",  # Six-Per-Em Space
+             "one\u2007two",  # Figure Space
+             "one\u2008two",  # Punctuation Space
+             "one\u2009two",  # Thin Space
+             "one\u200Atwo",  # Hair Space
+             "one\u202Ftwo",  # Narrow No-Break Space (NNBSP)
+             "one\u205Ftwo",  # Medium Mathematical Space (MMSP)
+             "one\u3000two"   # Ideographic Space
+    )
+    toks <- tokens(txt)
+    expect_true(all(lengths(toks) == 2))
+})


### PR DESCRIPTION
Replaces NNBSP with a regular space when a corpus is constructed.

Fixes #1934.
