### PR TITLE
Optimize tokenization loop for very large corpora

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ## Changes
 
+* Added `block_size` to `quanteda_options()` to control the number of documents in blocked tokenization.
 * Added `textstat_summary()` to provide detailed information about dfm, tokens and corpus objects. It will replace `summary()` in future versions.
 * Fixed a performance issue causing slowdowns in tokenizing (using the default `what = "word"`) corpora with large numbers of documents that contain social media tags and URLs that needed to be preserved (such a large corpus of Tweets).
 * Updated the (default) "word" tokenizer to preserve hashtags and usernames better with non-ASCII text, and made these patterns user-configurable in `quanteda_options()`.  The following are now preserved: "#政治" as well as Weibo-style hashtags such as "#英国首相#".

--- a/R/corpus.R
+++ b/R/corpus.R
@@ -142,19 +142,6 @@ corpus.character <- function(x, docnames = NULL, docvars = NULL,
     # normalize Unicode
     x <- stri_trans_nfc(x)
 
-    # convert the dreaded "curly quotes" to ASCII equivalents
-    x <- stri_replace_all_fixed(x,
-                                c("\u201C", "\u201D", "\u201F",
-                                  "\u2018", "\u201B", "\u2019"),
-                                c("\"", "\"", "\"",
-                                  "\'", "\'", "\'"), vectorize_all = FALSE)
-
-    # replace all hyphens with simple hyphen
-    x <- stri_replace_all_fixed(x, c("\u2012", "\u2013", "\u2014", "\u2015", "\u2053"), "--", 
-                                vectorize_all = FALSE)
-    x <- stri_replace_all_regex(x, c("\\p{Pd}", "\\p{Pd}{2,}"), c("-", " - "), 
-                                vectorize_all = FALSE)
-
     # normalize EOL
     x <- stri_replace_all_fixed(x, "\r\n", "\n") # Windows
     x <- stri_replace_all_fixed(x, "\r", "\n") # Old Macintosh

--- a/R/dfm.R
+++ b/R/dfm.R
@@ -381,7 +381,7 @@ dfm.dfm <- function(x,
         x <- x[, !is_na, drop = FALSE]
 
     if (verbose) {
-        catm(" ...complete, elapsed time: ",
+        catm(" ...complete, elapsed time:",
              format((proc.time() - dfm_env$START_TIME)[3], digits = 3), "seconds.\n")
         catm("Finished constructing a", paste(format(dim(x), big.mark = ",", trim = TRUE), collapse = " x "),
              "sparse dfm.\n")

--- a/R/quanteda_options.R
+++ b/R/quanteda_options.R
@@ -29,7 +29,10 @@
 #' [tokens_wordstem], and [dfm_wordstem]} 
 #' \item{`pattern_hashtag`, `pattern_username`}{character; regex patterns for
 #' (social media) hashtags and usernames respectively, used to avoid segmenting
-#' these in the default internal "word" tokenizer}}
+#' these in the default internal "word" tokenizer}
+#' \item{`block_size`}{integer; specifies the
+#'   number of documents to be tokenized at a time in blocked tokenization.
+#'   When the number is large, tokenization becomes faster but also memory-intensive.}}
 #' @return When called using a `key = value` pair (where `key` can be
 #' a label or quoted character name)), the option is set and `TRUE` is
 #' returned invisibly.
@@ -153,6 +156,7 @@ get_options_default <- function(){
                  base_compname = "comp",
                  language_stemmer = "english",
                  pattern_hashtag = "#\\w+#?",
-                 pattern_username = "@[a-zA-Z0-9_]+")
+                 pattern_username = "@[a-zA-Z0-9_]+",
+                 block_size = 10000L)
     return(opts)
 }

--- a/R/quanteda_options.R
+++ b/R/quanteda_options.R
@@ -30,7 +30,7 @@
 #' \item{`pattern_hashtag`, `pattern_username`}{character; regex patterns for
 #' (social media) hashtags and usernames respectively, used to avoid segmenting
 #' these in the default internal "word" tokenizer}
-#' \item{`block_size`}{integer; specifies the
+#' \item{`tokens_block_size`}{integer; specifies the
 #'   number of documents to be tokenized at a time in blocked tokenization.
 #'   When the number is large, tokenization becomes faster but also memory-intensive.}}
 #' @return When called using a `key = value` pair (where `key` can be
@@ -157,6 +157,6 @@ get_options_default <- function(){
                  language_stemmer = "english",
                  pattern_hashtag = "#\\w+#?",
                  pattern_username = "@[a-zA-Z0-9_]+",
-                 block_size = 10000L)
+                 tokens_block_size = 10000L)
     return(opts)
 }

