### PR TITLE
Fix corpus_reshape()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: quanteda
-Version: 2.1.0
+Version: 2.1.0.9000
 Title: Quantitative Analysis of Textual Data
 Description: A fast, flexible, and comprehensive framework for 
     quantitative text analysis in R.  Provides functionality for corpus management,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# quanteda > 2.0.0
+
+## Changes
+
+## Bug fixes and stability enhancements
+
+* `corpus_reshape()` now allows reshaping back to documents even when segmented texts were of zero length. (#1978)
+
 # quanteda 2.1.0
 
 ## Changes

--- a/R/corpus_reshape.R
+++ b/R/corpus_reshape.R
@@ -53,7 +53,7 @@ corpus_reshape.corpus <- function(x, to = c("sentences", "paragraphs", "document
         if (field_object(attrs, "unit") %in% c("sentences", "paragraphs", "segments")) {
             docnum <- as.integer(droplevels(attrs$docvars[["docid_"]]))
             temp <- list("text" = split(unclass(x), docnum))
-            if (field_object(attrs, "unit") %in% c("sentences", "segments")) {
+            if (field_object(attrs, "unit") %in% c("sentences", "segments", "segments")) {
                 temp[["text"]] <- unlist(lapply(temp[["text"]], paste0, collapse = "  "))
             } else {
                 temp[["text"]] <- unlist(lapply(temp[["text"]], paste0, collapse = "\n\n"))
@@ -61,7 +61,7 @@ corpus_reshape.corpus <- function(x, to = c("sentences", "paragraphs", "document
             attrs[["docvars"]] <- reshape_docvars(attrs[["docvars"]], !duplicated(docnum))
             unit <- "documents"
         } else {
-            stop("reshape to documents only goes from sentences or paragraphs")
+            stop("reshape to documents only goes from sentences, paragraphs or segments")
         }
     } else if (to %in% c("sentences", "paragraphs")) {
         if (field_object(attrs, "unit") %in% "documents") {

--- a/R/corpus_reshape.R
+++ b/R/corpus_reshape.R
@@ -49,29 +49,23 @@ corpus_reshape.corpus <- function(x, to = c("sentences", "paragraphs", "document
     attrs <- attributes(x)
     if (field_object(attrs, "unit") == to)
         return(x)
+    if (field_object(attrs, "unit") == "sentences" && to == "paragraphs")
+        stop("reshape to paragraphs only goes from documents or segments")
     if (to == "documents") {
-        if (field_object(attrs, "unit") %in% c("sentences", "paragraphs", "segments")) {
-            docnum <- as.integer(droplevels(attrs$docvars[["docid_"]]))
-            temp <- list("text" = split(unclass(x), docnum))
-            if (field_object(attrs, "unit") %in% c("sentences", "segments", "segments")) {
-                temp[["text"]] <- unlist(lapply(temp[["text"]], paste0, collapse = "  "))
-            } else {
-                temp[["text"]] <- unlist(lapply(temp[["text"]], paste0, collapse = "\n\n"))
-            }
-            attrs[["docvars"]] <- reshape_docvars(attrs[["docvars"]], !duplicated(docnum))
-            unit <- "documents"
+        docnum <- as.integer(droplevels(attrs$docvars[["docid_"]]))
+        temp <- list("text" = split(unclass(x), docnum))
+        if (field_object(attrs, "unit") %in% c("sentences", "segments", "segments")) {
+            temp[["text"]] <- unlist(lapply(temp[["text"]], paste0, collapse = "  "))
         } else {
-            stop("reshape to documents only goes from sentences, paragraphs or segments")
+            temp[["text"]] <- unlist(lapply(temp[["text"]], paste0, collapse = "\n\n"))
         }
-    } else if (to %in% c("sentences", "paragraphs")) {
-        if (field_object(attrs, "unit") %in% c("segments", "documents")) {
-            temp <- segment_texts(x,  pattern = NULL, extract_pattern = FALSE,
-                                  omit_empty = FALSE, what = to, ...)
-            attrs[["docvars"]] <- reshape_docvars(attrs[["docvars"]], temp[["docnum"]])
-            unit <- to
-        } else {
-            stop("reshape to sentences or paragraphs only goes from segments or documents")
-        }
+        attrs[["docvars"]] <- reshape_docvars(attrs[["docvars"]], !duplicated(docnum))
+        unit <- "documents"
+    } else {
+        temp <- segment_texts(x,  pattern = NULL, extract_pattern = FALSE,
+                              omit_empty = FALSE, what = to, ...)
+        attrs[["docvars"]] <- reshape_docvars(attrs[["docvars"]], temp[["docnum"]])
+        unit <- to
     }
     build_corpus(
         temp[["text"]],

--- a/R/corpus_reshape.R
+++ b/R/corpus_reshape.R
@@ -64,13 +64,13 @@ corpus_reshape.corpus <- function(x, to = c("sentences", "paragraphs", "document
             stop("reshape to documents only goes from sentences, paragraphs or segments")
         }
     } else if (to %in% c("sentences", "paragraphs")) {
-        if (field_object(attrs, "unit") %in% "documents") {
+        if (field_object(attrs, "unit") %in% c("segments", "documents")) {
             temp <- segment_texts(x,  pattern = NULL, extract_pattern = FALSE,
                                   omit_empty = FALSE, what = to, ...)
             attrs[["docvars"]] <- reshape_docvars(attrs[["docvars"]], temp[["docnum"]])
             unit <- to
         } else {
-            stop("reshape to sentences or paragraphs only goes from documents")
+            stop("reshape to sentences or paragraphs only goes from segments or documents")
         }
     }
     build_corpus(

--- a/R/corpus_segment.R
+++ b/R/corpus_segment.R
@@ -223,7 +223,7 @@ segment_texts <- function(x, pattern = NULL, valuetype = "regex",
 
     if (is.null(pattern)) {
         if (what == "sentences")
-            x <- as.list(tokens(x, what = "sentence", ...))
+            x <- as.list(tokenize_sentence(x, ...))
     } else {
 
         if (valuetype == "glob") {

--- a/R/corpus_segment.R
+++ b/R/corpus_segment.R
@@ -212,8 +212,8 @@ segment_texts <- function(x, pattern = NULL, valuetype = "regex",
                           omit_empty = TRUE, what = "other", ...) {
 
     # normalize EOL
-    x <- stringi::stri_replace_all_fixed(x, "\r\n", "\n") # Windows
-    x <- stringi::stri_replace_all_fixed(x, "\r", "\n") # Old Macintosh
+    x <- stri_replace_all_fixed(x, "\r\n", "\n") # Windows
+    x <- stri_replace_all_fixed(x, "\r", "\n") # Old Macintosh
 
     # use preset regex pattern
     if (what == "paragraphs") {
@@ -228,17 +228,17 @@ segment_texts <- function(x, pattern = NULL, valuetype = "regex",
 
         if (valuetype == "glob") {
             # treat as fixed if no glob character is detected
-            if (!any(stringi::stri_detect_charclass(pattern, c("[*?]")))) {
+            if (!any(stri_detect_charclass(pattern, c("[*?]")))) {
                 valuetype <- "fixed"
             } else {
                 pattern <- escape_regex(pattern)
-                pattern <- stringi::stri_replace_all_fixed(pattern, '*', '(\\S*)')
-                pattern <- stringi::stri_replace_all_fixed(pattern, '?', '(\\S)')
+                pattern <- stri_replace_all_fixed(pattern, '*', '(\\S*)')
+                pattern <- stri_replace_all_fixed(pattern, '?', '(\\S)')
                 valuetype <- "regex"
             }
         }
         
-        x <- stringi::stri_trim_both(x)
+        x <- stri_trim_both(x)
         
         if (valuetype == "fixed") {
             if (pattern_position == "after") {

--- a/R/corpus_segment.R
+++ b/R/corpus_segment.R
@@ -223,7 +223,7 @@ segment_texts <- function(x, pattern = NULL, valuetype = "regex",
 
     if (is.null(pattern)) {
         if (what == "sentences")
-            x <- as.list(tokenize_sentence(x, ...))
+            x <- tokenize_sentence(x, ...)
     } else {
 
         if (valuetype == "glob") {

--- a/R/quanteda_options.R
+++ b/R/quanteda_options.R
@@ -25,14 +25,16 @@
 #' through an operation that adds features}
 #' \item{`base_compname`}{character; stem name for components that are
 #' created by matrix factorization} 
-#' \item{`language_stemmer`}{character; language option for [char_wordstem], 
-#' [tokens_wordstem], and [dfm_wordstem]} 
+#' \item{`language_stemmer`}{character; language option for [char_wordstem()], 
+#' [tokens_wordstem()], and [dfm_wordstem()]} 
 #' \item{`pattern_hashtag`, `pattern_username`}{character; regex patterns for
 #' (social media) hashtags and usernames respectively, used to avoid segmenting
 #' these in the default internal "word" tokenizer}
 #' \item{`tokens_block_size`}{integer; specifies the
 #'   number of documents to be tokenized at a time in blocked tokenization.
 #'   When the number is large, tokenization becomes faster but also memory-intensive.}}
+#' \item{`tokens_locale`}{character; specify locale in stringi boundary detection in 
+#'   tokenization and corpus reshaping. See [stringi::stri_opts_brkiter()].}
 #' @return When called using a `key = value` pair (where `key` can be
 #' a label or quoted character name)), the option is set and `TRUE` is
 #' returned invisibly.
@@ -157,6 +159,7 @@ get_options_default <- function(){
                  language_stemmer = "english",
                  pattern_hashtag = "#\\w+#?",
                  pattern_username = "@[a-zA-Z0-9_]+",
-                 tokens_block_size = 10000L)
+                 tokens_block_size = 10000L,
+                 tokens_locale = "en_US@ss=standard")
     return(opts)
 }

--- a/R/quanteda_options.R
+++ b/R/quanteda_options.R
@@ -32,9 +32,9 @@
 #' these in the default internal "word" tokenizer}
 #' \item{`tokens_block_size`}{integer; specifies the
 #'   number of documents to be tokenized at a time in blocked tokenization.
-#'   When the number is large, tokenization becomes faster but also memory-intensive.}}
+#'   When the number is large, tokenization becomes faster but also memory-intensive.}
 #' \item{`tokens_locale`}{character; specify locale in stringi boundary detection in 
-#'   tokenization and corpus reshaping. See [stringi::stri_opts_brkiter()].}
+#'   tokenization and corpus reshaping. See [stringi::stri_opts_brkiter()].}}
 #' @return When called using a `key = value` pair (where `key` can be
 #' a label or quoted character name)), the option is set and `TRUE` is
 #' returned invisibly.

--- a/R/tokenizers.R
+++ b/R/tokenizers.R
@@ -189,28 +189,11 @@ tokenize_character <- function(x, ...) {
 #' @export
 tokenize_sentence <- function(x, ..., verbose = FALSE) {
     if (verbose) catm(" ...segmenting into sentences.\n")
-    named <- names(x)
-
-    # Replace . delimiter from common title abbreviations, with _pd_
-    exceptions <- c("Mr", "Mrs", "Ms", "Dr", "Jr", "Prof", "Ph.D", "M", "MM", "St", "etc")
-    findregex <- paste0("\\b(", exceptions, ")\\.")
-    x <- stri_replace_all_regex(x, findregex, "$1_pd_", vectorize_all = FALSE)
-
-    ## Remove newline chars
-    x <- lapply(x, stri_replace_all_fixed, "\n", " ")
-
-    ## Perform the tokenization
-    tok <- stri_split_boundaries(x, type = "sentence")
-
-    ## Cleaning
-    tok <- lapply(tok, function(x) {
-        x <- x[which(x != "")] # remove any "sentences" that were completely blanked out
-        x <- stri_trim_right(x) # trim trailing spaces
-        x <- stri_replace_all_fixed(x, "_pd_", ".") # replace the non-full-stop "." characters
-        return(x)
-    })
-    names(tok) <- named
-    return(tok)
+    m <- names(x)
+    x <- stri_split_boundaries(x, type = "sentence", locale = quanteda_options("tokens_locale"))
+    x <- lapply(x, function(y) if (length(y)) stri_trim_right(y) else "")
+    names(x) <- m
+    return(x)
 }
 
 #' @rdname tokenize_internal

--- a/R/tokenizers.R
+++ b/R/tokenizers.R
@@ -190,6 +190,7 @@ tokenize_character <- function(x, ...) {
 tokenize_sentence <- function(x, ..., verbose = FALSE) {
     if (verbose) catm(" ...segmenting into sentences.\n")
     m <- names(x)
+    x <- stri_replace_all_fixed(x, "\n", " ") # TODO consider removing
     x <- stri_split_boundaries(x, type = "sentence", locale = quanteda_options("tokens_locale"))
     x <- lapply(x, function(y) if (length(y)) stri_trim_right(y) else "")
     names(x) <- m

--- a/R/tokenizers.R
+++ b/R/tokenizers.R
@@ -146,7 +146,8 @@ tokenize_word1 <- function(x, split_hyphens = FALSE, verbose = quanteda_options(
     x <- preserve_special1(x, split_hyphens = split_hyphens, split_tags = TRUE, verbose = verbose)
 
     if (verbose) catm(" ...segmenting into words\n")
-    structure(stri_split_boundaries(x, type = "word"), names = m)
+    x <- stri_split_boundaries(x, type = "word", locale = quanteda_options("tokens_locale"))
+    structure(x, names = m)
 }
 
 # substitutions to preserve hyphens and tags
@@ -193,8 +194,7 @@ tokenize_sentence <- function(x, ..., verbose = FALSE) {
     x <- stri_replace_all_fixed(x, "\n", " ") # TODO consider removing
     x <- stri_split_boundaries(x, type = "sentence", locale = quanteda_options("tokens_locale"))
     x <- lapply(x, function(y) if (length(y)) stri_trim_right(y) else "")
-    names(x) <- m
-    return(x)
+    structure(x, names = m)
 }
 
 #' @rdname tokenize_internal

--- a/man/quanteda_options.Rd
+++ b/man/quanteda_options.Rd
@@ -50,14 +50,16 @@ features that are unnamed when they are added, for whatever reason, to a dfm
 through an operation that adds features}
 \item{\code{base_compname}}{character; stem name for components that are
 created by matrix factorization}
-\item{\code{language_stemmer}}{character; language option for \link{char_wordstem},
-\link{tokens_wordstem}, and \link{dfm_wordstem}}
+\item{\code{language_stemmer}}{character; language option for \code{\link[=char_wordstem]{char_wordstem()}},
+\code{\link[=tokens_wordstem]{tokens_wordstem()}}, and \code{\link[=dfm_wordstem]{dfm_wordstem()}}}
 \item{\code{pattern_hashtag}, \code{pattern_username}}{character; regex patterns for
 (social media) hashtags and usernames respectively, used to avoid segmenting
 these in the default internal "word" tokenizer}
 \item{\code{tokens_block_size}}{integer; specifies the
 number of documents to be tokenized at a time in blocked tokenization.
-When the number is large, tokenization becomes faster but also memory-intensive.}}
+When the number is large, tokenization becomes faster but also memory-intensive.}
+\item{\code{tokens_locale}}{character; specify locale in stringi boundary detection in
+tokenization and corpus reshaping. See \code{\link[stringi:stri_opts_brkiter]{stringi::stri_opts_brkiter()}}.}}
 }
 \examples{
 (opt <- quanteda_options())

--- a/tests/testthat/test-corpus_reshape.R
+++ b/tests/testthat/test-corpus_reshape.R
@@ -64,7 +64,8 @@ test_that("corpus_reshape works with segmented corpus", {
     corp <- corpus(c(textone = "This is a sentence.  Another sentence.  Yet another.", 
                      texttwo = "Premiere phrase.  Deuxieme phrase."))
     corp_segmented <- corpus_segment(corp, ".", pattern_position = "after")
-    corp_reshaped <- corpus_reshape(corp_segmented, to = "documents")
+    corp_reshaped <- corpus_reshape(corp_segmented, to = "sentences")
+    corp_reshaped <- corpus_reshape(corp_reshaped, to = "documents")
     expect_equal(texts(corp_reshaped),
                  c(textone = "This is a sentence  Another sentence  Yet another",
                    texttwo = "Premiere phrase  Deuxieme phrase"))

--- a/tests/testthat/test-corpus_reshape.R
+++ b/tests/testthat/test-corpus_reshape.R
@@ -28,6 +28,10 @@ test_that("corpus_reshape works to sentences and back", {
                      texttwo = "Premiere phrase.  Deuxieme phrase."), 
                      docvars = data.frame(country=c("UK", "USA"), year=c(1990, 2000)))
     corp_reshaped <- corpus_reshape(corp, to = "sentences")
+    expect_error(
+        corpus_reshape(corp_reshaped, to = "paragraphs"),
+        "reshape to paragraphs only goes from documents or segments"
+    )
     corp_unshaped <- corpus_reshape(corp_reshaped, to = "documents")
     expect_equal(texts(corp),
                  texts(corp_unshaped))
@@ -47,7 +51,7 @@ test_that("corpus_reshape works to paragraphs and back", {
                  docvars(corp_unshaped))
 })
 
-test_that("corpus_reshape works with empty documents, issue #670", {
+test_that("corpus_reshape works with empty documents (#670)", {
     corp <- corpus(c(textone = "This is a paragraph.\n\nAnother paragraph.\n\nYet paragraph.", 
                          texttwo = "Premiere phrase.\n\nDeuxieme phrase.",
                          textthree = ""), 

--- a/tests/testthat/test-corpus_reshape.R
+++ b/tests/testthat/test-corpus_reshape.R
@@ -71,3 +71,13 @@ test_that("corpus_reshape works with segmented corpus", {
                    texttwo = "Premiere phrase  Deuxieme phrase"))
 })
 
+test_that("corpus_reshape preserve empty documents (#1978)", {
+    corp <- corpus(c(textone = "This is a sentence.  Another sentence.  Yet another.", 
+                     texttwo = "Premiere phrase.  Deuxieme phrase.",
+                     textthree = ""))
+    corp_reshaped <- corpus_reshape(corp, to = "sentences")
+    expect_identical(
+        docnames(corp),
+        docnames(corpus_reshape(corp_reshaped, to = "documents"))
+    )
+})

--- a/tests/testthat/test-nfunctions.R
+++ b/tests/testthat/test-nfunctions.R
@@ -1,7 +1,7 @@
 context("test nfunctions")
 
 test_that("test nsentence", {
-    txt <- c(doc1 = "This is Mr. Smith.  He is married to Dr. Jones.",
+    txt <- c(doc1 = "This is Mr. Smith.  He is married to Mrs. Jones.",
              doc2 = "Never, before: a colon!  Gimme a break.")
     expect_identical(nsentence(txt), c(doc1 = 2L, doc2 = 2L))
     expect_identical(nsentence(corpus(txt)), c(doc1 = 2L, doc2 = 2L))


### PR DESCRIPTION
Address multiple issues related to `corpus_reshape()`
- Stop removing empty documents (#1978)
- Expose stringi's `locale` option (#1979)
- Allow further reshaping segmented corpus