### PR TITLE
Fix dictionary printing problem when max_nkey = 0,  max_nval = 0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -179,6 +179,6 @@ Collate:
     'utils.R'
     'wordstem.R'
     'zzz.R'
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1
 SystemRequirements: C++11
 Roxygen: list(markdown = TRUE)

--- a/R/dictionaries.R
+++ b/R/dictionaries.R
@@ -357,7 +357,7 @@ setMethod("print", signature(x = "dictionary2"),
                   if (lev != "") cat(" and ", depth, " nested levels", sep = "")
                   cat(".\n")
               }
-              print_dictionary(x, 1, max_nkey, max_nval, ...)
+              invisible(print_dictionary(x, 1, max_nkey, max_nval, ...))
           })
 
 #' @rdname print-quanteda

--- a/tests/testthat/test-dictionaries.R
+++ b/tests/testthat/test-dictionaries.R
@@ -206,6 +206,12 @@ test_that("dictionary printing works", {
       ),
       fixed = TRUE
     )
+    
+    expect_output(
+      print(dict, 0, 0),
+      "Dictionary object with 2 key entries.",
+      fixed = TRUE
+    )
 })
 
 


### PR DESCRIPTION
Fixes this problem:

```r
> print(data_dictionary_LSD2015, 0, 0)
Dictionary object with 4 key entries.
NULL
```

In the fix, it does not show the `NULL` which is returned by the early return of the function in `print_dictionary()`.