### PR TITLE
Correct input validation in dfm_match()

### DIFF
--- a/R/dfm_match.R
+++ b/R/dfm_match.R
@@ -46,7 +46,7 @@ dfm_match.default <- function(x, features) {
 #' @export
 dfm_match.dfm <- function(x, features) {
     x <- as.dfm(x)
-    features <- check_character(features, max_len = Inf)
+    features <- check_character(features, min_len = 0, max_len = Inf)
     attrs <- attributes(x)
     x <- pad_dfm(x, features)
     rebuild_dfm(x, attrs)

--- a/tests/testthat/test-dfm_match.R
+++ b/tests/testthat/test-dfm_match.R
@@ -4,43 +4,51 @@ test_that("dfm_match works", {
 
     txt <- c(doc1 = "aa bb BB cc DD ee",
              doc2 = "aa bb cc DD ee")
-    mt <- dfm(txt, tolower = FALSE)
+    dfmat <- dfm(txt, tolower = FALSE)
 
-    mt_conf1 <- dfm_match(mt, c("aa", "zz", "xx", "bb"))
+    dfmat_conf1 <- dfm_match(dfmat, c("aa", "zz", "xx", "bb"))
     expect_identical(
-        featnames(mt_conf1),
+        featnames(dfmat_conf1),
         c("aa", "zz", "xx", "bb")
     )
     expect_identical(
-        docnames(mt_conf1),
+        docnames(dfmat_conf1),
         c("doc1", "doc2")
     )
     expect_identical(
-        colSums(mt_conf1),
+        colSums(dfmat_conf1),
         c("aa" = 2, "zz" = 0, "xx" = 0, "bb" = 2)
     )
 
-    mt_conf2 <- dfm_match(mt, featnames(dfm("aa zz xx bb")))
+    dfmat_conf2 <- dfm_match(dfmat, featnames(dfm("aa zz xx bb")))
     expect_identical(
-        featnames(mt_conf2),
+        featnames(dfmat_conf2),
         c("aa", "zz", "xx", "bb")
     )
     expect_identical(
-        docnames(mt_conf2),
+        docnames(dfmat_conf2),
         c("doc1", "doc2")
     )
     expect_identical(
-        colSums(mt_conf2),
+        colSums(dfmat_conf2),
         c("aa" = 2, "zz" = 0, "xx" = 0, "bb" = 2)
     )
     
+    dfmat_conf3 <- dfm_match(dfmat, character())
+    expect_identical(
+        featnames(dfmat_conf3), character()
+    )
+    expect_identical(
+        docnames(dfmat_conf3),
+        c("doc1", "doc2")
+    )
 })
 
 test_that("dfm_match works with padding", {
     toks <- tokens("aa bb !", padding = TRUE, remove_punct = TRUE)
-    dfmt <- dfm(toks)
+    dfmat <- dfm(toks)
     expect_identical(
-        featnames(dfm_match(dfmt, c("aa", "bb", "cc", ""))),
+        featnames(dfm_match(dfmat, c("aa", "bb", "cc", ""))),
         c("aa", "bb", "cc", "")
     )
 })


### PR DESCRIPTION
`dfm_match()` did not have minimum length of `features`, so set it to 0. This is why https://github.com/koheiw/LSX/pull/47 was breaking many tests.