### PR TITLE
Allow startpos and endpos to be a vector

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -73,8 +73,8 @@ qatd_cpp_tokens_segment <- function(texts_, types_, patterns_, remove, position)
     .Call(`_quanteda_qatd_cpp_tokens_segment`, texts_, types_, patterns_, remove, position)
 }
 
-qatd_cpp_tokens_select <- function(texts_, types_, words_, mode, padding, window_left, window_right, pos_from, pos_to) {
-    .Call(`_quanteda_qatd_cpp_tokens_select`, texts_, types_, words_, mode, padding, window_left, window_right, pos_from, pos_to)
+qatd_cpp_tokens_select <- function(texts_, types_, words_, mode, padding, window_left, window_right, pos_from_, pos_to_) {
+    .Call(`_quanteda_qatd_cpp_tokens_select`, texts_, types_, words_, mode, padding, window_left, window_right, pos_from_, pos_to_)
 }
 
 qatd_cpp_is_grouped_numeric <- function(values_, groups_) {

--- a/R/tokens_select.R
+++ b/R/tokens_select.R
@@ -20,12 +20,12 @@
 #'   the pre- and post-selected tokens, for instance if a window of adjacency
 #'   needs to be computed.
 #' @param window integer of length 1 or 2; the size of the window of tokens
-#'   adjacent to `pattern` that will be selected. The window is symmetric
-#'   unless a vector of two elements is supplied, in which case the first
-#'   element will be the token length of the window before `pattern`, and
-#'   the second will be the token length of the window after `pattern`.
-#'   The default is `0`, meaning that only the pattern matched token(s) are
-#'   selected, with no adjacent terms.
+#'   adjacent to `pattern` that will be selected. The window is symmetric unless
+#'   a vector of two elements is supplied, in which case the first element will
+#'   be the token length of the window before `pattern`, and the second will be
+#'   the token length of the window after `pattern`. The default is `0`, meaning
+#'   that only the pattern matched token(s) are selected, with no adjacent
+#'   terms.
 #'
 #'   Terms from overlapping windows are never double-counted, but simply
 #'   returned in the pattern match. This is because `tokens_select` never
@@ -34,10 +34,13 @@
 #'   matching starts and ends, where 1 is the first token in a document.  For
 #'   negative indexes, counting starts at the ending token of the document, so
 #'   that -1 denotes the last token in the document, -2 the second to last, etc.
+#'   When the length of the vector is equal to `ndoc`, tokens in corresponding
+#'   positions will be selected. Otherwise, only the first element in the vector
+#'   is used.
 #' @param min_nchar,max_nchar optional numerics specifying the minimum and
 #'   maximum length in characters for tokens to be removed or kept; defaults are
-#'   `NULL` for no limits.  These are applied after (and hence, in addition
-#'   to) any selection based on pattern matches.
+#'   `NULL` for no limits.  These are applied after (and hence, in addition to)
+#'   any selection based on pattern matches.
 #' @return a [tokens] object with tokens selected or removed based on their
 #'   match to `pattern`
 #' @export

--- a/R/tokens_select.R
+++ b/R/tokens_select.R
@@ -7,7 +7,9 @@
 #' common usage for `tokens_remove` will be to eliminate stop words from a text
 #' or text-based object, while the most common use of `tokens_select` will be to
 #' select tokens with only positive pattern matches from a list of regular
-#' expressions, including a dictionary.
+#' expressions, including a dictionary. `startpos` and `endpos` determine the
+#' positions of tokens searched for `pattern` and areas affected are 
+#' expanded by `window`.
 #' @param x [tokens] object whose token elements will be removed or kept
 #' @inheritParams pattern
 #' @param selection whether to `"keep"` or `"remove"` the tokens matching
@@ -61,7 +63,7 @@
 #' tokens_select(toks, c("b", "f"), selection = "remove", window = 1)
 #' tokens_remove(toks, c("b", "f"), window = c(0, 1))
 #' tokens_select(toks, pattern = c("e", "g"), window = c(1, 2))
-#'
+#' 
 tokens_select <- function(x, pattern, selection = c("keep", "remove"),
                           valuetype = c("glob", "regex", "fixed"),
                           case_insensitive = TRUE, padding = FALSE, window = 0,

--- a/R/tokens_select.R
+++ b/R/tokens_select.R
@@ -46,21 +46,22 @@
 #' @export
 #' @examples
 #' ## tokens_select with simple examples
-#' toks <- tokens(c("This is a sentence.", "This is a second sentence."),
-#'                  remove_punct = TRUE)
-#' tokens_select(toks, c("is", "a", "this"), selection = "keep", padding = FALSE)
-#' tokens_select(toks, c("is", "a", "this"), selection = "keep", padding = TRUE)
-#' tokens_select(toks, c("is", "a", "this"), selection = "remove", padding = FALSE)
-#' tokens_select(toks, c("is", "a", "this"), selection = "remove", padding = TRUE)
+#' toks <- as.tokens(list(letters, LETTERS))
+#' tokens_select(toks, c("b", "e", "f"), selection = "keep", padding = FALSE)
+#' tokens_select(toks, c("b", "e", "f"), selection = "keep", padding = TRUE)
+#' tokens_select(toks, c("b", "e", "f"), selection = "remove", padding = FALSE)
+#' tokens_select(toks, c("b", "e", "f"), selection = "remove", padding = TRUE)
 #'
 #' # how case_insensitive works
-#' tokens_select(toks, c("is", "a", "this"), selection = "remove", case_insensitive = TRUE)
-#' tokens_select(toks, c("is", "a", "this"), selection = "remove", case_insensitive = FALSE)
+#' tokens_select(toks, c("b", "e", "f"), selection = "remove", case_insensitive = TRUE)
+#' tokens_select(toks, c("b", "e", "f"), selection = "remove", case_insensitive = FALSE)
 #'
 #' # use window
-#' tokens_select(toks, "second", selection = "keep", window = 1)
-#' tokens_select(toks, "second", selection = "remove", window = 1)
-#' tokens_remove(toks, "is", window = c(0, 1))
+#' tokens_select(toks, c("b", "f"), selection = "keep", window = 1)
+#' tokens_select(toks, c("b", "f"), selection = "remove", window = 1)
+#' tokens_remove(toks, c("b", "f"), window = c(0, 1))
+#' tokens_select(toks, pattern = c("e", "g"), window = c(1, 2))
+#'
 tokens_select <- function(x, pattern, selection = c("keep", "remove"),
                           valuetype = c("glob", "regex", "fixed"),
                           case_insensitive = TRUE, padding = FALSE, window = 0,
@@ -88,11 +89,13 @@ tokens_select.default <- function(x, pattern = NULL,
 #' @examples
 #' toks <- tokens(c(doc1 = "This is a SAMPLE text", doc2 = "this sample text is better"))
 #' feats <- c("this", "sample", "is")
+#'
 #' # keeping tokens
 #' tokens_select(toks, feats, selection = "keep")
 #' tokens_select(toks, feats, selection = "keep", padding = TRUE)
 #' tokens_select(toks, feats, selection = "keep", case_insensitive = FALSE)
 #' tokens_select(toks, feats, selection = "keep", padding = TRUE, case_insensitive = FALSE)
+#'
 #' # removing tokens
 #' tokens_select(toks, feats, selection = "remove")
 #' tokens_select(toks, feats, selection = "remove", padding = TRUE)
@@ -115,13 +118,14 @@ tokens_select.default <- function(x, pattern = NULL,
 #' # with minimum length
 #' tokens_select(toks2, min_nchar = 2, "keep") # simplified form
 #'
-#' # with starting adn ending positions
+#' # with starting and ending positions
 #' tokens_select(toks, "*", startpos = 3)  # exclude first two tokens
 #' tokens_select(toks, "*", endpos = 3)    # include only first 3 tokens
 #' tokens_select(toks, "*", startpos = -3) # include only last 2 tokens
 #'
 #' # combining positional selection with pattern matching
 #' tokens_select(toks, "t*", endpos = 3)
+#'
 tokens_select.tokens <- function(x, pattern = NULL,
                                  selection = c("keep", "remove"),
                                  valuetype = c("glob", "regex", "fixed"),
@@ -190,10 +194,11 @@ tokens_select.tokens <- function(x, pattern = NULL,
 #' @export
 #' @examples
 #' # tokens_remove example: remove stopwords
-#' txt <- c(wash1 <- "Fellow citizens, I am again called upon by the voice of my country to
-#'                    execute the functions of its Chief Magistrate.",
-#'          wash2 <- "When the occasion proper for it shall arrive, I shall endeavor to express
-#'                    the high sense I entertain of this distinguished honor.")
+#' txt <- c(wash1 <- "Fellow citizens, I am again called upon by the voice of my
+#'                    country to execute the functions of its Chief Magistrate.",
+#'          wash2 <- "When the occasion proper for it shall arrive, I shall
+#'                    endeavor to express the high sense I entertain of this
+#'                    distinguished honor.")
 #' tokens_remove(tokens(txt, remove_punct = TRUE), stopwords("english"))
 #'
 tokens_remove <- function(x, ...) {
@@ -208,6 +213,7 @@ tokens_remove <- function(x, ...) {
 #' @examples
 #' # token_keep example: keep two-letter words
 #' tokens_keep(tokens(txt, remove_punct = TRUE), "??")
+#'
 tokens_keep <- function(x, ...) {
     if ("selection" %in% names(list(...))) {
         stop("tokens_keep cannot include selection argument")

--- a/man/tokens_select.Rd
+++ b/man/tokens_select.Rd
@@ -91,7 +91,9 @@ shortcuts for \code{tokens_select(x, pattern, selection = "remove")} and
 common usage for \code{tokens_remove} will be to eliminate stop words from a text
 or text-based object, while the most common use of \code{tokens_select} will be to
 select tokens with only positive pattern matches from a list of regular
-expressions, including a dictionary.
+expressions, including a dictionary. \code{startpos} and \code{endpos} determine the
+positions of tokens searched for \code{pattern} and areas affected are
+expanded by \code{window}.
 }
 \examples{
 ## tokens_select with simple examples

--- a/man/tokens_select.Rd
+++ b/man/tokens_select.Rd
@@ -48,12 +48,12 @@ the pre- and post-selected tokens, for instance if a window of adjacency
 needs to be computed.}
 
 \item{window}{integer of length 1 or 2; the size of the window of tokens
-adjacent to \code{pattern} that will be selected. The window is symmetric
-unless a vector of two elements is supplied, in which case the first
-element will be the token length of the window before \code{pattern}, and
-the second will be the token length of the window after \code{pattern}.
-The default is \code{0}, meaning that only the pattern matched token(s) are
-selected, with no adjacent terms.
+adjacent to \code{pattern} that will be selected. The window is symmetric unless
+a vector of two elements is supplied, in which case the first element will
+be the token length of the window before \code{pattern}, and the second will be
+the token length of the window after \code{pattern}. The default is \code{0}, meaning
+that only the pattern matched token(s) are selected, with no adjacent
+terms.
 
 Terms from overlapping windows are never double-counted, but simply
 returned in the pattern match. This is because \code{tokens_select} never
@@ -61,13 +61,16 @@ redefines the document units; for this, see \code{\link[=kwic]{kwic()}}.}
 
 \item{min_nchar, max_nchar}{optional numerics specifying the minimum and
 maximum length in characters for tokens to be removed or kept; defaults are
-\code{NULL} for no limits.  These are applied after (and hence, in addition
-to) any selection based on pattern matches.}
+\code{NULL} for no limits.  These are applied after (and hence, in addition to)
+any selection based on pattern matches.}
 
 \item{startpos, endpos}{integer; position of tokens in documents where pattern
 matching starts and ends, where 1 is the first token in a document.  For
 negative indexes, counting starts at the ending token of the document, so
-that -1 denotes the last token in the document, -2 the second to last, etc.}
+that -1 denotes the last token in the document, -2 the second to last, etc.
+When the length of the vector is equal to \code{ndoc}, tokens in corresponding
+positions will be selected. Otherwise, only the first element in the vector
+is used.}
 
 \item{verbose}{if \code{TRUE} print messages about how many tokens were selected
 or removed}

--- a/man/tokens_select.Rd
+++ b/man/tokens_select.Rd
@@ -95,28 +95,31 @@ expressions, including a dictionary.
 }
 \examples{
 ## tokens_select with simple examples
-toks <- tokens(c("This is a sentence.", "This is a second sentence."),
-                 remove_punct = TRUE)
-tokens_select(toks, c("is", "a", "this"), selection = "keep", padding = FALSE)
-tokens_select(toks, c("is", "a", "this"), selection = "keep", padding = TRUE)
-tokens_select(toks, c("is", "a", "this"), selection = "remove", padding = FALSE)
-tokens_select(toks, c("is", "a", "this"), selection = "remove", padding = TRUE)
+toks <- as.tokens(list(letters, LETTERS))
+tokens_select(toks, c("b", "e", "f"), selection = "keep", padding = FALSE)
+tokens_select(toks, c("b", "e", "f"), selection = "keep", padding = TRUE)
+tokens_select(toks, c("b", "e", "f"), selection = "remove", padding = FALSE)
+tokens_select(toks, c("b", "e", "f"), selection = "remove", padding = TRUE)
 
 # how case_insensitive works
-tokens_select(toks, c("is", "a", "this"), selection = "remove", case_insensitive = TRUE)
-tokens_select(toks, c("is", "a", "this"), selection = "remove", case_insensitive = FALSE)
+tokens_select(toks, c("b", "e", "f"), selection = "remove", case_insensitive = TRUE)
+tokens_select(toks, c("b", "e", "f"), selection = "remove", case_insensitive = FALSE)
 
 # use window
-tokens_select(toks, "second", selection = "keep", window = 1)
-tokens_select(toks, "second", selection = "remove", window = 1)
-tokens_remove(toks, "is", window = c(0, 1))
+tokens_select(toks, c("b", "f"), selection = "keep", window = 1)
+tokens_select(toks, c("b", "f"), selection = "remove", window = 1)
+tokens_remove(toks, c("b", "f"), window = c(0, 1))
+tokens_select(toks, pattern = c("e", "g"), window = c(1, 2))
+
 # tokens_remove example: remove stopwords
-txt <- c(wash1 <- "Fellow citizens, I am again called upon by the voice of my country to
-                   execute the functions of its Chief Magistrate.",
-         wash2 <- "When the occasion proper for it shall arrive, I shall endeavor to express
-                   the high sense I entertain of this distinguished honor.")
+txt <- c(wash1 <- "Fellow citizens, I am again called upon by the voice of my
+                   country to execute the functions of its Chief Magistrate.",
+         wash2 <- "When the occasion proper for it shall arrive, I shall
+                   endeavor to express the high sense I entertain of this
+                   distinguished honor.")
 tokens_remove(tokens(txt, remove_punct = TRUE), stopwords("english"))
 
 # token_keep example: keep two-letter words
 tokens_keep(tokens(txt, remove_punct = TRUE), "??")
+
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -262,8 +262,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // qatd_cpp_tokens_select
-List qatd_cpp_tokens_select(const List& texts_, const CharacterVector types_, const List& words_, int mode, bool padding, int window_left, int window_right, int pos_from, int pos_to);
-RcppExport SEXP _quanteda_qatd_cpp_tokens_select(SEXP texts_SEXP, SEXP types_SEXP, SEXP words_SEXP, SEXP modeSEXP, SEXP paddingSEXP, SEXP window_leftSEXP, SEXP window_rightSEXP, SEXP pos_fromSEXP, SEXP pos_toSEXP) {
+List qatd_cpp_tokens_select(const List& texts_, const CharacterVector types_, const List& words_, int mode, bool padding, int window_left, int window_right, const IntegerVector pos_from_, const IntegerVector pos_to_);
+RcppExport SEXP _quanteda_qatd_cpp_tokens_select(SEXP texts_SEXP, SEXP types_SEXP, SEXP words_SEXP, SEXP modeSEXP, SEXP paddingSEXP, SEXP window_leftSEXP, SEXP window_rightSEXP, SEXP pos_from_SEXP, SEXP pos_to_SEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -274,9 +274,9 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< bool >::type padding(paddingSEXP);
     Rcpp::traits::input_parameter< int >::type window_left(window_leftSEXP);
     Rcpp::traits::input_parameter< int >::type window_right(window_rightSEXP);
-    Rcpp::traits::input_parameter< int >::type pos_from(pos_fromSEXP);
-    Rcpp::traits::input_parameter< int >::type pos_to(pos_toSEXP);
-    rcpp_result_gen = Rcpp::wrap(qatd_cpp_tokens_select(texts_, types_, words_, mode, padding, window_left, window_right, pos_from, pos_to));
+    Rcpp::traits::input_parameter< const IntegerVector >::type pos_from_(pos_from_SEXP);
+    Rcpp::traits::input_parameter< const IntegerVector >::type pos_to_(pos_to_SEXP);
+    rcpp_result_gen = Rcpp::wrap(qatd_cpp_tokens_select(texts_, types_, words_, mode, padding, window_left, window_right, pos_from_, pos_to_));
     return rcpp_result_gen;
 END_RCPP
 }

--- a/tests/testthat/test-tokens_select.R
+++ b/tests/testthat/test-tokens_select.R
@@ -677,7 +677,19 @@ test_that("position arguments are working", {
              doc3 = c("a"))
     )
     expect_identical(
+        as.list(tokens_select(toks, "*", startpos = numeric(), endpos = numeric())),
+        list(doc1 = c("a", "b", "c", "d", "e"),
+             doc2 = c("a", "b", "c"),
+             doc3 = c("a"))
+    )
+    expect_identical(
         as.list(tokens_remove(toks, "*", startpos = -100, endpos = 100)),
+        list(doc1 = character(),
+             doc2 = character(),
+             doc3 = character())
+    )
+    expect_identical(
+        as.list(tokens_remove(toks, "*", startpos = numeric(), endpos = numeric())),
         list(doc1 = character(),
              doc2 = character(),
              doc3 = character())

--- a/tests/testthat/test-tokens_select.R
+++ b/tests/testthat/test-tokens_select.R
@@ -554,10 +554,46 @@ test_that("position arguments are working", {
              doc3 = c("a"))
     )
     expect_identical(
+        as.list(tokens_select(toks, "*", startpos = rep(1, 3), endpos = rep(3, 3))),
+        list(doc1 = c("a", "b", "c"),
+             doc2 = c("a", "b", "c"),
+             doc3 = c("a"))
+    )
+    expect_identical(
+        as.list(tokens_select(toks, "*", startpos = c(1, 2), endpos = c(3))),
+        list(doc1 = c("a", "b", "c"),
+             doc2 = c("a", "b", "c"),
+             doc3 = c("a"))
+    )
+    expect_identical(
+        as.list(tokens_select(toks, "*", startpos = c(1, 2, 2), endpos = c(3, 2, 1))),
+        list(doc1 = c("a", "b", "c"),
+             doc2 = c("b"),
+             doc3 = character())
+    )
+    expect_identical(
         as.list(tokens_remove(toks, "*", startpos = 1, endpos = 3)),
         list(doc1 = c("d", "e"),
              doc2 = character(),
              doc3 = character())
+    )
+    expect_identical(
+        as.list(tokens_remove(toks, "*", startpos = rep(1, 3), endpos = rep(3, 3))),
+        list(doc1 = c("d", "e"),
+             doc2 = character(),
+             doc3 = character())
+    )
+    expect_identical(
+        as.list(tokens_remove(toks, "*", startpos = c(1, 2), endpos = c(3))),
+        list(doc1 = c("d", "e"),
+             doc2 = character(),
+             doc3 = character())
+    )
+    expect_identical(
+        as.list(tokens_remove(toks, "*", startpos = c(1, 2, 2), endpos = c(3, 2, 1))),
+        list(doc1 = c("d", "e"),
+             doc2 = c("a", "c"),
+             doc3 = c("a"))
     )
 
     expect_identical(


### PR DESCRIPTION
This PR upgrades `tokens_select()` to allow `startpos` and `endpos` to be a vector. We can create KWIC view with this function. For example,
``` r
require(quanteda)
#> Loading required package: quanteda
#> Package version: 2.0.2
#> Parallel computing: 2 of 4 threads used.
#> See https://quanteda.io for tutorials and examples.
#> 
#> Attaching package: 'quanteda'
#> The following object is masked from 'package:utils':
#> 
#>     View
toks <- tokens(data_char_ukimmig2010)
kw <- kwic(toks, "migra*")[,c("docname", "from", "to")]
head(kw)
#>        docname from  to
#> 1    Coalition   74  74
#> 2 Conservative   86  86
#> 3 Conservative  134 134
#> 4       Greens    3   3
#> 5       Greens  160 160
#> 6       Greens  374 374

tokens_select(toks[kw$docname], startpos = kw$from, endpos = kw$to)
#> Tokens consisting of 20 documents.
#> Coalition.1 :
#> [1] "migrants"
#> 
#> Conservative.1 :
#> [1] "migration"
#> 
#> Conservative.2 :
#> [1] "migrants"
#> 
#> Greens.1 :
#> [1] "Migration"
#> 
#> Greens.2 :
#> [1] "migrants"
#> 
#> Greens.3 :
#> [1] "migrate"
#> 
#> [ reached max_ndoc ... 14 more documents ]
tokens_select(toks[kw$docname], startpos = kw$from - 2, endpos = kw$to + 2)
#> Tokens consisting of 20 documents.
#> Coalition.1 :
#> [1] "non-EU"   "economic" "migrants" "admitted" "into"    
#> 
#> Conservative.1 :
#> [1] "take"      "net"       "migration" "back"      "to"       
#> 
#> Conservative.2 :
#> [1] "non-EU"   "economic" "migrants" "admitted" "into"    
#> 
#> Greens.1 :
#> [1] "Immigration" "."           "Migration"   "is"          "a"          
#> 
#> Greens.2 :
#> [1] "and"      "many"     "migrants" "return"   "with"    
#> 
#> Greens.3 :
#> [1] "people"     "to"         "migrate"    "."          "Emigration"
#> 
#> [ reached max_ndoc ... 14 more documents ]
```

<sup>Created on 2020-05-15 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>