### PR TITLE
Raise warning for NA

### DIFF
--- a/R/corpus.R
+++ b/R/corpus.R
@@ -120,8 +120,12 @@ corpus.character <- function(x, docnames = NULL, docvars = NULL,
                              meta = list(), unique_docnames = TRUE, ...) {
 
     unused_dots(...)
-    x[is.na(x)] <- ""
-
+    is_na <- is.na(x)
+    if (any(is.na(x))) {
+        warning("NA is replaced by empty string", call. = FALSE)
+        x[is_na] <- ""
+    }
+    
     if (!is.null(docnames)) {
         if (length(docnames) != length(x))
             stop(message_error("docnames_mismatch"))

--- a/tests/testthat/test-corpus.R
+++ b/tests/testthat/test-corpus.R
@@ -371,13 +371,17 @@ test_that("corpus.data.frame sets docnames correctly", {
     )
 })
 
-test_that("corpus handles NA correctly (#1372)", {
+test_that("corpus handles NA correctly (#1372, #1969)", {
+    txt <- c("a b c", NA, "d e f")
     expect_true(!any(
-        is.na(texts(corpus(c("a b c", NA, "d e f"))))
+        is.na(texts(corpus(txt)))
     ))
+    expect_warning(
+        corpus(txt),
+        "NA is replaced by empty string"
+    )
     expect_true(!any(
-        is.na(texts(corpus(data.frame(text = c("a b c", NA, "d e f"),
-                                      stringsAsFactors = FALSE))))
+        is.na(texts(corpus(data.frame(text = txt, stringsAsFactors = FALSE))))
     ))
 })
 


### PR DESCRIPTION
For #1969. I though we will remove NA documents, but it changing the number of documents affect other inputs like `docnames`, `docvars`, so this would be the safest approach. 