### PR TITLE
Fix 1976

### DIFF
--- a/CRAN-RELEASE
+++ b/CRAN-RELEASE
@@ -1,0 +1,2 @@
+This package was submitted to CRAN on 2020-06-25.
+Once it is accepted, delete this file and tag the release (commit c43c37b29e).

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: quanteda
-Version: 2.0.9000
+Version: 2.1.0
 Title: Quantitative Analysis of Textual Data
 Description: A fast, flexible, and comprehensive framework for 
     quantitative text analysis in R.  Provides functionality for corpus management,
@@ -72,6 +72,7 @@ Suggests:
     testthat,
     text2vec,
     tibble,
+    formatR,
     tidytext,
     tm (>= 0.6),
     tokenizers,

--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,7 @@
 * Fixed a bug that caused a `textstat_simil/dist` object converted to a data.frame to drop its `document2` labels (#1939).
 * Fixed a bug causing `dfm_match()` to fail on a dfm that included "pads" (`""`). (#1960)
 * Updated the `data_dfm_lbgexample` object using more modern dfm internals.
+* Updates `textstat_readability()`, `textstat_lexdiv()`, and `nscrabble()` so that empty texts are not dropped in the result. (#1976)
 
 
 # quanteda 2.0.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# quanteda 2.1.0 (when released)
+# quanteda 2.1.0
 
 ## Changes
 
@@ -21,6 +21,7 @@
 * Fixed a problem in `dfm_lookup()` and `tokens_lookup()` in which an error was caused when no dictionary key returned a single match (#1946).
 * Fixed a bug that caused a `textstat_simil/dist` object converted to a data.frame to drop its `document2` labels (#1939).
 * Fixed a bug causing `dfm_match()` to fail on a dfm that included "pads" (`""`). (#1960)
+* Updated the `data_dfm_lbgexample` object using more modern dfm internals.
 
 
 # quanteda 2.0.1

--- a/R/corpus-methods-base.R
+++ b/R/corpus-methods-base.R
@@ -26,14 +26,14 @@ print.corpus <- function(x, max_ndoc = quanteda_options("print_corpus_max_ndoc")
 
     if (show_summary) {
         cat("Corpus consisting of ", format(ndoc, big.mark = ","), " document",
-            if (ndoc(x) > 1L) "s" else "", sep = "")
+            if (ndoc(x) != 1L) "s" else "", sep = "")
         if (ncol(docvars))
             cat(" and ", format(ncol(docvars), big.mark = ","), " docvar",
                 if (ncol(docvars) == 1L) "" else "s", sep = "")
         cat(".\n")
     }
 
-    if (max_ndoc > 0) {
+    if (max_ndoc > 0 && ndoc(x) > 0) {
         x <- head(texts(x), max_ndoc)
         label <- paste0(names(x), " :")
         x <- stri_replace_all_regex(x, "[\\p{C}]+", " ")

--- a/R/corpus_trim.R
+++ b/R/corpus_trim.R
@@ -54,7 +54,7 @@ corpus_trim.corpus <- function(x, what = c("sentences", "paragraphs", "documents
         is_pattern <- stri_detect_regex(texts(result), exclude_pattern)
         result <- corpus_subset(result, !is_pattern)
     }
-    if (what != "documents")
+    if (what != "documents" && ndoc(result) > 0)
         result <- corpus_reshape(result, to = "documents")
     return(result)
 }

--- a/R/nscrabble.R
+++ b/R/nscrabble.R
@@ -48,8 +48,9 @@ nscrabble.character <- function(x, FUN = sum) {
     
     textDT <- letterVals[textDT]
     textDT <- textDT[order(docIndex), FUN(values, na.rm = TRUE), by = docIndex]
-    result <- textDT[, V1]
-    if (!is.null(names(x))) names(result) <- names(x)
+    
+    result <- structure(rep(NA, length(x)), names = names(x))
+    result[textDT[, docIndex]] <- textDT[, V1]
     result
 }
 

--- a/R/textstat_lexdiv.R
+++ b/R/textstat_lexdiv.R
@@ -364,6 +364,7 @@ compute_lexdiv_dfm_stats <- function(x, measure = NULL, log.base = 10) {
     result <- data.frame(document = docnames(x), stringsAsFactors = FALSE)
     if (length(measure))
         result <- cbind(result, as.data.frame(temp[, measure, with = FALSE]))
+    result[is.na(result)] <- NA
     class(result) <- c("lexdiv", "textstat", "data.frame")
     return(result)
 }
@@ -388,6 +389,7 @@ compute_lexdiv_tokens_stats <- function(x, measure = c("MATTR", "MSTTR"),
 
     # reorder output as originally supplied
     result <- result[, c("document", measure), drop = FALSE]
+    result[is.na(result)] <- NA
     class(result) <- c("lexdiv", "textstat", "data.frame")
     return(result)
 }

--- a/R/textstat_readability.R
+++ b/R/textstat_readability.R
@@ -526,9 +526,11 @@ textstat_readability.corpus <- function(x,
 
     x <- texts(x)
     if (!is.null(min_sentence_length) || !is.null(max_sentence_length)) {
-        x <- char_trim(x, "sentences",
-                       min_ntoken = min_sentence_length,
-                       max_ntoken = max_sentence_length)
+        temp <- char_trim(x, "sentences",
+                          min_ntoken = min_sentence_length,
+                          max_ntoken = max_sentence_length)
+        x[names(temp)] <- temp
+        x[!names(x) %in% names(temp)] <- ""
     }
 
     # get sentence lengths - BEFORE lower-casing
@@ -798,8 +800,12 @@ textstat_readability.corpus <- function(x,
                                                   "W6C", "W7C", "Wlt3Sy", "W_wl.Dale.Chall", "W_wl.Spache"))])
 
     result <- cbind(result, as.data.frame(temp[, measure, with = FALSE]))
+    
+    # make any NA or NaN into NA (for #1976)
+    result[is.na(result)] <- NA
+    
     class(result) <- c("readability", "textstat", "data.frame")
-    rownames(result) <- as.character(seq_len(nrow(result)))
+    rownames(result) <- NULL # as.character(seq_len(nrow(result)))
     return(result)
 }
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -19,7 +19,14 @@ Resubmission - fixes soft dependency on the **formatR** package, now added under
 
 No ERRORs, NOTEs, or WARNINGs produced, _except_:
 
-There are several URLs not working on the Windows platform, but in previous correspondence with Uwe Ligges, I was told that this was a CRAN issue due to the JSTOR firewall, and something that CRAN needs to fix (and that I should retain the links despite the warnings).
+```
+> checking installed package size ... NOTE
+    installed size is  5.1Mb
+    sub-directories of 1Mb or more:
+      R   2.0Mb
+```
+
+and: There are several URLs not working on the Windows platform, but in previous correspondence with Uwe Ligges, I was told that this was a CRAN issue due to the JSTOR firewall, and something that CRAN needs to fix (and that I should retain the links despite the warnings).
 
 
 ## Downstream dependencies

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,28 +1,27 @@
 # Submission notes
 
-RESUBMISSION: Fixed a test that failed on the pre-v4 R because of stringsAsFactors differences.
+Resubmission - fixes soft dependency on the **formatR** package, now added under `Suggests:`.
 
 ## Purpose
     
-- Fixes some issues related to the development release of R 4.0 that sets `stringsAsFactors = FALSE` by default, that were showing up as errors on the CRAN checks (Debian, Fedora, and Solaris platforms).
-- Fixes some minor bugs discovered following the milestone v2.0.0 release.
-- Moves two data objects to another package, reducing the size of the package.
-
+- Numerous improvements and some bug fixes.
+- Fixes a noLD issue (on Solaris) noted on 25 June by Brian Ripley by email.
+- Fixes some errors on the CRAN results, related to the missing soft dependency on the **formatR** package.
 
 ## Test environments
 
-* local macOS 10.15.3, R 3.6.3
-* ubuntu Ubuntu 18.04 LTS and 18.10, R 3.6.3
+* local macOS 10.15.5, R 4.0.1
+* Ubuntu 18.04 LTS and 18.10, R 4.0.2
 * Windows release via devtools::check_win_release()
 * Windows devel via devtools::check_win_devel()
-* rhub::check_on_debian()
-* rhub::check_on_solaris()
 
 ## R CMD check results
 
-No ERRORs, NOTEs, or WARNINGs produced.
+No ERRORs, NOTEs, or WARNINGs produced, _except_:
+
+There are several URLs not working on the Windows platform, but in previous correspondence with Uwe Ligges, I was told that this was a CRAN issue due to the JSTOR firewall, and something that CRAN needs to fix (and that I should retain the links despite the warnings).
 
 
 ## Downstream dependencies
 
-This release causes no *new* breaks in other packages.
+This release causes no breaks in other packages.

--- a/docs/articles/pkgdown/quickstart.Rmd
+++ b/docs/articles/pkgdown/quickstart.Rmd
@@ -372,18 +372,19 @@ We can use these distances to plot a dendrogram, clustering presidents:
 ```{r, fig.width = 10, fig.height = 7, eval = FALSE}
 data(data_corpus_sotu, package = "quanteda.corpora")
 pres_dfm <- dfm(corpus_subset(data_corpus_sotu, Date > as.Date("1980-01-01")), 
-               stem = TRUE, remove_punct = TRUE,
-               remove = stopwords("english"))
+                stem = TRUE, remove_punct = TRUE,
+                remove = stopwords("english"))
 pres_dfm <- dfm_trim(pres_dfm, min_termfreq = 5, min_docfreq = 3)
 
 # hierarchical clustering - get distances on normalized dfm
 pres_dist_mat <- textstat_dist(dfm_weight(pres_dfm, "prop"))
-# hiarchical clustering the distance object
+# hierchical clustering the distance object
 pres_cluster <- hclust(pres_dist_mat)
 # label with document names
 pres_cluster$labels <- docnames(pres_dfm)
 # plot as a dendrogram
-plot(pres_cluster, xlab = "", sub = "", main = "Euclidean Distance on Normalized Token Frequency")
+plot(pres_cluster, xlab = "", sub = "", 
+     main = "Euclidean Distance on Normalized Token Frequency")
 ```
 
 We can also look at term similarities:

--- a/tests/testthat/test-corpus.R
+++ b/tests/testthat/test-corpus.R
@@ -599,3 +599,10 @@ test_that("corpus indexing works as expected", {
     expect_error(corp[c("d1", "d4")], "Subscript out of bounds")
 })
 
+test_that("printing a corpus works that has no documents", {
+    corp <- corpus(c("one", "two", "three"), docvars = data.frame(dv = 1:3))
+    expect_output(
+      print(corpus_subset(corp, rep(FALSE, 3))),
+      "Corpus consisting of 0 documents and 1 docvar."
+    )
+})

--- a/tests/testthat/test-nscrabble.R
+++ b/tests/testthat/test-nscrabble.R
@@ -1,0 +1,9 @@
+context("tests for nscrabble")
+
+test_that("test nscrabble", {
+    txt1 <- c("muzjiks", "excellency", "")
+    txt2 <- c(d1 = "muzjiks", d2 = "excellency", d3 = "")
+    
+    expect_identical(nscrabble(txt1), c(29L, 24L, NA))
+    expect_identical(nscrabble(txt2), c(d1 = 29L, d2 = 24L, d3 = NA))
+})

--- a/tests/testthat/test-textstat_readability.R
+++ b/tests/testthat/test-textstat_readability.R
@@ -23,7 +23,7 @@ test_that("readability works with sentence length filtering", {
     expect_equal(rdb$meanSentenceLength, c(3, 1.67, 5.50), tolerance = 0.01)
     
     rdb2 <- textstat_readability(txt, measure = "all", min_sentence_length = 3)
-    expect_equal(rdb2$meanSentenceLength, c(4, 9))
+    expect_equal(rdb2$meanSentenceLength, c(4, NA, 9))
 })
 
 # test_that("readability works as koRpus", {
@@ -163,4 +163,27 @@ test_that("textstat_readability has a default measure (#1715)",{
         names(textstat_readability(data_char_sampletext)),
         c("document", "Flesch")
     )
+})
+
+test_that("man/textstat_readability returns NA for empty documents", {
+    txt <- c(d1 = "The cat in the hat at green ham and eggs.", 
+             d2 = "", 
+             d3 = "Once upon a time.")
+    corp <- corpus(txt)
+    
+    expect_equivalent(
+        textstat_readability(txt, "Flesch"),
+        data.frame(document = paste0("d", 1:3), 
+                   Flesch = c(112.085, NA, 97.025),
+                   row.names = NULL, stringsAsFactors = FALSE)
+    )
+    expect_equivalent(
+        textstat_readability(txt, "Flesch", min_sentence_length = 5),
+        data.frame(document = paste0("d", 1:3), 
+                   Flesch = c(112.085, NA, NA),
+                   row.names = NULL, stringsAsFactors = FALSE)
+    )
+    
+    allstat <- textstat_readability(txt, "all")
+    expect_true(all(is.na(allstat["d2", -1])))
 })

--- a/vignettes/quickstart.Rmd
+++ b/vignettes/quickstart.Rmd
@@ -2,14 +2,15 @@
 title: "Quick Start Guide"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{Quick Start Guide to quanteda}
+  %\VignetteIndexEntry{Quick Start Guide}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---
 
 ```{r, echo = FALSE}
 knitr::opts_chunk$set(collapse = FALSE,
-                      comment = "##")
+                      comment = "##",
+                      tidy = TRUE)
 ```
 
 # Installing the package
@@ -184,7 +185,7 @@ summary(corpus_subset(data_corpus_inaugural, President == "Adams"))
 
 The `kwic` function (keywords-in-context) performs a search for a word and allows us to view the contexts in which it occurs:
 
-```{r, tidy=TRUE}
+```{r}
 kwic(data_corpus_inaugural, pattern = "terror")
 ```
 


### PR DESCRIPTION
Don't drop documents from the results of `textstat_readability()`, `textstat_lexdiv()`, and `nscrabble()` when documents are empty.

Also fixes a bug in `print.corpus()` caused by empty documents.

Solves #1976