### PR TITLE
Ensure dfm_lookup returns dfm with all the keys

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@
 ## Bug fixes and stability enhancements
 
 * Stopped returning `NA` for non-existent features when `n` > `nfeat(x)` in `textstat_frequency(x, n)`.  (#1929)
+* Fixed a problem in `dfm_lookup()` and `tokens_lookup()` in which an error was caused when no dictionary key returned a single match (#1946).
 
 
 # quanteda 2.0.1

--- a/R/dfm_lookup.R
+++ b/R/dfm_lookup.R
@@ -132,10 +132,11 @@ dfm_lookup.dfm <- function(x, dictionary, levels = 1:5,
     } else {
         if (exclusive) {
             if (!is.null(nomatch)) {
-                result <- cbind(x[, 0], as.dfm(cbind(structure(ntoken(x),
-                                                               names = nomatch))))
+                result <- as.dfm(matrix(ntoken(x), ncol = 1,
+                                        dimnames = list(docnames(x), nomatch)))
             } else {
-                result <- x[, 0] # dfm without features
+                result <- make_null_dfm(document = docnames(x), 
+                                        feature = key)
             }
         } else {
             result <- x

--- a/tests/testthat/test-dfm_lookup.R
+++ b/tests/testthat/test-dfm_lookup.R
@@ -118,12 +118,19 @@ test_that("dfm_lookup works with multi-word keys, issue #704", {
 test_that("dfm_lookup return dfm even if no matches, issue #704", {
     dict <- dictionary(list('en'=list('foreign policy' = 'aaaaa', 'domestic politics' = 'bbbbb')))
     dfmt <- dfm(data_corpus_inaugural[1:5])
-    expect_equal(featnames(dfm_lookup(dfmt, dict)),
-                 c("en.foreign policy", "en.domestic politics"))
+    expect_identical(
+        featnames(dfm_lookup(dfmt, dict)),
+        c("en.foreign policy", "en.domestic politics")
+    )
+    expect_identical(
+        colSums(dfm_lookup(dfmt, dict)),
+        c("en.foreign policy" = 0, "en.domestic politics" = 0)
+    )
 })
 
 test_that("dfm_lookup return all features even if no matches when exclusive = FALSE, issue #116", {
-    dict <- dictionary(list('en'=list('foreign policy' = 'aaaaa', 'domestic politics' = 'bbbbb')))
+    dict <- dictionary(list("en" = list("foreign policy" = "aaaaa", 
+                                        "domestic politics" = "bbbbb")))
     testdfm <- dfm(data_corpus_inaugural[1:5])
     expect_equivalent(testdfm, dfm_lookup(testdfm, dict, exclusive = FALSE))
 })

--- a/tests/testthat/test-dfm_lookup.R
+++ b/tests/testthat/test-dfm_lookup.R
@@ -117,8 +117,9 @@ test_that("dfm_lookup works with multi-word keys, issue #704", {
 
 test_that("dfm_lookup return dfm even if no matches, issue #704", {
     dict <- dictionary(list('en'=list('foreign policy' = 'aaaaa', 'domestic politics' = 'bbbbb')))
-    testdfm <- dfm(data_corpus_inaugural[1:5])
-    expect_true(is.dfm(dfm_lookup(testdfm, dict)))
+    dfmt <- dfm(data_corpus_inaugural[1:5])
+    expect_equal(featnames(dfm_lookup(dfmt, dict)),
+                 c("en.foreign policy", "en.domestic politics"))
 })
 
 test_that("dfm_lookup return all features even if no matches when exclusive = FALSE, issue #116", {

--- a/tests/testthat/test-tokens_lookup.R
+++ b/tests/testthat/test-tokens_lookup.R
@@ -503,3 +503,9 @@ test_that("dictionary nested_scope is independent of orders", {
     )
 })
 
+test_that("tokens_lookup return tokens even if no matches", {
+    dict <- dictionary(list('en'=list('foreign policy' = 'aaaaa', 'domestic politics' = 'bbbbb')))
+    toks <- tokens(data_corpus_inaugural[1:5])
+    expect_equal(types(tokens_lookup(toks, dict)),
+                 c("en.foreign policy", "en.domestic politics"))
+})

--- a/tests/testthat/test-tokens_lookup.R
+++ b/tests/testthat/test-tokens_lookup.R
@@ -504,8 +504,16 @@ test_that("dictionary nested_scope is independent of orders", {
 })
 
 test_that("tokens_lookup return tokens even if no matches", {
-    dict <- dictionary(list('en'=list('foreign policy' = 'aaaaa', 'domestic politics' = 'bbbbb')))
+    dict <- dictionary(list("en" = list("foreign policy" = "aaaaa", 
+                                        "domestic politics" = "bbbbb")))
     toks <- tokens(data_corpus_inaugural[1:5])
-    expect_equal(types(tokens_lookup(toks, dict)),
-                 c("en.foreign policy", "en.domestic politics"))
+    expect_identical(
+        types(tokens_lookup(toks, dict)),
+        c("en.foreign policy", "en.domestic politics")
+    )
+    expect_identical(
+        lengths(tokens_lookup(toks, dict)),
+        c("1789-Washington" = 0L, "1793-Washington" = 0L, "1797-Adams" = 0L,
+          "1801-Jefferson"  = 0L, "1805-Jefferson" = 0L)
+    )
 })


### PR DESCRIPTION
This is a major bug. `dfm_lookup()` returns a dfm without columns when there is no matches.
```r
> toks <- tokens(c("aaaa aaaa", "bbbb"))
> dfmt <- dfm(toks)
> dfm(tokens_lookup(toks, dict)) # Correct
Document-feature matrix of: 2 documents, 2 features (100.0% sparse).
       features
docs    key1 key2
  text1    0    0
  text2    0    0
> dfm_lookup(dfmt, dict) # Not (not features)
Document-feature matrix of: 2 documents, 0 features.
```