### PR TITLE
Add interface to set hash table sizes

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -85,6 +85,14 @@ qatd_cpp_is_grouped_character <- function(values_, groups_) {
     .Call(`_quanteda_qatd_cpp_is_grouped_character`, values_, groups_)
 }
 
+qatd_cpp_set_load_factor <- function(type, value) {
+    invisible(.Call(`_quanteda_qatd_cpp_set_load_factor`, type, value))
+}
+
+qatd_cpp_get_load_factor <- function() {
+    .Call(`_quanteda_qatd_cpp_get_load_factor`)
+}
+
 qatd_cpp_tbb_enabled <- function() {
     .Call(`_quanteda_qatd_cpp_tbb_enabled`)
 }

--- a/inst/include/lib.h
+++ b/inst/include/lib.h
@@ -199,6 +199,12 @@ namespace quanteda{
             set.insert(patterns[g]);
             spans[g] = patterns[g].size();
         }
+        
+        // Rcout << "current max_load_factor: " << set.max_load_factor() << std::endl;
+        // Rcout << "current size           : " << set.size() << std::endl;
+        // Rcout << "current bucket_count   : " << set.unsafe_bucket_count() << std::endl;
+        // Rcout << "current load_factor    : " << set.load_factor() << std::endl;
+        
         sort(spans.begin(), spans.end());
         spans.erase(unique(spans.begin(), spans.end()), spans.end());
         std::reverse(std::begin(spans), std::end(spans));

--- a/inst/include/lib.h
+++ b/inst/include/lib.h
@@ -16,7 +16,7 @@ using namespace RcppParallel;
 #define CLANG_VERSION (__clang_major__ * 10000 + __clang_minor__ * 100 + __clang_patchlevel__)
 
 // global setting for unordered_map and unordered_set 
-extern float GLOBAL_PATTERNS_MAX_LOAD_FACTOR;
+extern float GLOBAL_PATTERN_MAX_LOAD_FACTOR;
 extern float GLOBAL_NGRAMS_MAX_LOAD_FACTOR;
 
 // compiler has to be newer than clang 3.30 or gcc 4.8.1