--- a/R/tokenizers.R
+++ b/R/tokenizers.R
@@ -120,9 +120,10 @@ restore_special <- function(x, special, recompile = TRUE) {
             )
         }
     }
-    if (!identical(type, attr(x, "types")) && recompile) {
+    if (!identical(type, attr(x, "types"))) {
         attr(x, "types") <- type
-        x <- tokens_recompile(x)
+        if (recompile)
+            x <- tokens_recompile(x)
     }
     return(x)
 }
@@ -164,7 +165,7 @@ preserve_special1 <- function(x, split_hyphens = TRUE, split_tags = TRUE, verbos
 }
 
 # re-substitute the replacement hyphens and tags
-restore_special1 <- function(x, split_hyphens = TRUE, split_tags = TRUE, recopile = TRUE, 
+restore_special1 <- function(x, split_hyphens = TRUE, split_tags = TRUE, recompile = TRUE, 
                              verbose = FALSE) {
     type <- attr(x, "types")
     if (!split_hyphens)
@@ -172,9 +173,10 @@ restore_special1 <- function(x, split_hyphens = TRUE, split_tags = TRUE, recopil
     if (!split_tags)
         type <- stri_replace_all_fixed(type, c("_ht_", "_as_"), c("#", "@"),
                                        vectorize_all = FALSE)
-    if (!identical(type, attr(x, "types")) && recopile) {
+    if (!identical(type, attr(x, "types"))) {
         attr(x, "types") <- type
-        x <- tokens_recompile(x)
+        if (recompile)
+            x <- tokens_recompile(x)
     }
     return(x)
 }

--- a/R/tokenizers.R
+++ b/R/tokenizers.R
@@ -229,3 +229,21 @@ tokenize_fasterword <- function(x, ...) {
 tokenize_fastestword <- function(x, ...) {
     stri_split_regex(x, " ")
 }
+
+
+normalize_characters <- function(x) {
+    # convert the dreaded "curly quotes" to ASCII equivalents
+    x <- stri_replace_all_fixed(x,
+                                c("\u201C", "\u201D", "\u201F",
+                                  "\u2018", "\u201B", "\u2019"),
+                                c("\"", "\"", "\"",
+                                  "\'", "\'", "\'"), vectorize_all = FALSE)
+    
+    # replace all hyphens with simple hyphen
+    x <- stri_replace_all_fixed(x, c("\u2012", "\u2013", "\u2014", "\u2015", "\u2053"), "--", 
+                                vectorize_all = FALSE)
+    x <- stri_replace_all_regex(x, c("\\p{Pd}", "\\p{Pd}{2,}"), c("-", " - "), 
+                                vectorize_all = FALSE)
+    
+    return(x)
+}

--- a/R/tokenizers.R
+++ b/R/tokenizers.R
@@ -122,8 +122,6 @@ restore_special <- function(x, special, recompile = TRUE) {
     }
     if (!identical(type, attr(x, "types"))) {
         attr(x, "types") <- type
-        if (recompile)
-            x <- tokens_recompile(x)
     }
     return(x)
 }
@@ -165,8 +163,7 @@ preserve_special1 <- function(x, split_hyphens = TRUE, split_tags = TRUE, verbos
 }
 
 # re-substitute the replacement hyphens and tags
-restore_special1 <- function(x, split_hyphens = TRUE, split_tags = TRUE, recompile = TRUE, 
-                             verbose = FALSE) {
+restore_special1 <- function(x, split_hyphens = TRUE, split_tags = TRUE, verbose = FALSE) {
     type <- attr(x, "types")
     if (!split_hyphens)
         type <- stri_replace_all_fixed(type, "_hy_", "-")
@@ -175,8 +172,6 @@ restore_special1 <- function(x, split_hyphens = TRUE, split_tags = TRUE, recompi
                                        vectorize_all = FALSE)
     if (!identical(type, attr(x, "types"))) {
         attr(x, "types") <- type
-        if (recompile)
-            x <- tokens_recompile(x)
     }
     return(x)
 }

--- a/R/tokenizers.R
+++ b/R/tokenizers.R
@@ -37,11 +37,11 @@ NULL
 #' @importFrom stringi stri_replace_all_regex stri_detect_fixed stri_split_boundaries
 #' @export
 tokenize_word <- function(x, split_hyphens = FALSE, verbose = quanteda_options("verbose")) {
-    
+
     if (verbose) catm(" ...segmenting texts\n")
     m <- names(x)
     x[is.na(x)] <- "" # make NAs ""
-    
+
     # this will not be needed if we can modify the ICU type rules to protect them
     # remove variant selector & whitespace with diacritical marks
     x <- stri_replace_all_regex(x, c("[\uFE00-\uFE0F]", "\\s[\u0300-\u036F]"), "",
@@ -51,12 +51,12 @@ tokenize_word <- function(x, split_hyphens = FALSE, verbose = quanteda_options("
 }
 
 preserve_special <- function(x, split_hyphens = TRUE, split_tags = TRUE, verbose = FALSE) {
-    
+
     name <- names(x)
     x <- as.character(x)
-    
+
     hyphen <- "[\\p{Pd}]"
-    username <- quanteda_options("pattern_username") 
+    username <- quanteda_options("pattern_username")
     hashtag <- quanteda_options("pattern_hashtag")
     # preserves web and email address
     address <- "(https?:\\/\\/(www\\.)?|@)[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-z]{2,4}\\b([-a-zA-Z0-9@:%_\\+.~#?&//=]*)"
@@ -70,11 +70,11 @@ preserve_special <- function(x, split_hyphens = TRUE, split_tags = TRUE, verbose
         if (verbose) catm(" ...preserving social media tags (#, @)\n")
         regex <- c(regex, username, hashtag)
     }
-    
+
     s <- stri_extract_all_regex(x, paste(regex, collapse = "|"),  omit_no_match = TRUE)
     r <- lengths(s)
     s <- unlist(s, use.names = FALSE)
-    
+
     # index specials
     u <- unique(s)
     u <- u[order(stri_length(u), decreasing = TRUE)] # substitute longer match first
@@ -84,15 +84,15 @@ preserve_special <- function(x, split_hyphens = TRUE, split_tags = TRUE, verbose
         names(special) <- names(index)
         for (i in seq_along(index)) {
             x[index[[i]]] <- stri_replace_all_fixed(
-                x[index[[i]]], 
-                names(special)[i], 
+                x[index[[i]]],
+                names(special)[i],
                 special[i],
                 vectorize_all = FALSE
             )
         }
     } else {
         special <- character()
-    } 
+    }
     structure(x, names = name, special = special)
 }
 
@@ -100,21 +100,21 @@ restore_special <- function(x, special, recompile = TRUE) {
 
     if (!length(special))
         return(x)
-    
+
     type <- attr(x, "types")
     # extract all placeholders
     d <- stri_extract_all_regex(type, "\u100000\\d+\u100001", omit_no_match = TRUE)
     r <- lengths(d)
     d <- unlist(d, use.names = FALSE)
-    
+
     # index placeholders
     index <- split(rep(seq_along(type), r), factor(d, levels = unique(d)))
     if (length(index)) {
         pos <- fastmatch::fmatch(names(index), special)
         for (i in seq_along(index)) {
             type[index[[i]]] <- stri_replace_all_fixed(
-                type[index[[i]]], 
-                special[pos[i]], 
+                type[index[[i]]],
+                special[pos[i]],
                 names(special)[pos[i]],
                 vectorize_all = FALSE
             )
@@ -135,7 +135,7 @@ restore_special <- function(x, special, recompile = TRUE) {
 #'   stri_replace_all_regex stri_detect_fixed stri_replace_all_fixed
 #' @export
 tokenize_word1 <- function(x, split_hyphens = FALSE, verbose = quanteda_options("verbose")) {
-    
+
     m <- names(x)
     x[is.na(x)] <- "" # make NAs ""
 
@@ -235,12 +235,12 @@ normalize_characters <- function(x) {
                                   "\u2018", "\u201B", "\u2019"),
                                 c("\"", "\"", "\"",
                                   "\'", "\'", "\'"), vectorize_all = FALSE)
-    
+
     # replace all hyphens with simple hyphen
-    x <- stri_replace_all_fixed(x, c("\u2012", "\u2013", "\u2014", "\u2015", "\u2053"), "--", 
+    x <- stri_replace_all_fixed(x, c("\u2012", "\u2013", "\u2014", "\u2015", "\u2053"), "--",
                                 vectorize_all = FALSE)
-    x <- stri_replace_all_regex(x, c("\\p{Pd}", "\\p{Pd}{2,}"), c("-", " - "), 
+    x <- stri_replace_all_regex(x, c("\\p{Pd}", "\\p{Pd}{2,}"), c("-", " - "),
                                 vectorize_all = FALSE)
-    
+
     return(x)
 }

--- a/R/tokenizers.R
+++ b/R/tokenizers.R
@@ -96,32 +96,32 @@ preserve_special <- function(x, split_hyphens = TRUE, split_tags = TRUE, verbose
     structure(x, names = name, special = special)
 }
 
-restore_special <- function(x, special) {
+restore_special <- function(x, special, recompile = TRUE) {
 
     if (!length(special))
         return(x)
     
-    types <- types(x)
+    type <- attr(x, "types")
     # extract all placeholders
-    d <- stri_extract_all_regex(types, "\u100000\\d+\u100001", omit_no_match = TRUE)
+    d <- stri_extract_all_regex(type, "\u100000\\d+\u100001", omit_no_match = TRUE)
     r <- lengths(d)
     d <- unlist(d, use.names = FALSE)
     
     # index placeholders
-    index <- split(rep(seq_along(types), r), factor(d, levels = unique(d)))
+    index <- split(rep(seq_along(type), r), factor(d, levels = unique(d)))
     if (length(index)) {
         pos <- fastmatch::fmatch(names(index), special)
         for (i in seq_along(index)) {
-            types[index[[i]]] <- stri_replace_all_fixed(
-                types[index[[i]]], 
+            type[index[[i]]] <- stri_replace_all_fixed(
+                type[index[[i]]], 
                 special[pos[i]], 
                 names(special)[pos[i]],
                 vectorize_all = FALSE
             )
         }
     }
-    if (!identical(types, types(x))) {
-        types(x) <- types
+    if (!identical(type, attr(x, "types")) && recompile) {
+        attr(x, "types") <- type
         x <- tokens_recompile(x)
     }
     return(x)
@@ -165,14 +165,14 @@ preserve_special1 <- function(x, split_hyphens = TRUE, split_tags = TRUE, verbos
 
 # re-substitute the replacement hyphens and tags
 restore_special1 <- function(x, split_hyphens = TRUE, split_tags = TRUE, verbose) {
-    types <- types(x)
+    type <- attr(x, "types")
     if (!split_hyphens)
-        types <- stri_replace_all_fixed(types, "_hy_", "-")
+        type <- stri_replace_all_fixed(type, "_hy_", "-")
     if (!split_tags)
-        types <- stri_replace_all_fixed(types, c("_ht_", "_as_"), c("#", "@"),
-                                        vectorize_all = FALSE)
-    if (!identical(types, types(x))) {
-        types(x) <- types
+        type <- stri_replace_all_fixed(type, c("_ht_", "_as_"), c("#", "@"),
+                                       vectorize_all = FALSE)
+    if (!identical(type, attr(x, "types"))) {
+        attr(x, "types") <- type
         x <- tokens_recompile(x)
     }
     return(x)

--- a/R/tokenizers.R
+++ b/R/tokenizers.R
@@ -38,7 +38,7 @@ NULL
 #' @export
 tokenize_word <- function(x, split_hyphens = FALSE, verbose = quanteda_options("verbose")) {
     
-    if (verbose) catm(" ...segmenting tokens\n")
+    if (verbose) catm(" ...segmenting texts\n")
     m <- names(x)
     x[is.na(x)] <- "" # make NAs ""
     

--- a/R/tokenizers.R
+++ b/R/tokenizers.R
@@ -164,14 +164,15 @@ preserve_special1 <- function(x, split_hyphens = TRUE, split_tags = TRUE, verbos
 }
 
 # re-substitute the replacement hyphens and tags
-restore_special1 <- function(x, split_hyphens = TRUE, split_tags = TRUE, verbose) {
+restore_special1 <- function(x, split_hyphens = TRUE, split_tags = TRUE, recopile = TRUE, 
+                             verbose = FALSE) {
     type <- attr(x, "types")
     if (!split_hyphens)
         type <- stri_replace_all_fixed(type, "_hy_", "-")
     if (!split_tags)
         type <- stri_replace_all_fixed(type, c("_ht_", "_as_"), c("#", "@"),
                                        vectorize_all = FALSE)
-    if (!identical(type, attr(x, "types"))) {
+    if (!identical(type, attr(x, "types")) && recopile) {
         attr(x, "types") <- type
         x <- tokens_recompile(x)
     }

--- a/R/tokenizers.R
+++ b/R/tokenizers.R
@@ -38,7 +38,7 @@ NULL
 #' @export
 tokenize_word <- function(x, split_hyphens = FALSE, verbose = quanteda_options("verbose")) {
 
-    if (verbose) catm(" ...segmenting texts\n")
+    if (verbose) catm(" ...segmenting into words\n")
     m <- names(x)
     x[is.na(x)] <- "" # make NAs ""
 
@@ -145,7 +145,7 @@ tokenize_word1 <- function(x, split_hyphens = FALSE, verbose = quanteda_options(
     # substitute characters not to split
     x <- preserve_special1(x, split_hyphens = split_hyphens, split_tags = TRUE, verbose = verbose)
 
-    if (verbose) catm(" ...segmenting texts\n")
+    if (verbose) catm(" ...segmenting into words\n")
     structure(stri_split_boundaries(x, type = "word"), names = m)
 }
 

--- a/R/tokens.R
+++ b/R/tokens.R
@@ -580,9 +580,9 @@ tokens_recompile <- function(x, method = c("C++", "R"), gap = TRUE, dup = TRUE) 
 
     method <- match.arg(method)
     attrs <- attributes(x)
-
+    type <- attr(x, "types")
     if (method == "C++") {
-        x <- qatd_cpp_tokens_recompile(x, types(x), gap, dup)
+        x <- qatd_cpp_tokens_recompile(x, type, gap, dup)
         x <- rebuild_tokens(x, attrs)
     } else {
     
@@ -596,29 +596,29 @@ tokens_recompile <- function(x, method = c("C++", "R"), gap = TRUE, dup = TRUE) 
     
         # Remove gaps in the type index, if any, remap index
         if (gap) {
-            if (any(is.na(match(seq_len(length(types(x))), index_unique)))) {
-                types_new <- types(x)[index_unique]
+            if (any(is.na(match(seq_len(length(type)), index_unique)))) {
+                type_new <- type[index_unique]
                 index_new <- c(0, seq_along(index_unique)) # padding index is zero but not in types
                 index_unique <- c(0, index_unique) # padding index is zero but not in types
                 x <- lapply(unclass(x), function(y) index_new[fastmatch::fmatch(y, index_unique)])
                 attributes(x) <- attrs
-                types(x) <- types_new
+                type <- type_new
             }
         }
     
         # Reindex duplicates, if any
         if (dup) {
-            if (any(duplicated(types(x)))) {
-                types <- types(x)
-                types_unique <- unique(types)
-                index_mapping <- match(types, types_unique)
+            if (any(duplicated(type))) {
+                type_unique <- unique(type)
+                index_mapping <- match(type, type_unique)
                 index_mapping <- c(0, index_mapping) # padding index is zero but not in types
                 x <- lapply(unclass(x), function(y) index_mapping[y + 1]) # shift index for padding
                 attributes(x) <- attrs
-                types(x) <- types_unique
+                type <- type_unique
             }
         }
-        Encoding(types(x)) <- "UTF-8"
+        Encoding(type) <- "UTF-8"
+        attr(x, "types") <- type
         x <- rebuild_tokens(x, attrs)
     }
     return(x)

--- a/R/tokens.R
+++ b/R/tokens.R
@@ -389,7 +389,7 @@ tokens.tokens <-  function(x,
         docvars(x) <- NULL
 
     if (verbose) {
-        catm(" ...complete, elapsed time: ",
+        catm(" ...complete, elapsed time:",
              format((proc.time() - tokens_env$START_TIME)[3], digits = 3), "seconds.\n")
         catm("Finished constructing tokens from ", format(length(x), big.mark = ","), " document",
              if (length(x) > 1) "s", ".\n", sep = "")

--- a/R/tokens.R
+++ b/R/tokens.R
@@ -269,7 +269,7 @@ tokens.corpus <- function(x,
     
     # split x into smaller blocks to reducre peak memory consumption
     x <- texts(x)
-    x <- split(x, ceiling(seq_along(x) / 10000))
+    x <- split(x, factor(ceiling(seq_along(x) / 10000)))
     x <- lapply(x, function(y) {
         if (verbose) 
             catm(" ...", head(names(y), 1), "to", tail(names(y), 1), "by process", Sys.getpid(), "\n")
@@ -281,9 +281,9 @@ tokens.corpus <- function(x,
         }
         y <- serialize_tokens(tokenizer_fn(y, split_hyphens = split_hyphens, verbose = verbose))
         if (what == "word")
-            y <- restore_special(y, special, recompile = FALSE)
+            y <- restore_special(y, special)
         if (what == "word1" && !split_hyphens)
-            y <- restore_special1(y, split_hyphens = FALSE, split_tags = TRUE, recompile = FALSE)
+            y <- restore_special1(y, split_hyphens = FALSE, split_tags = TRUE)
         return(y)
     })
     type <- unique(unlist(lapply(x, attr, "types"), use.names = FALSE))

--- a/R/tokens.R
+++ b/R/tokens.R
@@ -270,6 +270,7 @@ tokens.corpus <- function(x,
     # split x into smaller blocks to reducre peak memory consumption
     x <- split(x, ceiling(seq_along(x) / 10000))
     for (i in seq_along(x)) {
+        x[[i]] <- normalize_characters(x[[i]])
         if (what == "word") {
             x[[i]] <- preserve_special(x[[i]], split_hyphens = split_hyphens, 
                                   split_tags = FALSE, verbose = verbose)

--- a/R/tokens.R
+++ b/R/tokens.R
@@ -269,7 +269,7 @@ tokens.corpus <- function(x,
 
     # split x into smaller blocks to reduce peak memory consumption
     x <- texts(x)
-    x <- split(x, factor(ceiling(seq_along(x) / quanteda_options("block_size"))))
+    x <- split(x, factor(ceiling(seq_along(x) / quanteda_options("tokens_block_size"))))
     x <- lapply(x, function(y) {
         if (verbose)
             catm(" ...", head(names(y), 1), " to ", tail(names(y), 1), "\n", sep = "")

--- a/R/tokens.R
+++ b/R/tokens.R
@@ -269,11 +269,13 @@ tokens.corpus <- function(x,
 
     # split x into smaller blocks to reduce peak memory consumption
     x <- texts(x)
-    x <- split(x, factor(ceiling(seq_along(x) / 10000)))
+    x <- split(x, factor(ceiling(seq_along(x) / quanteda_options("block_size"))))
     x <- lapply(x, function(y) {
         if (verbose)
-            catm(" ...", head(names(y), 1), " to ", tail(names(y), 1),
-                 " by process ", Sys.getpid(), "\n", sep = "")
+            catm(" ...", head(names(y), 1), " to ", tail(names(y), 1), "\n", sep = "")
+            #catm(" ...", head(names(y), 1), " to ", tail(names(y), 1),
+            #     " by process ", Sys.getpid(), "\n", sep = "")
+            
         y <- normalize_characters(y)
         if (what == "word") {
             y <- preserve_special(y, split_hyphens = split_hyphens,

--- a/R/tokens.R
+++ b/R/tokens.R
@@ -268,16 +268,17 @@ tokens.corpus <- function(x,
         warning("remove_separators is always TRUE for this type")
     
     # split x into smaller blocks to reducre peak memory consumption
+    x <- texts(x)
     x <- split(x, ceiling(seq_along(x) / 10000))
     x <- lapply(x, function(y) {
+        if (verbose) 
+            catm(" ...", head(names(y), 1), "to", tail(names(y), 1), "by process", Sys.getpid(), "\n")
         y <- normalize_characters(y)
         if (what == "word") {
             y <- preserve_special(y, split_hyphens = split_hyphens, 
                                   split_tags = FALSE, verbose = verbose)
             special <- attr(y, "special")
         }
-        if (verbose) 
-            catm(" ...", head(names(y), 1), "to", tail(names(y), 1), "by pid=", Sys.getpid(), "\n")
         y <- serialize_tokens(tokenizer_fn(y, split_hyphens = split_hyphens, verbose = verbose))
         if (what == "word")
             y <- restore_special(y, special, recompile = FALSE)
@@ -287,7 +288,7 @@ tokens.corpus <- function(x,
     })
     type <- unique(unlist(lapply(x, attr, "types"), use.names = FALSE))
     if (verbose) 
-        catm(format(length(type), big.mark = ",", trim = TRUE), "unique types\n")
+        catm(" ...", format(length(type), big.mark = ",", trim = TRUE), "unique types\n")
     x <- lapply(x, function(y) {
         map <- fastmatch::fmatch(attr(y, "types"), type)
         y <- lapply(y, function(z) map[z])
@@ -349,8 +350,7 @@ tokens.tokens <-  function(x,
     # splits
     if (split_hyphens) {
         if (verbose) catm(" ...splitting hyphens\n")
-        x <- tokens_split(x, "\\p{Pd}", valuetype = "regex", remove_separator = FALSE,
-                          verbose = verbose)
+        x <- tokens_split(x, "\\p{Pd}", valuetype = "regex", remove_separator = FALSE)
     }
     
     # removals
@@ -370,14 +370,14 @@ tokens.tokens <-  function(x,
     
     if (length(removals[["separators"]])) {
         x <- tokens_remove(x, removals[["separators"]], valuetype = "regex",
-                           verbose = verbose)
+                           verbose = FALSE)
         removals["separators"] <- NULL
     }
     
     if (length(removals)) {
         x <- tokens_remove(x, paste(unlist(removals), collapse = "|"),
                            valuetype = "regex",  padding = padding,
-                           verbose = verbose)
+                           verbose = FALSE)
     }
 
     if (!include_docvars)

--- a/man/quanteda_options.Rd
+++ b/man/quanteda_options.Rd
@@ -55,7 +55,7 @@ created by matrix factorization}
 \item{\code{pattern_hashtag}, \code{pattern_username}}{character; regex patterns for
 (social media) hashtags and usernames respectively, used to avoid segmenting
 these in the default internal "word" tokenizer}
-\item{\code{block_size}}{integer; specifies the
+\item{\code{tokens_block_size}}{integer; specifies the
 number of documents to be tokenized at a time in blocked tokenization.
 When the number is large, tokenization becomes faster but also memory-intensive.}}
 }

--- a/man/quanteda_options.Rd
+++ b/man/quanteda_options.Rd
@@ -54,7 +54,10 @@ created by matrix factorization}
 \link{tokens_wordstem}, and \link{dfm_wordstem}}
 \item{\code{pattern_hashtag}, \code{pattern_username}}{character; regex patterns for
 (social media) hashtags and usernames respectively, used to avoid segmenting
-these in the default internal "word" tokenizer}}
+these in the default internal "word" tokenizer}
+\item{\code{block_size}}{integer; specifies the
+number of documents to be tokenized at a time in blocked tokenization.
+When the number is large, tokenization becomes faster but also memory-intensive.}}
 }
 \examples{
 (opt <- quanteda_options())

--- a/tests/testthat/test-corpus.R
+++ b/tests/testthat/test-corpus.R
@@ -595,14 +595,3 @@ test_that("corpus indexing works as expected", {
     expect_error(corp[c("d1", "d4")], "Subscript out of bounds")
 })
 
-test_that("corpus normalize dashes and hyphens", {
-  corp <- corpus(c(d1 = "thanks--great, good-bye",
-                   d2 = "100‒200, maybe ⁓150",
-                   d3 = "cut here –––––––––"))
-
-  expect_equal(texts(corp),
-               c(d1 = "thanks - great, good-bye",
-                 d2 = "100 - 200, maybe  - 150",
-                 d3 = "cut here  - ")
-  )
-})

--- a/tests/testthat/test-dfm.R
+++ b/tests/testthat/test-dfm.R
@@ -110,7 +110,7 @@ test_that("test rbind.dfm with the same features, but in a different order", {
 
 test_that("dfm keeps all types with > 10,000 documents (#438) (a)", {
     generate_testdfm <- function(n) {
-        dfm(paste("X", 1:n, sep = ""))
+        dfm(paste("X", seq_len(n), sep = ""))
     }
     expect_equal(nfeat(generate_testdfm(10000)), 10000)
     expect_equal(nfeat(generate_testdfm(20000)), 20000)

--- a/tests/testthat/test-tokens.R
+++ b/tests/testthat/test-tokens.R
@@ -804,7 +804,7 @@ test_that("tokens.tokens(x, remove_separators = TRUE, verbose = TRUE) works as e
     )
     expect_message(
         tokens(tokens("Removing separators", remove_separators = TRUE), verbose = TRUE),
-        c("elapsed time:  .+ seconds")
+        c("elapsed time: .+ seconds")
     )
 })
 

--- a/tests/testthat/test-tokens.R
+++ b/tests/testthat/test-tokens.R
@@ -1045,6 +1045,31 @@ test_that("tokens.tokens(x, padding = TRUE) works", {
     )
 })
 
+test_that("special1 functions are working", {
+    expect_identical(
+        quanteda:::preserve_special1("#quanteda #q-x #q_y #q100 #q", 
+                                     split_hyphens = TRUE, split_tags = FALSE),
+        "_ht_quanteda _ht_q-x _ht_q_y _ht_q100 _ht_q"
+    )
+    expect_identical(
+        quanteda:::preserve_special1("#quanteda #q-x #q_y #q100 #q", 
+                                     split_hyphens = FALSE, split_tags = FALSE),
+        "_ht_quanteda _ht_q_hy_x _ht_q_y _ht_q100 _ht_q"
+    )
+    toks1 <- list(1:5)
+    attr(toks1, "types") <- c("_ht_quanteda", "_ht_q-x", "_ht_q_y", "_ht_q100", "_ht_q")
+    expect_identical(
+        attr(quanteda:::restore_special1(toks1, split_hyphens = TRUE, split_tags = FALSE), "types"),
+        c("#quanteda", "#q-x", "#q_y", "#q100", "#q")
+    )
+    toks2 <- list(1:5)
+    attr(toks2, "types") <- c("_ht_quanteda", "_ht_q_hy_x", "_ht_q_y", "_ht_q100", "_ht_q")
+    expect_identical(
+        attr(quanteda:::restore_special1(toks2, split_hyphens = FALSE, split_tags = FALSE), "types"),
+        c("#quanteda", "#q-x", "#q_y", "#q100", "#q")
+    )
+})
+
 test_that("tokenizing Japanese with URLs works", {
     txt <- c(d1 = "私のユーザー名は@quantedainitです。")
     expect_identical(
@@ -1104,7 +1129,7 @@ test_that("username is preserved", {
     )
 })
 
-test_that("htags are preserved", {
+test_that("tags are preserved", {
     txt <- c(d1 = "#quanteda #q-x #q_y #q100 #q")
     expect_identical(
         as.list(tokens(txt, what = "word")),
@@ -1159,3 +1184,5 @@ test_that("remove_numbers functions correctly", {
         c("and", "and", "100bn", "20-year-old", "4ever", "gr8")
     )
 })
+
+


### PR DESCRIPTION
This is for restructuring of tokens internals to increase the efficiency with very large corpora.

- Concentrate slow functions within a `lapply()` loop (which can be replaced by `future_lapply()`) (#1965)
- Change how tokenization progress is displayed
- Move character normalization (e.g. hyphens) to tokenizer
- Fix handling of the `verbose` option in `tokens.tokens()` (#1926)

The internal design is tested in `tokens_parallel()` in [a separate branch](https://github.com/quanteda/quanteda/blob/dev-tokens_parallel/R/tokens_parallel.R) and worked with a corpus of 30 million texts (20GB) (takes only 30 min in serial process).

Remaining questions are

- How to print the progress when `verbose = TRUE`?
- When should be switch to `future_lapply()`?