### PR TITLE
Remove ngrams argument examples from dfm help

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,9 +2,12 @@
 
 ## Changes
 
+* Mentions of the now-removed `ngrams` option in `dfm(x, ...)` has now been removed from the dfm documentation.  (#1990)
+
 ## Bug fixes and stability enhancements
 
 * Allow use of multi-threading with more than two threads by fixing `quanteda_options()`.
+
 
 # quanteda 2.1.2
 

--- a/R/dfm.R
+++ b/R/dfm.R
@@ -8,8 +8,7 @@
 #' @param remove a [pattern] of user-supplied features to ignore, such as "stop
 #'   words".  To access one possible list (from any list you wish), use
 #'   [stopwords()].  The pattern matching type will be set by `valuetype`.  See
-#'   also [tokens_select()].  For behaviour of `remove` with `ngrams > 1`, see
-#'   Details.
+#'   also [tokens_select()].  
 #' @param select a  [pattern]  of user-supplied features to keep, while
 #'   excluding all others.  This can be used in lieu of a dictionary if there
 #'   are only specific features that a user wishes to keep. To extract only
@@ -33,15 +32,6 @@
 #' @param verbose display messages if `TRUE`
 #' @param ... additional arguments passed to [tokens]; not used when `x` is a
 #'   [dfm]
-#' @details The default behaviour for `remove`/`select` when constructing ngrams
-#'   using `dfm(x, ` *ngrams > 1*`)` is to remove/select any ngram constructed
-#'   from a matching feature.  If you wish to remove these before constructing
-#'   ngrams, you will need to first tokenize the texts with ngrams, then remove
-#'   the features to be ignored, and then construct the dfm using this modified
-#'   tokenization object.  See the code examples for an illustration.
-#'
-#'   To select on and match the features of a another [dfm], `x` must also be a
-#'   [dfm].
 #' @return a [dfm-class] object
 #' @import Matrix
 #' @export
@@ -80,13 +70,10 @@
 #' corp <- corpus(txt)
 #' # note: "also" is not in the default stopwords("english")
 #' featnames(dfm(corp, select = stopwords("english")))
-#' # for ngrams
-#' featnames(dfm(corp, ngrams = 2, select = stopwords("english"), remove_punct = TRUE))
-#' featnames(dfm(corp, ngrams = 1:2, select = stopwords("english"), remove_punct = TRUE))
 #'
 #' # removing stopwords before constructing ngrams
 #' toks1 <- tokens(char_tolower(txt), remove_punct = TRUE)
-#' toks2 <- tokens_remove(toks1, stopwords("english"))
+#' toks2 <- tokens_remove(toks1, stopwords("english"), padding = TRUE)
 #' toks3 <- tokens_ngrams(toks2, 2)
 #' featnames(dfm(toks3))
 #'
@@ -341,13 +328,6 @@ dfm.dfm <- function(x,
         if (!is.null(remove) & !is.null(select))
             stop("only one of select and remove may be supplied at once")
         if (verbose) catm(" ...")
-        # if ngrams > 1 and remove or select is specified, then convert these
-        # into a regex that will remove any ngram containing one of the words
-        # if (!identical(field_object(attrs, "ngram"), 1L)) {
-        #     remove <- make_ngram_pattern(remove, valuetype,
-        #                                  field_object(attrs, "concatenator"))
-        #     valuetype <- "regex"
-        # }
         x <- dfm_select(x,
                         pattern = if (!is.null(remove)) remove else select,
                         selection = if (!is.null(remove)) "remove" else "keep",

--- a/man/dfm.Rd
+++ b/man/dfm.Rd
@@ -38,8 +38,7 @@ this matching pattern.  The pattern matching type will be set by
 \item{remove}{a \link{pattern} of user-supplied features to ignore, such as "stop
 words".  To access one possible list (from any list you wish), use
 \code{\link[=stopwords]{stopwords()}}.  The pattern matching type will be set by \code{valuetype}.  See
-also \code{\link[=tokens_select]{tokens_select()}}.  For behaviour of \code{remove} with \code{ngrams > 1}, see
-Details.}
+also \code{\link[=tokens_select]{tokens_select()}}.}
 
 \item{dictionary}{a \link{dictionary} object to apply to the tokens when creating
 the dfm}
@@ -74,17 +73,6 @@ a \linkS4class{dfm} object
 \description{
 Construct a sparse document-feature matrix, from a character, \link{corpus},
 \link{tokens}, or even other \link{dfm} object.
-}
-\details{
-The default behaviour for \code{remove}/\code{select} when constructing ngrams
-using \verb{dfm(x, } \emph{ngrams > 1}\verb{)} is to remove/select any ngram constructed
-from a matching feature.  If you wish to remove these before constructing
-ngrams, you will need to first tokenize the texts with ngrams, then remove
-the features to be ignored, and then construct the dfm using this modified
-tokenization object.  See the code examples for an illustration.
-
-To select on and match the features of a another \link{dfm}, \code{x} must also be a
-\link{dfm}.
 }
 \note{
 When \code{x} is a \link{dfm}, \code{groups} provides a convenient and fast method of
@@ -122,13 +110,10 @@ txt <- "The quick brown fox named Seamus jumps over the lazy dog also named Seam
 corp <- corpus(txt)
 # note: "also" is not in the default stopwords("english")
 featnames(dfm(corp, select = stopwords("english")))
-# for ngrams
-featnames(dfm(corp, ngrams = 2, select = stopwords("english"), remove_punct = TRUE))
-featnames(dfm(corp, ngrams = 1:2, select = stopwords("english"), remove_punct = TRUE))
 
 # removing stopwords before constructing ngrams
 toks1 <- tokens(char_tolower(txt), remove_punct = TRUE)
-toks2 <- tokens_remove(toks1, stopwords("english"))
+toks2 <- tokens_remove(toks1, stopwords("english"), padding = TRUE)
 toks3 <- tokens_ngrams(toks2, 2)
 featnames(dfm(toks3))
 

--- a/tests/testthat/test-corpus.R
+++ b/tests/testthat/test-corpus.R
@@ -374,14 +374,16 @@ test_that("corpus.data.frame sets docnames correctly", {
 test_that("corpus handles NA correctly (#1372, #1969)", {
     txt <- c("a b c", NA, "d e f")
     expect_true(!any(
-        is.na(texts(corpus(txt)))
-    ))
+        suppressWarnings(is.na(texts(corpus(txt)))
+    )))
     expect_warning(
         corpus(txt),
         "NA is replaced by empty string"
     )
     expect_true(!any(
-        is.na(texts(corpus(data.frame(text = txt, stringsAsFactors = FALSE))))
+        suppressWarnings(
+          is.na(texts(corpus(data.frame(text = txt, stringsAsFactors = FALSE))))
+        )
     ))
 })
 

--- a/tests/testthat/test-kwic.R
+++ b/tests/testthat/test-kwic.R
@@ -7,7 +7,7 @@ test_that("test attr(kwic, 'ntoken') with un-named texts", {
         "The quick brown dog jumped over the lazy dog",
         NA
     )
-    kw <- kwic(txt, "fox")
+    kw <- suppressWarnings(kwic(txt, "fox"))
 
     expect_equal(
         attr(kw, "ntoken"),

--- a/tests/testthat/test-tokens.R
+++ b/tests/testthat/test-tokens.R
@@ -521,11 +521,11 @@ test_that("tokens works as expected with NA, and blanks", {
         list(text1 = "one", text2 = "two", text3 = character())
     )
     expect_equal(
-        as.list(tokens(c("one", NA, ""))),
+        as.list(suppressWarnings(tokens(c("one", NA, "")))),
         list(text1 = "one", text2 = character(), text3 = character())
     )
     expect_equal(
-        as.list(tokens(c(NA, "one", ""))),
+        as.list(suppressWarnings(tokens(c(NA, "one", "")))),
         list(text1 = character(), text2 = "one", text3 = character())
     )
     expect_equal(
@@ -533,11 +533,11 @@ test_that("tokens works as expected with NA, and blanks", {
         list(text1 = character())
     )
     expect_equal(
-        as.list(tokens(c(d1 = "", d2 = NA))),
+        as.list(suppressWarnings(tokens(c(d1 = "", d2 = NA)))),
         list(d1 = character(), d2 = character())
     )
     expect_equal(
-        as.list(tokens(c(d1 = NA, d2 = ""))),
+        as.list(suppressWarnings(tokens(c(d1 = NA, d2 = "")))),
         list(d1 = character(), d2 = character())
     )
     expect_equal(


### PR DESCRIPTION
Removes the examples from the dfm help that still contain the `ngrams` argument, despite this being removed many versions ago.

Solves #1990 
Closes #1896 

See also #1602