@@ -191,8 +191,8 @@ namespace quanteda{
     }
 
     inline std::vector<std::size_t> register_ngrams(List patterns_, SetNgrams &set) {
-
-        set.max_load_factor(GLOBAL_PATTERNS_MAX_LOAD_FACTOR);
+        
+        set.max_load_factor(GLOBAL_PATTERN_MAX_LOAD_FACTOR);
         Ngrams patterns = Rcpp::as<Ngrams>(patterns_);
         std::vector<std::size_t> spans(patterns.size());
         for (size_t g = 0; g < patterns.size(); g++) {
@@ -207,7 +207,7 @@ namespace quanteda{
 
     inline std::vector<std::size_t> register_ngrams(List patterns_, IntegerVector ids_, MapNgrams &map) {
 
-        map.max_load_factor(GLOBAL_PATTERNS_MAX_LOAD_FACTOR);
+        map.max_load_factor(GLOBAL_PATTERN_MAX_LOAD_FACTOR);
         Ngrams patterns = Rcpp::as<Ngrams>(patterns_);
         std::vector<unsigned int> ids = Rcpp::as< std::vector<unsigned int> >(ids_);
         std::vector<std::size_t> spans(patterns.size());

--- a/inst/include/lib.h
+++ b/inst/include/lib.h
@@ -15,9 +15,9 @@ using namespace RcppParallel;
 
 #define CLANG_VERSION (__clang_major__ * 10000 + __clang_minor__ * 100 + __clang_patchlevel__)
 
-// setting for unordered_map and unordered_set 
-const float GLOBAL_PATTERNS_MAX_LOAD_FACTOR = 0.1;
-const float GLOBAL_NGRAMS_MAX_LOAD_FACTOR = 0.5;
+// global setting for unordered_map and unordered_set 
+extern float GLOBAL_PATTERNS_MAX_LOAD_FACTOR;
+extern float GLOBAL_NGRAMS_MAX_LOAD_FACTOR;
 
 // compiler has to be newer than clang 3.30 or gcc 4.8.1
 #if RCPP_PARALLEL_USE_TBB && (CLANG_VERSION >= 30300 || GCC_VERSION >= 40801) 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -304,6 +304,27 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// qatd_cpp_set_load_factor
+void qatd_cpp_set_load_factor(std::string type, float value);
+RcppExport SEXP _quanteda_qatd_cpp_set_load_factor(SEXP typeSEXP, SEXP valueSEXP) {
+BEGIN_RCPP
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< std::string >::type type(typeSEXP);
+    Rcpp::traits::input_parameter< float >::type value(valueSEXP);
+    qatd_cpp_set_load_factor(type, value);
+    return R_NilValue;
+END_RCPP
+}
+// qatd_cpp_get_load_factor
+List qatd_cpp_get_load_factor();
+RcppExport SEXP _quanteda_qatd_cpp_get_load_factor() {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    rcpp_result_gen = Rcpp::wrap(qatd_cpp_get_load_factor());
+    return rcpp_result_gen;
+END_RCPP
+}
 // qatd_cpp_tbb_enabled
 bool qatd_cpp_tbb_enabled();
 RcppExport SEXP _quanteda_qatd_cpp_tbb_enabled() {
@@ -352,6 +373,8 @@ static const R_CallMethodDef CallEntries[] = {
     {"_quanteda_qatd_cpp_tokens_select", (DL_FUNC) &_quanteda_qatd_cpp_tokens_select, 9},
     {"_quanteda_qatd_cpp_is_grouped_numeric", (DL_FUNC) &_quanteda_qatd_cpp_is_grouped_numeric, 2},
     {"_quanteda_qatd_cpp_is_grouped_character", (DL_FUNC) &_quanteda_qatd_cpp_is_grouped_character, 2},
+    {"_quanteda_qatd_cpp_set_load_factor", (DL_FUNC) &_quanteda_qatd_cpp_set_load_factor, 2},
+    {"_quanteda_qatd_cpp_get_load_factor", (DL_FUNC) &_quanteda_qatd_cpp_get_load_factor, 0},
     {"_quanteda_qatd_cpp_tbb_enabled", (DL_FUNC) &_quanteda_qatd_cpp_tbb_enabled, 0},
     {"_quanteda_qatd_cpp_is_overlap", (DL_FUNC) &_quanteda_qatd_cpp_is_overlap, 5},
     {NULL, NULL, 0}

--- a/src/collocations_mt_.cpp
+++ b/src/collocations_mt_.cpp
@@ -307,7 +307,7 @@ DataFrame qatd_cpp_collocations(const List &texts_,
     unsigned int id_ignore = UINT_MAX; // use largest limit as filler
     
     SetUnigrams set_ignore;
-    set_ignore.max_load_factor(GLOBAL_PATTERNS_MAX_LOAD_FACTOR);
+    set_ignore.max_load_factor(GLOBAL_PATTERN_MAX_LOAD_FACTOR);
     for (size_t g = 0; g < words_ignore.size(); g++) {
         set_ignore.insert(words_ignore[g]);
     }
@@ -323,7 +323,7 @@ DataFrame qatd_cpp_collocations(const List &texts_,
 #endif
     
     MapNgramsPair counts_seq;
-    counts_seq.max_load_factor(GLOBAL_PATTERNS_MAX_LOAD_FACTOR);
+    counts_seq.max_load_factor(GLOBAL_PATTERN_MAX_LOAD_FACTOR);
     
     //dev::Timer timer;
     //dev::start_timer("Count", timer);

--- a/src/kwic_mt.cpp
+++ b/src/kwic_mt.cpp
@@ -85,7 +85,7 @@ DataFrame qatd_cpp_kwic(const List &texts_,
     CharacterVector names_ = texts_.attr("names");
 
     MultiMapNgrams map_pats;
-    map_pats.max_load_factor(GLOBAL_PATTERNS_MAX_LOAD_FACTOR);
+    map_pats.max_load_factor(GLOBAL_PATTERN_MAX_LOAD_FACTOR);
     Ngrams words = Rcpp::as<Ngrams>(words_);
     std::vector<unsigned int> pats = Rcpp::as< std::vector<unsigned int> >(pats_);
     

--- a/src/tokens_compound_mt.cpp
+++ b/src/tokens_compound_mt.cpp
@@ -214,9 +214,9 @@ List qatd_cpp_tokens_compound(const List &texts_,
     #endif
     
     SetNgrams set_comps; // for matching
-    set_comps.max_load_factor(GLOBAL_PATTERNS_MAX_LOAD_FACTOR);
+    set_comps.max_load_factor(GLOBAL_PATTERN_MAX_LOAD_FACTOR);
     MapNgrams map_comps; // for ID generation
-    map_comps.max_load_factor(GLOBAL_PATTERNS_MAX_LOAD_FACTOR);
+    map_comps.max_load_factor(GLOBAL_NGRAMS_MAX_LOAD_FACTOR);
 
     Ngrams comps = Rcpp::as<Ngrams>(compounds_);
     std::vector<std::size_t> spans(comps.size());

--- a/src/tokens_lookup_mt.cpp
+++ b/src/tokens_lookup_mt.cpp
@@ -180,7 +180,7 @@ List qatd_cpp_tokens_lookup(const List &texts_,
     //dev::start_timer("Map construction", timer);
 
     MultiMapNgrams map_keys;
-    map_keys.max_load_factor(GLOBAL_PATTERNS_MAX_LOAD_FACTOR);
+    map_keys.max_load_factor(GLOBAL_PATTERN_MAX_LOAD_FACTOR);
     Ngrams words = Rcpp::as<Ngrams>(words_);
     std::vector<unsigned int> keys = Rcpp::as< std::vector<unsigned int> >(keys_);
     

--- a/src/tokens_replace_mt.cpp
+++ b/src/tokens_replace_mt.cpp
@@ -100,7 +100,7 @@ List qatd_cpp_tokens_replace(const List &texts_,
     //dev::start_timer("Map construction", timer);
 
     MapNgrams map_pat;
-    map_pat.max_load_factor(GLOBAL_PATTERNS_MAX_LOAD_FACTOR);
+    map_pat.max_load_factor(GLOBAL_PATTERN_MAX_LOAD_FACTOR);
     Ngrams pats = Rcpp::as<Ngrams>(patterns_);
 
     size_t len = std::min(pats.size(), ids_repls.size());

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -90,23 +90,24 @@ bool qatd_cpp_is_grouped_character(CharacterVector values_, IntegerVector groups
     return(true);
 }
 
-float GLOBAL_PATTERNS_MAX_LOAD_FACTOR = 0.05;
+float GLOBAL_PATTERN_MAX_LOAD_FACTOR = 0.05;
 float GLOBAL_NGRAMS_MAX_LOAD_FACTOR = 0.25;
 
 // [[Rcpp::export]]
 void qatd_cpp_set_load_factor(std::string type, float value) {
+    
     if (0 < value && value < 1.0) {
         if (type == "pattern")
-            GLOBAL_PATTERNS_MAX_LOAD_FACTOR = value;
-        if (type == "ngram")
-            GLOBAL_PATTERNS_MAX_LOAD_FACTOR = value;
+            GLOBAL_PATTERN_MAX_LOAD_FACTOR = value;
+        if (type == "ngrams")
+            GLOBAL_NGRAMS_MAX_LOAD_FACTOR = value;
     }
 }
 
 // [[Rcpp::export]]
 List qatd_cpp_get_load_factor() {
     return List::create(
-         _["patterns"] = GLOBAL_PATTERNS_MAX_LOAD_FACTOR,
+         _["pattern"] = GLOBAL_PATTERN_MAX_LOAD_FACTOR,
          _["ngrams"] = GLOBAL_NGRAMS_MAX_LOAD_FACTOR
     );
 }

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -90,6 +90,27 @@ bool qatd_cpp_is_grouped_character(CharacterVector values_, IntegerVector groups
     return(true);
 }
 
+float GLOBAL_PATTERNS_MAX_LOAD_FACTOR = 0.05;
+float GLOBAL_NGRAMS_MAX_LOAD_FACTOR = 0.25;
+
+// [[Rcpp::export]]
+void qatd_cpp_set_load_factor(std::string type, float value) {
+    if (0 < value && value < 1.0) {
+        if (type == "pattern")
+            GLOBAL_PATTERNS_MAX_LOAD_FACTOR = value;
+        if (type == "ngram")
+            GLOBAL_PATTERNS_MAX_LOAD_FACTOR = value;
+    }
+}
+
+// [[Rcpp::export]]
+List qatd_cpp_get_load_factor() {
+    return List::create(
+         _["patterns"] = GLOBAL_PATTERNS_MAX_LOAD_FACTOR,
+         _["ngrams"] = GLOBAL_NGRAMS_MAX_LOAD_FACTOR
+    );
+}
+
 // [[Rcpp::export]]
 bool qatd_cpp_tbb_enabled(){
 #if QUANTEDA_USE_TBB

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -93,6 +93,16 @@ bool qatd_cpp_is_grouped_character(CharacterVector values_, IntegerVector groups
 float GLOBAL_PATTERN_MAX_LOAD_FACTOR = 0.05;
 float GLOBAL_NGRAMS_MAX_LOAD_FACTOR = 0.25;
 
+/* 
+ * Internal function to set max_load_factors of hash tables used for pattern
+ * matching and ngram generation. Smaller values will increase the speed but also 
+ * the use of RAM. Ngram generation requires significantly larger amount of
+ * storage than pattern matching, so should be larger.
+ * See: https://en.cppreference.com/w/cpp/container/unordered_map/max_load_factor
+ * @param pattern or ngrams
+ * @param value between 0 and 1.0
+ */
+//
 // [[Rcpp::export]]
 void qatd_cpp_set_load_factor(std::string type, float value) {
     

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -180,6 +180,6 @@ test_that("max_load_factor can be configured", {
     quanteda:::qatd_cpp_set_load_factor("ngrams", -1.0)
     quanteda:::qatd_cpp_set_load_factor("ngrams", 2.0)
     expect_equal(quanteda:::qatd_cpp_get_load_factor(),
-                 list(patterns = 0.2, ngrams = 0.7))
+                 list(pattern = 0.2, ngrams = 0.7), tolerance = 0.001)
     
 })

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -171,3 +171,15 @@ test_that("sample_bygroup works with groups of size 1", {
         expect_equal(tmp[4], 4)
     }
 })
+
+test_that("max_load_factor can be configured", {
+    quanteda:::qatd_cpp_set_load_factor("pattern", 0.2)
+    quanteda:::qatd_cpp_set_load_factor("pattern", -1.0)
+    quanteda:::qatd_cpp_set_load_factor("pattern", 2.0)
+    quanteda:::qatd_cpp_set_load_factor("ngrams", 0.7)
+    quanteda:::qatd_cpp_set_load_factor("ngrams", -1.0)
+    quanteda:::qatd_cpp_set_load_factor("ngrams", 2.0)
+    expect_equal(quanteda:::qatd_cpp_get_load_factor(),
+                 list(patterns = 0.2, ngrams = 0.7))
+    
+})


### PR DESCRIPTION
Add interface to change max_load_factor. It is a setting of the hash table that affects performance of C++ functions. 
```r
quanteda:::qatd_cpp_set_load_factor("pattern", 0.025)
quanteda:::qatd_cpp_get_load_factor()
```
We will not export these functions, but they allow us to find optimal settings on different systems with different data.