### PR TITLE
Update preserve_special()

### DIFF
--- a/R/quanteda_options.R
+++ b/R/quanteda_options.R
@@ -155,6 +155,6 @@ get_options_default <- function(){
                  base_compname = "comp",
                  language_stemmer = "english",
                  pattern_hashtag = "#\\w+#?",
-                 pattern_username = "@")
+                 pattern_username = "@[a-zA-Z0-9]+")
     return(opts)
 }

--- a/R/quanteda_options.R
+++ b/R/quanteda_options.R
@@ -62,15 +62,13 @@ quanteda_options <- function(..., reset = FALSE, initialize = FALSE) {
         args <- args[[1]]
     
     # initialize automatically it not yet done so
-    if (is.null(options('quanteda_initialized')) || !"package:quanteda" %in% search())
+    if (is.null(getOption('quanteda_initialized')) || !"package:quanteda" %in% search())
         quanteda_initialize()
         
     if (initialize) {
-        quanteda_initialize()
-        return(invisible(TRUE))
+        return(invisible(quanteda_initialize()))
     } else if (reset) {
-        quanteda_reset()
-        return(invisible(TRUE))
+        return(invisible(quanteda_reset()))
     } else if (!length(args)) {
         # return all option values with names
         opts_names <- names(get_options_default())
@@ -95,7 +93,7 @@ quanteda_initialize <- function() {
         if (is.null(getOption(paste0("quanteda_", key))))
             set_option_value(key, opts[[key]])
     }
-    options('quanteda_initialized' = TRUE)
+    unlist(options('quanteda_initialized' = TRUE), use.names = FALSE)
 }
 
 quanteda_reset <- function() {
@@ -103,7 +101,7 @@ quanteda_reset <- function() {
     for (key in names(opts)) {
         set_option_value(key, opts[[key]])
     }
-    options('quanteda_initialized' = TRUE)
+    unlist(options('quanteda_initialized' = TRUE), use.names = FALSE)
 }
 
 set_option_value <- function(key, value) {

--- a/R/tokenizers.R
+++ b/R/tokenizers.R
@@ -56,11 +56,12 @@ preserve_special <- function(x, split_hyphens = TRUE, split_tags = TRUE, verbose
     x <- as.character(x)
     
     hyphen <- "[\\p{Pd}]"
-    username <- quanteda_options("pattern_username") # preserves email address too
+    username <- quanteda_options("pattern_username") 
     hashtag <- quanteda_options("pattern_hashtag")
-    url <- "https?:\\/\\/(www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-z]{2,4}\\b([-a-zA-Z0-9@:%_\\+.~#?&//=]*)"
+    # preserves web and email address
+    address <- "(https?:\\/\\/(www\\.)?|@)[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-z]{2,4}\\b([-a-zA-Z0-9@:%_\\+.~#?&//=]*)"
 
-    regex <- character()
+    regex <- address
     if (!split_hyphens) {
         if (verbose) catm(" ...preserving hyphens\n")
         regex <- c(regex, hyphen)
@@ -69,7 +70,6 @@ preserve_special <- function(x, split_hyphens = TRUE, split_tags = TRUE, verbose
         if (verbose) catm(" ...preserving social media tags (#, @)\n")
         regex <- c(regex, username, hashtag)
     }
-    regex <- c(regex, url)
     
     s <- stri_extract_all_regex(x, paste(regex, collapse = "|"),  omit_no_match = TRUE)
     r <- lengths(s)

--- a/tests/testthat/test-quanteda_options.R
+++ b/tests/testthat/test-quanteda_options.R
@@ -1,6 +1,13 @@
 context("test quanteda_options")
 
+test_that("quanteda_options initialization works", {
+    options('quanteda_initialized' = NULL)
+    quanteda_options()
+    expect_true(getOption('quanteda_initialized'))
+})
+
 test_that("quanteda_options initialize works correctly", {
+    
     threads_temp <- getOption("quanteda_threads")
     quanteda_options(verbose = TRUE, threads = 1)
     quanteda_options(initialize = TRUE)

--- a/tests/testthat/test-tokens.R
+++ b/tests/testthat/test-tokens.R
@@ -1089,14 +1089,22 @@ test_that("Weibo-style hashtags are preserved", {
 })
 
 test_that("emails address is preserved", {
-    txt <- c(d1 = "support@quanteda.io @quanteda")
+    txt <- c(d1 = "support@quanteda.io K.Watanabe@qi1234.co.jp")
     expect_identical(
         as.list(tokens(txt, what = "word")),
-        list(d1 = c("support@quanteda.io", "@quanteda"))
+        list(d1 = c("support@quanteda.io", "K.Watanabe@qi1234.co.jp"))
     )
 })
 
-test_that("hashtags are preserved", {
+test_that("hasusername is preserved", {
+    txt <- c(d1 = "@quanteda @koheiw7 @QUANEDA_INITIATIVE")
+    expect_identical(
+        as.list(tokens(txt, what = "word")),
+        list(d1 = c("@quanteda", "@koheiw7", "@QUANEDA_INITIATIVE"))
+    )
+})
+
+test_that("htags are preserved", {
     txt <- c(d1 = "#quanteda #q-x #q_y #q100 #q")
     expect_identical(
         as.list(tokens(txt, what = "word")),


### PR DESCRIPTION
Update `preserve_special()` for more accurate counting of social media user names in `textstat_summary()`.
 - Integrate protection of website and email address
 - Use pattern_username option only for usernames
