### PR TITLE
Fixes tm VCorpus corpus constructor problem

### DIFF
--- a/R/corpus.R
+++ b/R/corpus.R
@@ -290,7 +290,6 @@ corpus.kwic <- function(x, split_context = TRUE, extract_keyword = TRUE, meta = 
 #' @rdname corpus
 #' @export
 corpus.Corpus <- function(x, ...) {
-
     unused_dots(...)
 
     if (inherits(x, what = "VCorpus")) {
@@ -301,7 +300,7 @@ corpus.Corpus <- function(x, ...) {
         docvars <- data.frame()
         for (i in seq_along(docs)) {
             doc <- docs[[i]]
-            txt <- c(txt, doc$content)
+            txt <- c(txt, paste(doc$content, collapse = "\n\n"))
             l <- lengths(doc$meta)
             meta <- rep(list(NA), length(l))
             names(meta) <- names(doc$meta)


### PR DESCRIPTION
When the texts were vectors rather than single character elements, then `corpus.Corpus()` read them in as individual elements.  This fixes that by concatenating the vectors of documents as paragraphs, separated by two `\n` characters.

This was causing a problem on a Factiva source import, for instance.