### PR TITLE
Stop omit_empty warnings

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -68,8 +68,6 @@ Suggests:
     DT,
     xtable,
     ggplot2
-Remotes:
-    quanteda/quanteda.textplots
 URL: https://quanteda.io
 Encoding: UTF-8
 BugReports: https://github.com/quanteda/quanteda/issues

--- a/R/convert.R
+++ b/R/convert.R
@@ -93,7 +93,9 @@ convert.dfm <- function(x, to = c("lda", "tm", "stm", "austin", "topicmodels",
 
     x <- as.dfm(x)
     to <- match.arg(to)
-    omit_empty <- check_logical(omit_empty)
+    if (!missing(omit_empty)) {
+        omit_empty <- check_logical(omit_empty)
+    }
     docid_field <- check_character(docid_field)
     check_dots(...)
     
@@ -110,7 +112,7 @@ convert.dfm <- function(x, to = c("lda", "tm", "stm", "austin", "topicmodels",
             stop("cannot convert a non-count dfm to a topic model format")
     }
 
-    if (!to %in% c("lda", "topicmodels") && !missing(omit_empty) && omit_empty) {
+    if (!to %in% c("lda", "topicmodels") && !missing(omit_empty)) {
         warning("omit_empty not used for 'to = \"", to, "\"'")
     }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -55,15 +55,18 @@ NULL
 #     return(x)
 # }
 
-#' Convert various input as pattern to a vector used in tokens_select,
-#' tokens_compound and kwic.
+#' Convert various inputs as pattern to a vector
+#' 
+#' Convert various inputs as pattern to a vector.  Used in [tokens_select],
+#' [tokens_compound], and [kwic].
 #' @inheritParams pattern
 #' @inheritParams valuetype
-#' @param concatenator concatenator that join multi-word expression in tokens object
+#' @param concatenator concatenator that joins multi-word expressions in a
+#'   tokens object
 #' @param levels only used when pattern is a dictionary
 #' @param remove_unigram ignore single-word patterns if `TRUE`
-#' @seealso [pattern2id()]
 #' @keywords internal
+#' @seealso [pattern2id()]
 pattern2list <- function(x, types, valuetype, case_insensitive,
                          concatenator = "_", levels = 1, remove_unigram = FALSE,
                          keep_nomatch = FALSE) {

--- a/man/pattern2list.Rd
+++ b/man/pattern2list.Rd
@@ -25,7 +25,8 @@ exact matching. See \link{valuetype} for details.}
 \item{case_insensitive}{logical; if \code{TRUE}, ignore case when matching a
 \code{pattern} or \link{dictionary} values}
 
-\item{concatenator}{concatenator that join multi-word expression in tokens object}
+\item{concatenator}{concatenator that joins multi-word expressions in a
+tokens object}
 
 \item{levels}{only used when pattern is a dictionary}
 
@@ -42,17 +43,18 @@ Function to assign multiple slots to a S4 object
 \code{\link[=pattern2id]{pattern2id()}}
 }
 \keyword{Convert}
+\keyword{Used}
+\keyword{[kwic].}
+\keyword{[tokens_compound],}
+\keyword{[tokens_select],}
 \keyword{a}
 \keyword{and}
 \keyword{as}
 \keyword{in}
-\keyword{input}
+\keyword{inputs}
 \keyword{internal}
-\keyword{kwic.}
 \keyword{pattern}
 \keyword{to}
-\keyword{tokens_compound}
-\keyword{tokens_select,}
-\keyword{used}
 \keyword{various}
 \keyword{vector}
+\keyword{vector.}


### PR DESCRIPTION
These happened even when the argument was not supplied, because `check_logical()` created a value even when this value was missing.