### PR TITLE
Print Unicode and ICU versions

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,7 +1,9 @@
 .onAttach <- function(...) {
     # startup message
     #packageStartupMessage("Initializing package: ", sQuote('quanteda'))
-    packageStartupMessage("Package version: ", as.character(utils::packageVersion("quanteda")))
+    packageStartupMessage("Package version: ", as.character(utils::packageVersion("quanteda")), "\n",
+                          "Unicode version: ", stringi::stri_info()[["Unicode.version"]], "\n",
+                          "ICU version: ", stringi::stri_info()[["ICU.version"]])
     
     # initialize options
     quanteda_options(initialize = TRUE)


### PR DESCRIPTION
to make trouble shooting easier and make users aware of the differences. It also helps to address https://github.com/quanteda/quanteda.textstats/issues/24.