### PR TITLE
Make dfm_match() work with padding

### DIFF
--- a/R/dfm.R
+++ b/R/dfm.R
@@ -427,6 +427,6 @@ pad_dfm <- function(x, feature) {
             x <- cbind(x, make_null_dfm(feat_pad, docnames(x)))
         )
     }
-    x <- x[, feature]
+    x <- x[, match(feature, featnames(x))]
     return(x)
 }

--- a/tests/testthat/test-dfm_match.R
+++ b/tests/testthat/test-dfm_match.R
@@ -39,3 +39,12 @@ test_that("test dfm_match", {
     expect_error(dfm_match(mt, 1:3),
                  "features must be a character vector")
 })
+
+test_that("dfm_match works with padding", {
+    toks <- tokens("aa bb !", padding = TRUE, remove_punct = TRUE)
+    dfmt <- dfm(toks)
+    expect_identical(
+        featnames(dfm_match(dfmt, c("aa", "bb", "cc", ""))),
+        c("aa", "bb", "cc", "")
+    )
+})


### PR DESCRIPTION
In https://github.com/koheiw/newsmap/issues/39, I noticed that `dfm_match()` crashes when `features` contain "". 
```r
toks <- tokens("a b !", padding = TRUE, remove_punct = TRUE)
dfmt <- dfm(toks)
dfm_match(dfm("a b c"), "") # error
```
The root cause is actually `[.dfm`
```
dfmt[,""] #  error
dfm_select(dfmt, "") # works
```
This is a deeper issue that requires careful redesigning of how we handle paddings, because R treats empty names as a special case according to `?names()`:

> The name "" is special: it is used to indicate that there is no name associated with an element of a (atomic or generic) vector. Subscripting by "" will match nothing (not even elements which have no name).