### PR TITLE
Add logsmooth, needed for sentiment

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: quanteda
-Version: 2.0.2
+Version: 2.0.9000
 Title: Quantitative Analysis of Textual Data
 Description: A fast, flexible, and comprehensive framework for 
     quantitative text analysis in R.  Provides functionality for corpus management,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# quanteda 2.0.2
+# quanteda 2.1.0 (when released)
 
 ## Changes
 
@@ -9,13 +9,15 @@
 * Added `dictionary_edit()` for easy, interactive editing of dictionaries, plus the functions `char_edit()` and `list_edit()` for editing character and list of character objects.
 * Added a method to `textplot_wordcloud()` that plots objects from `textstat_keyness()`, to visualize keywords either by comparison or for the target category only.
 * Improved the performance of `kwic()` (#1840).
+* Added new `logsmooth` scheme to `dfm_weight()`.
+* Added new `textstat_summary()` method, which returns summary information about the tokens/types/features etc in an object.  It also caches summary information so that this can be retrieved on subsequent calls, rather than re-computed.
 
 ## Bug fixes and stability enhancements
 
 * Stopped returning `NA` for non-existent features when `n` > `nfeat(x)` in `textstat_frequency(x, n)`.  (#1929)
 * Fixed a problem in `dfm_lookup()` and `tokens_lookup()` in which an error was caused when no dictionary key returned a single match (#1946).
 * Fixed a bug that caused a `textstat_simil/dist` object converted to a data.frame to drop its `document2` labels (#1939).
-
+* Fixed a bug causing `dfm_match()` to fail on a dfm that included "pads" (`""`). (#1960)
 
 # quanteda 2.0.1
 

--- a/R/dfm_weight.R
+++ b/R/dfm_weight.R
@@ -121,7 +121,7 @@ dfm_weight.dfm <- function(
             .Deprecated(msg = 'scheme = "tfidf" is deprecated; use dfm_tfidf(x) instead')
             return(dfm_tfidf(x, base = base))
         } else if (scheme == "logsmooth") {
-            return(dfm_smooth(x, smoothing) %>% log(base = base) %>% as.dfm())
+            return(as.dfm(log(dfm_smooth(x, smoothing), base = base)))
         }
     }
 

--- a/R/dfm_weight.R
+++ b/R/dfm_weight.R
@@ -5,9 +5,10 @@
 #' @param x document-feature matrix created by [dfm]
 #' @param scheme a label of the weight type:
 #' \describe{
-#'   \item{`count`}{\eqn{tf_{ij}}, an integer feature count (default when a dfm is created)}
-#'   \item{`prop`}{the proportion of the feature counts of total feature
-#'   counts (aka relative frequency), calculated as \eqn{tf_{ij} / \sum_j tf_{ij}}}
+#'   \item{`count`}{\eqn{tf_{ij}}, an integer feature count (default when a dfm
+#'   is created)}
+#'   \item{`prop`}{the proportion of the feature counts of total feature counts
+#'   (aka relative frequency), calculated as \eqn{tf_{ij} / \sum_j tf_{ij}}}
 #'   \item{`propmax`}{the proportion of the feature counts of the highest
 #'   feature count in a document, \eqn{tf_{ij} / \textrm{max}_j tf_{ij}}}
 #'   \item{`logcount`}{take the 1 + the logarithm of each count, for the
@@ -16,8 +17,10 @@
 #'   \item{`boolean`}{recode all non-zero counts as 1}
 #'   \item{`augmented`}{equivalent to \eqn{k + (1 - k) *} `dfm_weight(x,
 #'   "propmax")`}
-#'   \item{`logave`}{1 + the log of the counts) / (1 + log of the counts / the average count within document), or
-#'   \deqn{\frac{1 + \textrm{log}_{base} tf_{ij}}{1 + \textrm{log}_{base}(\sum_j tf_{ij} / N_i)}}}
+#'   \item{`logave`}{(1 + the log of the counts) / (1 + log of the average count
+#'   within document), or \deqn{\frac{1 + \textrm{log}_{base} tf_{ij}}{1 +
+#'   \textrm{log}_{base}(\sum_j tf_{ij} / N_i)}}}
+#'   \item{`logsmooth`}{log of the counts + `smooth`, or \eqn{tf_{ij} + s}}
 #' }
 #' @param weights if `scheme` is unused, then `weights` can be a named
 #'   numeric vector of weights to be applied to the dfm, where the names of the
@@ -66,10 +69,12 @@
 #'   <https://nlp.stanford.edu/IR-book/pdf/irbookonlinereading.pdf>
 dfm_weight <- function(
     x,
-    scheme = c("count", "prop", "propmax", "logcount", "boolean", "augmented", "logave"),
+    scheme = c("count", "prop", "propmax", "logcount", "boolean", "augmented", 
+               "logave", "logsmooth"),
     weights = NULL,
     base = 10,
     k = 0.5,
+    smoothing = 0.5,
     force = FALSE) {
     UseMethod("dfm_weight")
 }
@@ -77,10 +82,12 @@ dfm_weight <- function(
 #' @export
 dfm_weight.default <- function(
     x,
-    scheme = c("count", "prop", "propmax", "logcount", "boolean", "augmented", "logave"),
+    scheme = c("count", "prop", "propmax", "logcount", "boolean", "augmented", 
+               "logave", "logsmooth"),
     weights = NULL,
     base = 10,
     k = 0.5,
+    smoothing = 0.5,
     force = FALSE) {
     stop(friendly_class_undefined_message(class(x), "dfm_weight"))
 }
@@ -92,6 +99,7 @@ dfm_weight.dfm <- function(
     weights = NULL,
     base = 10,
     k = 0.5,
+    smoothing = 0.5,
     force = FALSE) {
 
     # traps for deprecated scheme values
@@ -112,6 +120,8 @@ dfm_weight.dfm <- function(
         } else if (scheme == "tfidf") {
             .Deprecated(msg = 'scheme = "tfidf" is deprecated; use dfm_tfidf(x) instead')
             return(dfm_tfidf(x, base = base))
+        } else if (scheme == "logsmooth") {
+            return(dfm_smooth(x, smoothing) %>% log(base = base) %>% as.dfm())
         }
     }
 
@@ -199,7 +209,8 @@ dfm_weight.dfm <- function(
 # dfm_smooth --------------
 
 #' @rdname dfm_weight
-#' @param smoothing constant added to the dfm cells for smoothing, default is 1
+#' @param smoothing constant added to the dfm cells for smoothing, default is 1 
+#'   for `dfm_smooth()` and 0.5 for `dfm_weight()`
 #' @return `dfm_smooth` returns a dfm whose values have been smoothed by
 #'   adding the `smoothing` amount. Note that this effectively converts a
 #'   matrix from sparse to dense format, so may exceed memory requirements

--- a/man/dfm_weight.Rd
+++ b/man/dfm_weight.Rd
@@ -7,10 +7,12 @@
 \usage{
 dfm_weight(
   x,
-  scheme = c("count", "prop", "propmax", "logcount", "boolean", "augmented", "logave"),
+  scheme = c("count", "prop", "propmax", "logcount", "boolean", "augmented", "logave",
+    "logsmooth"),
   weights = NULL,
   base = 10,
   k = 0.5,
+  smoothing = 0.5,
   force = FALSE
 )
 
@@ -21,9 +23,10 @@ dfm_smooth(x, smoothing = 1)
 
 \item{scheme}{a label of the weight type:
 \describe{
-\item{\code{count}}{\eqn{tf_{ij}}, an integer feature count (default when a dfm is created)}
-\item{\code{prop}}{the proportion of the feature counts of total feature
-counts (aka relative frequency), calculated as \eqn{tf_{ij} / \sum_j tf_{ij}}}
+\item{\code{count}}{\eqn{tf_{ij}}, an integer feature count (default when a dfm
+is created)}
+\item{\code{prop}}{the proportion of the feature counts of total feature counts
+(aka relative frequency), calculated as \eqn{tf_{ij} / \sum_j tf_{ij}}}
 \item{\code{propmax}}{the proportion of the feature counts of the highest
 feature count in a document, \eqn{tf_{ij} / \textrm{max}_j tf_{ij}}}
 \item{\code{logcount}}{take the 1 + the logarithm of each count, for the
@@ -31,8 +34,10 @@ given base, or 0 if the count was zero: \eqn{1 +
   \textrm{log}_{base}(tf_{ij})} if \eqn{tf_{ij} > 0}, or 0 otherwise.}
 \item{\code{boolean}}{recode all non-zero counts as 1}
 \item{\code{augmented}}{equivalent to \eqn{k + (1 - k) *} \code{dfm_weight(x, "propmax")}}
-\item{\code{logave}}{1 + the log of the counts) / (1 + log of the counts / the average count within document), or
-\deqn{\frac{1 + \textrm{log}_{base} tf_{ij}}{1 + \textrm{log}_{base}(\sum_j tf_{ij} / N_i)}}}
+\item{\code{logave}}{(1 + the log of the counts) / (1 + log of the average count
+within document), or \deqn{\frac{1 + \textrm{log}_{base} tf_{ij}}{1 +
+  \textrm{log}_{base}(\sum_j tf_{ij} / N_i)}}}
+\item{\code{logsmooth}}{log of the counts + \code{smooth}, or \eqn{tf_{ij} + s}}
 }}
 
 \item{weights}{if \code{scheme} is unused, then \code{weights} can be a named
@@ -47,12 +52,13 @@ named features.  Any features not named will be assigned a weight of 1.0
 
 \item{k}{the k for the augmentation when \code{scheme = "augmented"}}
 
+\item{smoothing}{constant added to the dfm cells for smoothing, default is 1
+for \code{dfm_smooth()} and 0.5 for \code{dfm_weight()}}
+
 \item{force}{logical; if \code{TRUE}, apply weighting scheme even if the dfm
 has been weighted before.  This can result in invalid weights, such as as
 weighting by \code{"prop"} after applying \code{"logcount"}, or after
 having grouped a dfm using \code{\link[=dfm_group]{dfm_group()}}.}
-
-\item{smoothing}{constant added to the dfm cells for smoothing, default is 1}
 }
 \value{
 \code{dfm_weight} returns the dfm with weighted values.  Note the

--- a/tests/testthat/test-dfm_weight.R
+++ b/tests/testthat/test-dfm_weight.R
@@ -317,3 +317,19 @@ test_that("featfreq() works", {
         c(a = 4, b = 2, c = 1)
     )
 })
+
+test_that("logsmooth works", {
+    dfmat <- dfm(c("a a a b c d d", "b b c d d d"))
+    expect_equivalent(
+        dfm_weight(dfmat, scheme = "logsmooth", smoothing = 0.5, base = exp(1)) %>% as.matrix(),
+        matrix(log(c(3, 0, 1, 2, 1, 1, 2, 3) + 0.5), nrow = 2)
+    )
+    expect_equivalent(
+        dfm_weight(dfmat, scheme = "logsmooth", smoothing = 0.5, base = 10) %>% as.matrix(),
+        matrix(log10(c(3, 0, 1, 2, 1, 1, 2, 3) + 0.5), nrow = 2)
+    )
+    expect_equivalent(
+        dfm_weight(dfmat, scheme = "logsmooth", smoothing = 1, base = 10) %>% as.matrix(),
+        matrix(log10(c(3, 0, 1, 2, 1, 1, 2, 3) + 1), nrow = 2)
+    )
+})


### PR DESCRIPTION
Adds new scheme for weighting, which is log(x + smoothing), needed for the logit scaling of sentiment (in #1958).