### PR TITLE
Deprecate corpus and character methods for dfm and fcm

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # quanteda 3.0
 
+**quanteda** 3.0 is a major release that improves functionality, completes the modularisation of the package begun in v2.0, and further improves function consistency by removing previously deprecated functions, and deprecating some shortcut steps in the text analysis workflow.
+
 ## Changes
 
 * Separated the `textplot_*()` functions from the main package into a separate package **quanteda.textplots**.
@@ -12,13 +14,15 @@
 
 * The documentation for `dfm` now has all references to the defunct `ngrams` argument removed.
 
-* The following functions have been removed:
-    - all methods for defunct `corpuszip` objects.
-    - `View()` functions
-    - `as.wfm()` and `as.DocumentTermMatrix()` (the same functionality is available via `convert()`)
-    - `metadoc()` and `metacorpus()`
-    - `corpus_trimsentences()` (replaced by `corpus_trim()`)
-    - all of the `tortl` functions
+* The package dependency structure is now greatly reduced, partly by addressing complex downstream dependencies in packages such as **stopwords**, but also by reducing several package dependencies and through modularisation.
+
+* The punctuation regular expression and that for matching social media usernames has now been redefined so that the valid Twitter username `@_` is now counted as a "tag" rather than as "punctuation". (#2049)
+
+* The `kwic()` return object structure has been redefined, and built with an option to use a new function `index()` that returns token spans following a pattern search.  (#2045 and #2065)
+
+* The data object `data_corpus_inaugural` has been updated to include the Biden 2021 inaugural address.
+
+* A new system of validators for input types now provides better argument type and value checking, with more consistent error messages for invalid types or values.
 
 ## Bug fixes and stability enhancements
 
@@ -26,25 +30,30 @@
 
 * `kwic()` is more stable and does not crash when a vector is supplied as the `window` argument (#2008).
 
+* Allow use of multi-threading with more than two threads by fixing `quanteda_options()`.
+
+* Mentions of the now-removed `ngrams` option in `dfm(x, ...)` has now been removed from the dfm documentation.  (#1990)
 
 ## Deprecated
 
 * `dfm_sample(x, margins = "features")` is deprecated; future versions will not support sampling on features using `dfm_sample()`.
 
+* `dfm.character()` and `dfm.corpus()` are deprecated.  Users should create a tokens object first, and input that to `dfm()`.
+
+* Convenience passing of arguments to `tokens()` via `...` for methods that skipped the tokenisation step are now deprecated, although they still function with a warning.  Users should now create a tokens object (using `tokens()` from character or corpus inputs before calling `dfm()` or `kwic()`.
+
 ## Removed
 
 * See note above under **Changes** about the `textplot_*()` and `textstat_*()` functions.
 
-
-# quanteda 2.1.3
-
-## Changes
-
-* Mentions of the now-removed `ngrams` option in `dfm(x, ...)` has now been removed from the dfm documentation.  (#1990)
-
-## Bug fixes and stability enhancements
-
-* Allow use of multi-threading with more than two threads by fixing `quanteda_options()`.
+* The following functions have been removed:
+    - all methods for defunct `corpuszip` objects.
+    - `View()` functions
+    - `as.wfm()` and `as.DocumentTermMatrix()` (the same functionality is available via `convert()`)
+    - `metadoc()` and `metacorpus()`
+    - `corpus_trimsentences()` (replaced by `corpus_trim()`)
+    - all of the `tortl` functions
+    - all legacy functions related to the ancient "corpuszip" corpus variant.
 
 
 # quanteda 2.1.2

--- a/R/bootstrap_dfm.R
+++ b/R/bootstrap_dfm.R
@@ -44,7 +44,7 @@ bootstrap_dfm.corpus <- function(x, n = 10, ..., verbose = quanteda_options("ver
     x <- as.corpus(x)
     x <- corpus_reshape(x, to = "sentences")
     if (verbose) message("done.")
-    bootstrap_dfm(dfm(x, ...),  n = n, ..., verbose = verbose)
+    bootstrap_dfm(suppressWarnings(dfm(x, ...)),  n = n, ..., verbose = verbose)
 }
 
 #' @noRd

--- a/R/dfm.R
+++ b/R/dfm.R
@@ -2,7 +2,7 @@
 #'
 #' Construct a sparse document-feature matrix, from a character, [corpus],
 #' [tokens], or even other [dfm] object.
-#' @param x character, [corpus], [tokens], or [dfm] object
+#' @param x a [tokens] or [dfm] object
 #' @param tolower convert all features to lowercase
 #' @param stem if `TRUE`, stem words
 #' @param remove a [pattern] of user-supplied features to ignore, such as "stop
@@ -40,57 +40,20 @@
 #' @seealso  [dfm_select()], [dfm-class]
 #' @examples
 #' ## for a corpus
-#' corp <- corpus_subset(data_corpus_inaugural, Year > 1980)
-#' dfm(corp)
-#' dfm(corp, tolower = FALSE)
+#' toks <- data_corpus_inaugural %>%
+#'   corpus_subset(Year > 1980) %>%
+#'   tokens()
+#' dfm(toks)
 #'
-#' # grouping documents by docvars in a corpus
-#' dfm(corp, groups = "President", verbose = TRUE)
-#'
-#' # with English stopwords and stemming
-#' dfm(corp, remove = stopwords("english"), stem = TRUE, verbose = TRUE)
-#' # works for both words in ngrams too
-#' tokens("Banking industry") %>%
-#'     tokens_ngrams(n = 2) %>%
-#'     dfm(stem = TRUE)
-#'
-#' # with dictionaries
-#' dict <- dictionary(list(christmas = c("Christmas", "Santa", "holiday"),
-#'                opposition = c("Opposition", "reject", "notincorpus"),
-#'                taxing = "taxing",
-#'                taxation = "taxation",
-#'                taxregex = "tax*",
-#'                country = "states"))
-#' dfm(corpus_subset(data_corpus_inaugural, Year > 1900), dictionary = dict)
-#'
-#'
-#' # removing stopwords
-#' txt <- "The quick brown fox named Seamus jumps over the lazy dog also named Seamus, with
-#'              the newspaper from a boy named Seamus, in his mouth."
-#' corp <- corpus(txt)
-#' # note: "also" is not in the default stopwords("english")
-#' featnames(dfm(corp, select = stopwords("english")))
-#'
-#' # removing stopwords before constructing ngrams
-#' toks1 <- tokens(char_tolower(txt), remove_punct = TRUE)
-#' toks2 <- tokens_remove(toks1, stopwords("english"), padding = TRUE)
-#' toks3 <- tokens_ngrams(toks2, 2)
-#' featnames(dfm(toks3))
-#'
-#' # keep only certain words
-#' dfm(corp, select = "*s")  # keep only words ending in "s"
-#' dfm(corp, select = "s$", valuetype = "regex")
-#'
-#' # testing Twitter functions
-#' txttweets <- c("My homie @@justinbieber #justinbieber shopping in #LA yesterday #beliebers",
-#'                 "2all the ha8ers including my bro #justinbieber #emabiggestfansjustinbieber",
-#'                 "Justin Bieber #justinbieber #belieber #fetusjustin #EMABiggestFansJustinBieber")
-#' dfm(txttweets, select = "#*", split_tags = FALSE)  # keep only hashtags
-#' dfm(txttweets, select = "^#.*$", valuetype = "regex", split_tags = FALSE)
-#'
-#' # for a dfm
-#' dfm(corpus_subset(data_corpus_inaugural, Year > 1980), groups = "Party")
-#'
+#' # removal options
+#' toks <- tokens(c("a b c", "A B C D")) %>%
+#'     tokens_remove("b", padding = TRUE)
+#' toks
+#' dfm(toks)                
+#' dfm(toks, remove = "") # remove "pads"
+#' 
+#' # preserving case
+#' dfm(toks, tolower = FALSE)
 dfm <- function(x,
                 tolower = TRUE,
                 stem = FALSE,
@@ -141,6 +104,7 @@ dfm.character <- function(x,
                           groups = NULL,
                           verbose = quanteda_options("verbose"),
                           ...) {
+    .Deprecated(msg = "'dfm.character()' is deprecated. Use 'tokens()' first.")
     dfm.tokens(tokens(corpus(x), ...),
         tolower = tolower,
         stem = stem,
@@ -169,6 +133,7 @@ dfm.corpus <- function(x,
                        groups = NULL,
                        verbose = quanteda_options("verbose"),
                        ...) {
+    .Deprecated(msg = "'dfm.corpus()' is deprecated. Use 'tokens()' first.")
     dfm.tokens(tokens(x, ...),
                tolower = tolower,
                stem = stem,
@@ -285,7 +250,6 @@ dfm.tokens <- function(x,
 
 
 #' @noRd
-#' @author Kenneth Benoit
 #' @import Matrix
 #' @importFrom stringi stri_trans_totitle
 #' @export

--- a/R/fcm.R
+++ b/R/fcm.R
@@ -1,4 +1,3 @@
-
 #' Create a feature co-occurrence matrix
 #'
 #' Create a sparse feature co-occurrence matrix, measuring co-occurrences of

--- a/R/fcm.R
+++ b/R/fcm.R
@@ -5,8 +5,8 @@
 #' features within a user-defined context. The context can be defined as a
 #' document or a window within a collection of documents, with an optional
 #' vector of weights applied to the co-occurrence counts.
-#' @param x character, [corpus], [tokens], or [dfm] object from
-#'   which to generate the feature co-occurrence matrix
+#' @param x a [tokens], or [dfm] object from which to generate the feature
+#'   co-occurrence matrix
 #' @param context the context in which to consider term co-occurrence:
 #'   `"document"` for co-occurrence counts within document; `"window"`
 #'   for co-occurrence within a defined window of words, which requires a
@@ -81,25 +81,23 @@
 #'  *Computational Linguistics*, 16(1), 22-29.
 #' @examples
 #' # see http://bit.ly/29b2zOA
-#' txt1 <- "A D A C E A D F E B A C E D"
-#' fcm(txt1, context = "window", window = 2)
-#' fcm(txt1, context = "window", count = "weighted", window = 3)
-#' fcm(txt1, context = "window", count = "weighted", window = 3,
-#'              weights = c(3, 2, 1), ordered = TRUE, tri = FALSE)
+#' toks1 <- tokens(c("A D A C E A D F E B A C E D"))
+#' fcm(toks1, context = "window", window = 2)
+#' fcm(toks1, context = "window", count = "weighted", window = 3)
+#' fcm(toks1, context = "window", count = "weighted", window = 3,
+#'     weights = c(3, 2, 1), ordered = TRUE, tri = FALSE)
 #'
 #' # with multiple documents
-#' txt2 <- c("a a a b b c", "a a c e", "a c e f g")
-#' fcm(txt2, context = "document", count = "frequency")
-#' fcm(txt2, context = "document", count = "boolean")
-#' fcm(txt2, context = "window", window = 2)
+#' toks2 <- tokens(c("a a a b b c", "a a c e", "a c e f g"))
+#' fcm(toks2, context = "document", count = "frequency")
+#' fcm(toks2, context = "document", count = "boolean")
+#' fcm(toks2, context = "window", window = 2)
 #'
-#'
-#' # from tokens
 #' txt3 <- c("The quick brown fox jumped over the lazy dog.",
 #'          "The dog jumped and ate the fox.")
-#' toks <- tokens(char_tolower(txt3), remove_punct = TRUE)
-#' fcm(toks, context = "document")
-#' fcm(toks, context = "window", window = 3)
+#' toks3 <- tokens(char_tolower(txt3), remove_punct = TRUE)
+#' fcm(toks3, context = "document")
+#' fcm(toks3, context = "window", window = 3)
 fcm <- function(x, context = c("document", "window"),
                 count = c("frequency", "boolean", "weighted"),
                 window = 5L,
@@ -117,12 +115,14 @@ fcm.default <- function(x, ...) {
 #' @noRd
 #' @export
 fcm.character <- function(x, ...) {
+    .Deprecated(msg = "'fcm.character()' is deprecated. Use 'tokens()' or 'dfm()' first.")
     fcm(corpus(x), ...)
 }
 
 #' @noRd
 #' @export
 fcm.corpus <- function(x, ...) {
+    .Deprecated(msg = "'fcm.corpus()' is deprecated. Use 'tokens()' or 'dfm()' first.")
     fcm(tokens(x), ...)
 }
 

--- a/R/summary.R
+++ b/R/summary.R
@@ -40,7 +40,6 @@ summary.corpus <- function(object, n = 100, tolower = FALSE, showmeta = TRUE, ..
 #' @rdname corpus-class
 #' @method print summary.corpus
 print.summary.corpus <- function(x, ...) {
-
     ndoc_all <- attr(x, "ndoc_all")
     ndoc_show <- attr(x, "ndoc_show")
 
@@ -61,8 +60,7 @@ print.summary.corpus <- function(x, ...) {
     NextMethod("[")
 }
 
-summarize <- function(x, ...) {
-
+summarize <- function(x, tolower = FALSE, ...) {
     patterns <- removals_regex(punct = TRUE, symbols = TRUE,
                                numbers = TRUE, url = TRUE)
     patterns[["tag"]] <-
@@ -71,7 +69,7 @@ summarize <- function(x, ...) {
     patterns[["emoji"]] <- "^\\p{Emoji_Presentation}+$"
     dict <- dictionary(patterns)
 
-    y <- dfm(x, ...)
+    y <- dfm(tokens(x, ...), tolower = tolower)
     temp <- convert(
         quanteda::dfm_lookup(y, dictionary = dict, valuetype = "regex", levels = 1),
         "data.frame",
@@ -94,7 +92,7 @@ summarize <- function(x, ...) {
     )
 
     if (is.corpus(x)) {
-        result$chars <- nchar(x)
+        result$chars <- stringi::stri_length(x)
         result$sents <- ntoken(tokens(x, what = "sentence"))
     }
 

--- a/man/dfm.Rd
+++ b/man/dfm.Rd
@@ -20,7 +20,7 @@ dfm(
 )
 }
 \arguments{
-\item{x}{character, \link{corpus}, \link{tokens}, or \link{dfm} object}
+\item{x}{a \link{tokens} or \link{dfm} object}
 
 \item{tolower}{convert all features to lowercase}
 
@@ -80,57 +80,20 @@ combining and refactoring the documents of the dfm according to the groups.
 }
 \examples{
 ## for a corpus
-corp <- corpus_subset(data_corpus_inaugural, Year > 1980)
-dfm(corp)
-dfm(corp, tolower = FALSE)
+toks <- data_corpus_inaugural \%>\%
+  corpus_subset(Year > 1980) \%>\%
+  tokens()
+dfm(toks)
 
-# grouping documents by docvars in a corpus
-dfm(corp, groups = "President", verbose = TRUE)
+# removal options
+toks <- tokens(c("a b c", "A B C D")) \%>\%
+    tokens_remove("b", padding = TRUE)
+toks
+dfm(toks)                
+dfm(toks, remove = "") # remove "pads"
 
-# with English stopwords and stemming
-dfm(corp, remove = stopwords("english"), stem = TRUE, verbose = TRUE)
-# works for both words in ngrams too
-tokens("Banking industry") \%>\%
-    tokens_ngrams(n = 2) \%>\%
-    dfm(stem = TRUE)
-
-# with dictionaries
-dict <- dictionary(list(christmas = c("Christmas", "Santa", "holiday"),
-               opposition = c("Opposition", "reject", "notincorpus"),
-               taxing = "taxing",
-               taxation = "taxation",
-               taxregex = "tax*",
-               country = "states"))
-dfm(corpus_subset(data_corpus_inaugural, Year > 1900), dictionary = dict)
-
-
-# removing stopwords
-txt <- "The quick brown fox named Seamus jumps over the lazy dog also named Seamus, with
-             the newspaper from a boy named Seamus, in his mouth."
-corp <- corpus(txt)
-# note: "also" is not in the default stopwords("english")
-featnames(dfm(corp, select = stopwords("english")))
-
-# removing stopwords before constructing ngrams
-toks1 <- tokens(char_tolower(txt), remove_punct = TRUE)
-toks2 <- tokens_remove(toks1, stopwords("english"), padding = TRUE)
-toks3 <- tokens_ngrams(toks2, 2)
-featnames(dfm(toks3))
-
-# keep only certain words
-dfm(corp, select = "*s")  # keep only words ending in "s"
-dfm(corp, select = "s$", valuetype = "regex")
-
-# testing Twitter functions
-txttweets <- c("My homie @justinbieber #justinbieber shopping in #LA yesterday #beliebers",
-                "2all the ha8ers including my bro #justinbieber #emabiggestfansjustinbieber",
-                "Justin Bieber #justinbieber #belieber #fetusjustin #EMABiggestFansJustinBieber")
-dfm(txttweets, select = "#*", split_tags = FALSE)  # keep only hashtags
-dfm(txttweets, select = "^#.*$", valuetype = "regex", split_tags = FALSE)
-
-# for a dfm
-dfm(corpus_subset(data_corpus_inaugural, Year > 1980), groups = "Party")
-
+# preserving case
+dfm(toks, tolower = FALSE)
 }
 \seealso{
 \code{\link[=dfm_select]{dfm_select()}}, \linkS4class{dfm}

--- a/man/fcm.Rd
+++ b/man/fcm.Rd
@@ -17,8 +17,8 @@ fcm(
 )
 }
 \arguments{
-\item{x}{character, \link{corpus}, \link{tokens}, or \link{dfm} object from
-which to generate the feature co-occurrence matrix}
+\item{x}{a \link{tokens}, or \link{dfm} object from which to generate the feature
+co-occurrence matrix}
 
 \item{context}{the context in which to consider term co-occurrence:
 \code{"document"} for co-occurrence counts within document; \code{"window"}
@@ -89,25 +89,23 @@ type \link{fcm}.
 }
 \examples{
 # see http://bit.ly/29b2zOA
-txt1 <- "A D A C E A D F E B A C E D"
-fcm(txt1, context = "window", window = 2)
-fcm(txt1, context = "window", count = "weighted", window = 3)
-fcm(txt1, context = "window", count = "weighted", window = 3,
-             weights = c(3, 2, 1), ordered = TRUE, tri = FALSE)
+toks1 <- tokens(c("A D A C E A D F E B A C E D"))
+fcm(toks1, context = "window", window = 2)
+fcm(toks1, context = "window", count = "weighted", window = 3)
+fcm(toks1, context = "window", count = "weighted", window = 3,
+    weights = c(3, 2, 1), ordered = TRUE, tri = FALSE)
 
 # with multiple documents
-txt2 <- c("a a a b b c", "a a c e", "a c e f g")
-fcm(txt2, context = "document", count = "frequency")
-fcm(txt2, context = "document", count = "boolean")
-fcm(txt2, context = "window", window = 2)
+toks2 <- tokens(c("a a a b b c", "a a c e", "a c e f g"))
+fcm(toks2, context = "document", count = "frequency")
+fcm(toks2, context = "document", count = "boolean")
+fcm(toks2, context = "window", window = 2)
 
-
-# from tokens
 txt3 <- c("The quick brown fox jumped over the lazy dog.",
          "The dog jumped and ate the fox.")
-toks <- tokens(char_tolower(txt3), remove_punct = TRUE)
-fcm(toks, context = "document")
-fcm(toks, context = "window", window = 3)
+toks3 <- tokens(char_tolower(txt3), remove_punct = TRUE)
+fcm(toks3, context = "document")
+fcm(toks3, context = "window", window = 3)
 }
 \references{
 Momtazi, S., Khudanpur, S., & Klakow, D. (2010). "\href{https://www.aclweb.org/anthology/N10-1046/}{A comparative study of word co-occurrence for term clustering in language model-based sentence retrieval.}" \emph{Human Language

--- a/tests/testthat/meta.R
+++ b/tests/testthat/meta.R
@@ -1,5 +1,3 @@
-context("test meta")
-
 field_system <- c("source", "package-version", "r-version", "system", "directory", "created")
 
 test_that("meta works", {

--- a/tests/testthat/test-as.dfm.R
+++ b/tests/testthat/test-as.dfm.R
@@ -1,9 +1,6 @@
-context("test as.dfm")
-
-set.seed(19)
-elements <- rpois(20, 1)
-
 test_that("as.dfm adds document and feature names when a matrix has none", {
+    set.seed(19)
+    elements <- rpois(20, 1)
     m <- matrix(elements, nrow = 4)
     expect_equal(
         docnames(as.dfm(m)),
@@ -20,6 +17,8 @@ test_that("as.dfm adds document and feature names when a matrix has none", {
 })
 
 test_that("as.dfm adds names of dimnames when a matrix has none", {
+    set.seed(19)
+    elements <- rpois(20, 1)
     m <- matrix(elements, nrow = 4)
     dimnames(m) <- list(paste0("text", seq_len(nrow(m))),
                         letters[seq_len(ncol(m))])
@@ -38,6 +37,9 @@ test_that("as.dfm adds names of dimnames when a matrix has none", {
 })
 
 test_that("as.dfm keeps document and feature names from a data.frame", {
+    set.seed(19)
+    elements <- rpois(20, 1)
+    m <- matrix(elements, nrow = 4)
     m <- data.frame(matrix(elements, nrow = 4))
     expect_equal(
         docnames(as.dfm(m)),
@@ -54,6 +56,9 @@ test_that("as.dfm keeps document and feature names from a data.frame", {
 })
 
 test_that("as.dfm adds names of dimnames when a data.frame has none", {
+    set.seed(19)
+    elements <- rpois(20, 1)
+    m <- matrix(elements, nrow = 4)
     m <- data.frame(matrix(elements, nrow = 4))
     dimnames(m) <- list(paste0("text", seq_len(nrow(m))),
                         letters[seq_len(ncol(m))])
@@ -72,6 +77,9 @@ test_that("as.dfm adds names of dimnames when a data.frame has none", {
 })
 
 test_that("is.dfm works as expected", {
+    set.seed(19)
+    elements <- rpois(20, 1)
+    m <- matrix(elements, nrow = 4)
     m <- data.frame(matrix(elements, nrow = 4))
     expect_true(is.dfm(as.dfm(m)))
     expect_false(is.dfm(m))
@@ -87,14 +95,14 @@ test_that("as.dfm for tm matrix objects", {
                                   control = list(wordLengths = c(1, Inf)))
     expect_equivalent(
         as.dfm(dtm),
-        dfm(txt)
+        dfm(tokens(txt))
     )
     
     tdm <- tm::TermDocumentMatrix(tm::Corpus(tm::VectorSource(txt)),
                                   control = list(wordLengths = c(1, Inf)))
     expect_equivalent(
         as.dfm(tdm),
-        dfm(txt)
+        dfm(tokens(txt))
     )
 })
 
@@ -148,7 +156,7 @@ test_that("dfm2dataframe same as as.data.frame.dfm", {
 test_that("as.data.frame.dfm handles irregular feature names correctly", {
     skip_on_os("windows")
     skip_on_cran()
-    mydfm <- dfm(data_char_sampletext, 
+    mydfm <- dfm(tokens(data_char_sampletext),
                  dictionary = dictionary(list("字" = "a", "spe cial" = "the", 
                                               "飛機" = "if", "spec+ial" = "of")))
     expect_equal(
@@ -189,22 +197,13 @@ test_that("as.dfm to and from a matrix works with docvars", {
     txt <- c(docA = "a a a b c c f",
              docB = "a b b b c d",
              docC = "c c c f f")
+    toks <- tokens(txt)
     expect_identical(
-        attributes(dfm(txt)@docvars)$row.names,
-        attributes(as.dfm(as.matrix(dfm(txt)))@docvars)$row.names
+        attributes(dfm(toks)@docvars)$row.names,
+        attributes(as.dfm(as.matrix(dfm(toks)))@docvars)$row.names
     )
     expect_equivalent(
-        dfm(txt),
-        as.dfm(as.matrix(dfm(txt)))
+        dfm(toks),
+        as.dfm(as.matrix(dfm(toks)))
     )
 })
-
-# test_that("as.dfm works on old objects", {
-#     load("../data/pre_v2_objects/data_dfm_pre2.rda")
-#     expect_is(as.dfm(data_dfm_pre2), "dfm")
-#     expect_false(quanteda:::is_pre2(as.dfm(data_dfm_pre2)))
-#     expect_identical(
-#         names(as.dfm(data_dfm_pre2)@meta),
-#         c("user", "system")
-#     )
-# })

--- a/tests/testthat/test-as.dictionary.R
+++ b/tests/testthat/test-as.dictionary.R
@@ -1,5 +1,3 @@
-context("test as.dictionary function")
-
 test_that("as.dictionary works for data.frame", {
     df <- data.frame(
         word = letters[1:6],

--- a/tests/testthat/test-attributes.R
+++ b/tests/testthat/test-attributes.R
@@ -1,7 +1,4 @@
-context("test attributes")
-
 test_that("unit attributes are set correctly", {
-    
     txt <- c(d1 = "Sentence one.  Second sentence is this one!\n
                    Here is the third sentence.",
              d2 = "Only sentence of doc2?  No there is another.")
@@ -26,11 +23,9 @@ test_that("unit attributes are set correctly", {
     toks_chunk <- tokens_chunk(toks, 2)
     expect_equal(attr(toks_chunk, "meta")$object$unit, "segments")
     
-    expect_equal(dfm(corp_sent)@meta$object$unit, "sentences")
-    expect_equal(dfm(corp_para)@meta$object$unit, "paragraphs")
+    expect_equal(dfm(tokens(corp_sent))@meta$object$unit, "sentences")
+    expect_equal(dfm(tokens(corp_para))@meta$object$unit, "paragraphs")
     expect_equal(dfm(toks_chunk)@meta$object$unit, "segments")
     expect_equal(fcm(dfm(toks_chunk))@meta$object$unit, "segments")
     expect_equal(fcm(toks_chunk)@meta$object$unit, "segments")
-    
 })
-

--- a/tests/testthat/test-bootstrap.R
+++ b/tests/testthat/test-bootstrap.R
@@ -1,5 +1,3 @@
-context("test bootstrap_dfm")
-
 test_that("bootstrap_dfm works with character and corpus objects", {
     txt <- c(textone = "This is a sentence.  Another sentence.  Yet another.",
              texttwo = "Premiere phrase.  Deuxieme phrase.",
@@ -8,14 +6,14 @@ test_that("bootstrap_dfm works with character and corpus objects", {
                    docvars = data.frame(country = c("UK", "USA", "UK"), 
                                         year = c(1990, 2000, 2005)))
     set.seed(10)
-    bs1 <- bootstrap_dfm(corp, n = 10, verbose = TRUE)
+    bs1 <- bootstrap_dfm(corp, n = 10)
     # print(bs1[[1]], -1, -1)
     # print(dfm(corp), -1, -1)
-    expect_equal(bs1[[1]], dfm(corp))
+    expect_equal(bs1[[1]], dfm(tokens(corp)))
     
     bs2 <- bootstrap_dfm(txt, n = 10, verbose = TRUE)
     expect_identical(bs2[[1]],
-                     dfm(corp, include_docvars = FALSE))
+                     dfm(tokens(corp), include_docvars = FALSE))
     
     # are feature names of resamples identical?
     expect_identical(
@@ -39,17 +37,17 @@ test_that("bootstrap_dfm works as planned with dfm", {
     txt <- c(textone = "This is a sentence.  Another sentence.  Yet another.",
              texttwo = "Premiere phrase.  Deuxieme phrase.")
     corp <- corpus(txt, 
-                   docvars = data.frame(country=c("UK", "USA"), year=c(1990, 2000)))
-    dfmt <- dfm(corpus_reshape(corp, to = "sentences"))
+                   docvars = data.frame(country = c("UK", "USA"), year = c(1990, 2000)))
+    dfmt <- dfm(tokens(corpus_reshape(corp, to = "sentences")))
     
     set.seed(10)
     bs1 <- bootstrap_dfm(dfmt, n = 3, verbose = FALSE)
     expect_equivalent(bs1[[1]], 
-                      dfm(corp))
+                      dfm(tokens(corp)))
     
     bs2 <- bootstrap_dfm(txt, n = 3, verbose = FALSE)
     expect_identical(bs2[[1]], 
-                     dfm(corp, include_docvars = FALSE))
+                     dfm(tokens(corp), include_docvars = FALSE))
 
     # are feature names of resamples identical?
     expect_identical(

--- a/tests/testthat/test-casechanges.R
+++ b/tests/testthat/test-casechanges.R
@@ -1,8 +1,5 @@
-context("test case change functions")
-
-txt <- c("According to NATO", "There is G7 meeting")
-
 test_that("tolower works", {
+    txt <- c("According to NATO", "There is G7 meeting")
     expect_equal(char_tolower(txt), c("according to nato", "there is g7 meeting"))
     expect_error(char_tolower(txt, logical()), 
                  "The length of keep_acronyms must be 1")
@@ -11,16 +8,19 @@ test_that("tolower works", {
 })
 
 test_that("char_tolower/char_toUpper works", {
+    txt <- c("According to NATO", "There is G7 meeting")
     expect_equal(char_tolower(txt[1]), "according to nato")
     expect_equal(char_toupper(txt[1]), "ACCORDING TO NATO")
 })
 
 test_that("char_tolower keeps acronyms", {
-    expect_equal((char_tolower(txt, keep_acronyms = TRUE)), 
+    txt <- c("According to NATO", "There is G7 meeting")
+    expect_equal(char_tolower(txt, keep_acronyms = TRUE),
                  c("according to NATO", "there is G7 meeting"))
 })
 
 test_that("tokens_tolower/tokens_toupper works", {
+    txt <- c("According to NATO", "There is G7 meeting")
     toks <- tokens(txt)
     expect_equal(as.list(tokens_tolower(toks)),
                   list(text1 = c("according", "to", "nato"),
@@ -38,7 +38,8 @@ test_that("tokens_tolower/tokens_toupper works", {
 })
 
 test_that("tokens_tolower/tokens_toupper works", {
-    dfmat <- dfm(txt, tolower = FALSE)
+    txt <- c("According to NATO", "There is G7 meeting")
+    dfmat <- dfm(tokens(txt), tolower = FALSE)
     expect_equal(featnames(dfm_tolower(dfmat)),
                  c("according", "to", "nato", "there", "is", "g7", "meeting"))
     expect_equal(featnames(dfm_tolower(dfmat, keep_acronyms = TRUE)),
@@ -52,7 +53,6 @@ test_that("tokens_tolower/tokens_toupper works", {
 })
 
 test_that("set encoding when no gap or duplication is found, #1387", {
-    
     toks <- tokens("привет tschüß bye")
     toks <- tokens_tolower(toks)
     expect_equal(Encoding(types(toks)), 

--- a/tests/testthat/test-char_select.R
+++ b/tests/testthat/test-char_select.R
@@ -1,5 +1,3 @@
-context("test char_select functions")
-
 test_that("test character selection", {
     txt <- c("natural", "National", "denatured", "other")
     

--- a/tests/testthat/test-collocations.R
+++ b/tests/testthat/test-collocations.R
@@ -1,5 +1,3 @@
-context("test core methods with collocations objects")
-
 test_that("object2id is working with collocations", {
     txt <- c(". . . . a b c . . a b c . . . c d e",
              "a b . . a b . . a b . . a b . a b",
@@ -50,7 +48,7 @@ test_that("tokens_compound works as expected with collocations", {
 })
 
 
-context("tokens_select feature selection works according to new scheme")
+# context("tokens_select feature selection works according to new scheme")
 
 test_that("tokens_select works correctly with collocations objects", {
   txt <- c(d1 = "a b c d e g h",  d2 = "a b e g h i j")

--- a/tests/testthat/test-convert.R
+++ b/tests/testthat/test-convert.R
@@ -1,8 +1,6 @@
-context("test convert function and shortcuts")
-
 txt_test <- c(text1 = "The new law included a capital gains tax, and an inheritance tax.",
               text2 = "New York City has raised a taxes: an income tax and a sales tax.")
-dfmat_test <- dfm(txt_test, remove_punct = TRUE)
+dfmat_test <- dfm(tokens(txt_test, remove_punct = TRUE))
 
 test_that("test STM package converter", {
     skip_if_not_installed("stm")
@@ -37,7 +35,7 @@ test_that("test STM package converter with metadata", {
     skip_if_not_installed("tm")
     dat <- data.frame(myvar = c("A", "B"))
     corp <- corpus(txt_test, docvars = dat)
-    dfmat <- dfm(corp, remove_punct = TRUE)
+    dfmat <- dfm(tokens(corp), remove_punct = TRUE)
     stmdfm <- convert(dfmat, to = "stm")
     stmtp <- stm::textProcessor(txt_test, removestopwords = FALSE, verbose = FALSE,
                                 stem = FALSE, wordLengths = c(1, Inf))
@@ -55,7 +53,7 @@ test_that("test STM package converter with metadata w/zero-count document", {
                   text3 = "New York City has raised a taxes: an income tax and a sales tax.")
     dat <- data.frame(myvar = c("A", "B", "C"))
     corp <- corpus(txt_test2, docvars = dat)
-    dfmat <- dfm(corp, remove_punct = TRUE)
+    dfmat <- dfm(tokens(corp), remove_punct = TRUE)
     expect_true(ntoken(dfmat)[2] == 0)
 
     stmdfm <- suppressWarnings(convert(dfmat, to = "stm"))
@@ -170,7 +168,7 @@ test_that("lsa converter works under extreme situations", {
 })
 
 test_that("topicmodels converter works under extreme situations", {
-    skip_on_os("mac") 
+    # skip_on_os("mac") 
     skip_if_not_installed("topicmodels")
     require(topicmodels)
     #zero-count document
@@ -266,8 +264,7 @@ test_that("weighted dfm is not convertible to a topic model format (#1091)", {
 })
 
 test_that("triplet converter works", {
-
-    mt <- dfm(c("a b c", "c c d"))
+    mt <- dfm(tokens(c("a b c", "c c d")))
     expect_identical(convert(mt, to = "tripletlist"),
                      list(document = c(rep("text1", 3), rep("text2", 2)),
                           feature = c("a", "b", "c", "c", "d"),
@@ -322,7 +319,7 @@ test_that("convert.corpus works", {
         "^nothing argument is not used",
     )
     expect_warning(
-        convert(dfm(corp), to = "data.frame", nothing = TRUE),
+        convert(dfm(tokens(corp)), to = "data.frame", nothing = TRUE),
         "^nothing argument is not used",
     )
 
@@ -352,8 +349,8 @@ test_that("convert.corpus works", {
 })
 
 test_that("convert to = data.frame works", {
-    dfmat <- dfm(c(d1 = "this is a fine document",
-                   d2 = "this is a fine feature"))
+    dfmat <- dfm(tokens(c(d1 = "this is a fine document",
+                   d2 = "this is a fine feature")))
     expect_identical(
         convert(dfmat, to = "data.frame"),
         data.frame(

--- a/tests/testthat/test-corpus.R
+++ b/tests/testthat/test-corpus.R
@@ -1,5 +1,3 @@
-context("test corpus")
-
 test_that("print works", {
     expect_output(
         print(corpus(c("The"))),

--- a/tests/testthat/test-corpus_reshape.R
+++ b/tests/testthat/test-corpus_reshape.R
@@ -1,5 +1,3 @@
-context("test corpus_reshape")
-
 test_that("corpus_reshape works for sentences", {
     corp <- corpus(c(textone = "This is a sentence.  Another sentence.  Yet another.", 
                      texttwo = "Premiere phrase.  Deuxieme phrase."), 

--- a/tests/testthat/test-corpus_sample.R
+++ b/tests/testthat/test-corpus_sample.R
@@ -1,5 +1,3 @@
-context("test corpus_sample")
-
 corp <- corpus(c(one = "Sentence one.  Sentence two.  Third sentence.",
                  two = "First sentence, doc2.  Second sentence, doc2."))
 corp_sent <- corpus_reshape(corp, to = "sentences")

--- a/tests/testthat/test-corpus_segment.R
+++ b/tests/testthat/test-corpus_segment.R
@@ -1,5 +1,3 @@
-context("test corpus_segment")
-
 test_that("char_segment works with punctuations", {
     txt <- c(d1 = "Sentence one.  Second sentence is this one!\n
              Here is the third sentence.",

--- a/tests/testthat/test-corpus_subset.R
+++ b/tests/testthat/test-corpus_subset.R
@@ -1,5 +1,3 @@
-context('test corpus_subset')
-
 test_that("corpus_subset works in a basic way", {
     corp <- corpus(corpus_subset(data_corpus_inaugural, Year > 1980 & Year < 2018))
     expect_equal(

--- a/tests/testthat/test-corpus_trim.R
+++ b/tests/testthat/test-corpus_trim.R
@@ -1,5 +1,3 @@
-context("test corpus_trim")
-
 txt <- c("PAGE 1. This is a single sentence.  Short sentence. Three word sentence.",
          "PAGE 2. Very short! Shorter.",
          "Very long sentence, with multiple parts, separated by commas.  PAGE 3.")

--- a/tests/testthat/test-data.R
+++ b/tests/testthat/test-data.R
@@ -1,5 +1,3 @@
-context("test data objects")
-
 test_that("corpus data objects contain expected quantities", {
     expected_user_fields <- c("description", "source", "url", "author", "keywords", "title")
     expected_system_fields <- "summary"

--- a/tests/testthat/test-default-methods.R
+++ b/tests/testthat/test-default-methods.R
@@ -1,5 +1,3 @@
-context("test default methods for nice error messages")
-
 test_that("test default corpus* methods", {
     expect_error(
         corpus(TRUE),

--- a/tests/testthat/test-dfm.R
+++ b/tests/testthat/test-dfm.R
@@ -1,25 +1,24 @@
-context("test dfm")
-
 test_that("test c.corpus", {
-    expect_equal(
+    suppressWarnings({
+        expect_equal(
         matrix(dfm(corpus(c("What does the fox say?", "What does the fox say?", "")),
                    remove_punct = TRUE)),
         matrix(rep(c(1, 1, 0), 5), nrow = 15, ncol = 1)
     )
+    })
 })
 
 ## rbind.dfm
 ## TODO: Test classes returned
 
 test_that("test rbind.dfm with the same columns", {
-
     fox <- "What does the fox say?"
     foxdfm <- rep(1, 20)
     dim(foxdfm) <- c(4, 5)
     colnames(foxdfm) <- c("does", "fox", "say", "the", "what")
     rownames(foxdfm) <-  rep(c("text1", "text2"), 2)
 
-    dfm1 <- dfm(c(fox, fox), remove_punct = TRUE)
+    dfm1 <- dfm(tokens(c(fox, fox)), remove_punct = TRUE)
 
     expect_true(
         all(rbind(dfm1, dfm1) == foxdfm)
@@ -34,8 +33,8 @@ test_that("test rbind.dfm with the same columns", {
 # TODO: Add function for testing the equality of dfms
 
 test_that("test rbind.dfm with different columns", {
-    dfmt1 <- dfm(c(text1 = "What does the fox?"), remove_punct = TRUE)
-    dfmt2 <- dfm(c(text2 = "fox say"), remove_punct = TRUE)
+    dfmt1 <- dfm(tokens(c(text1 = "What does the fox?"), remove_punct = TRUE))
+    dfmt2 <- dfm(tokens(c(text2 = "fox say"), remove_punct = TRUE))
     dfmt3 <- rbind(dfmt1, dfmt2)
     dfmt4 <- as.dfm(matrix(c(1, 0, 1, 1, 0, 1, 1, 0, 1, 0), nrow = 2,
                     dimnames = list(c("text1", "text2"),
@@ -53,10 +52,9 @@ test_that("test rbind.dfm with different columns", {
 })
 
 test_that("test rbind.dfm with different columns, three args and repeated words", {
-
-    dfmt1 <- dfm("What does the?", remove_punct = TRUE)
-    dfmt2 <- dfm("fox say fox", remove_punct = TRUE)
-    dfmt3 <- dfm("The quick brown fox", remove_punct = TRUE)
+    dfmt1 <- dfm(tokens("What does the?", remove_punct = TRUE))
+    dfmt2 <- dfm(tokens("fox say fox", remove_punct = TRUE))
+    dfmt3 <- dfm(tokens("The quick brown fox", remove_punct = TRUE))
     dfmt4 <- rbind(dfmt1, dfmt2, dfmt3)
 
     dfmt5 <- as.dfm(matrix(
@@ -83,25 +81,24 @@ test_that("test rbind.dfm with a single argument returns the same dfm", {
     fox <- "What does the fox say?"
     expect_true(
         all(
-            rbind(dfm(fox)) == dfm(fox)
+            rbind(dfm(tokens(fox))) == dfm(tokens(fox))
         )
     )
     expect_that(
-        rbind(dfm(fox, remove_punct = TRUE)),
+        rbind(dfm(tokens(fox, remove_punct = TRUE))),
         is_a("dfm")
     )
 })
 
 test_that("test rbind.dfm with the same features, but in a different order", {
-
     fox <- "What does the fox say?"
     xof <- "say fox the does What??"
     foxdfm <- rep(1, 20)
     dim(foxdfm) <- c(4, 5)
     colnames(foxdfm) <- c("does", "fox", "say", "the", "what")
-    rownames(foxdfm) <-  rep(c("text1", "text2"), 2)
+    rownames(foxdfm) <- rep(c("text1", "text2"), 2)
 
-    dfm1 <- dfm(c(fox, xof), remove_punct = TRUE)
+    dfm1 <- dfm(tokens(c(fox, xof), remove_punct = TRUE))
 
     expect_true(
         all(rbind(dfm1, dfm1) == foxdfm)
@@ -110,7 +107,7 @@ test_that("test rbind.dfm with the same features, but in a different order", {
 
 test_that("dfm keeps all types with > 10,000 documents (#438) (a)", {
     generate_testdfm <- function(n) {
-        dfm(paste("X", seq_len(n), sep = ""))
+        dfm(tokens(paste("X", seq_len(n), sep = "")))
     }
     expect_equal(nfeat(generate_testdfm(10000)), 10000)
     expect_equal(nfeat(generate_testdfm(20000)), 20000)
@@ -119,7 +116,7 @@ test_that("dfm keeps all types with > 10,000 documents (#438) (a)", {
 test_that("dfm keeps all types with > 10,000 documents (#438) (b)", {
     set.seed(10)
     generate_testdfm <- function(n) {
-        dfm(paste(sample(letters, n, replace = TRUE), 1:n))
+        dfm(tokens(paste(sample(letters, n, replace = TRUE), 1:n)))
     }
     expect_equal(nfeat(generate_testdfm(10000)), 10026)
     expect_equal(nfeat(generate_testdfm(10001)), 10027)
@@ -137,8 +134,8 @@ test_that("dfm.dfm works as expected", {
     expect_identical(dfm_tolower(dfmt), dfm(dfmt, tolower = TRUE))
 
     expect_true({
-        sum(dfm(corp, select = c("The", "a", "an"))) >
-        sum(dfm(corp, select = c("The", "a", "an"), case_insensitive = FALSE))
+        sum(dfm(tokens(corp), select = c("The", "a", "an"))) >
+        sum(dfm(tokens(corp), select = c("The", "a", "an"), case_insensitive = FALSE))
     })
 
     expect_identical(dfm(dfmt, remove = c("The", "a", "an"), case_insensitive = FALSE, tolower = FALSE),
@@ -162,12 +159,12 @@ test_that("dfm.dfm works as expected", {
                             preps = c("of", "for", "In")), tolower = FALSE)
 
     expect_true({
-        sum(dfm(corp, dictionary = dict)) >
-        sum(dfm(corp, dictionary = dict, case_insensitive = FALSE))
+        sum(dfm(tokens(corp), dictionary = dict)) >
+        sum(dfm(tokens(corp), dictionary = dict, case_insensitive = FALSE))
     })
 
     expect_equivalent(
-        dfm(corp, dictionary = dict),
+        suppressWarnings(dfm(corp, dictionary = dict)),
         dfm(dfmt, dictionary = dict)
     )
 
@@ -177,7 +174,7 @@ test_that("dfm.dfm works as expected", {
     )
 
     expect_equivalent(
-        dfm(corp, dictionary = dict, case_insensitive = FALSE),
+        suppressWarnings(dfm(corp, dictionary = dict, case_insensitive = FALSE)),
         dfm(dfmt, dictionary = dict, case_insensitive = FALSE)
     )
 
@@ -187,18 +184,18 @@ test_that("dfm.dfm works as expected", {
     )
 
     expect_identical(
-        dfm(corp, stem = TRUE),
+        dfm(tokens(corp), stem = TRUE),
         dfm(dfmt, stem = TRUE)
     )
     expect_identical(
-        dfm(corp, stem = TRUE),
+        dfm(tokens(corp), stem = TRUE),
         dfm(dfmt, stem = TRUE)
     )
 })
 
 test_that("cbind.dfm works as expected", {
-    dfm1 <- dfm("This is one sample text sample")
-    dfm2 <- dfm("More words here")
+    dfm1 <- dfm(tokens("This is one sample text sample"))
+    dfm2 <- dfm(tokens("More words here"))
     dfm12 <- cbind(dfm1, dfm2)
 
     expect_equal(nfeat(dfm12), 8)
@@ -207,7 +204,7 @@ test_that("cbind.dfm works as expected", {
 })
 
 test_that("cbind.dfm works with non-dfm objects", {
-    dfm1 <- dfm(c("a b c", "c d e"))
+    dfm1 <- dfm(tokens(c("a b c", "c d e")))
 
     vec <- c(10, 20)
     expect_equal(
@@ -266,7 +263,7 @@ test_that("cbind.dfm works with non-dfm objects", {
 
 test_that("more cbind tests for dfms", {
     txts <- c("a b c d", "b c d e")
-    mydfm <- dfm(txts)
+    mydfm <- dfm(tokens(txts))
 
     expect_equal(
         as.matrix(cbind(mydfm, as.dfm(cbind("ALL" = ntoken(mydfm))))),
@@ -303,8 +300,8 @@ test_that("cbind.dfm keeps attributes of the dfm", {
 })
 
 test_that("rbind.dfm works as expected", {
-    dfm1 <- dfm("This is one sample text sample")
-    dfm2 <- dfm("More words here")
+    dfm1 <- dfm(tokens("This is one sample text sample"))
+    dfm2 <- dfm(tokens("More words here"))
     dfm12 <- rbind(dfm1, dfm2)
 
     expect_equal(nfeat(dfm12), 8)
@@ -321,7 +318,7 @@ test_that("dfm(x, dictionary = mwvdict) works with multi-word values", {
              d4 = "f g")
 
     # as dictionary
-    dfm1 <- dfm(txt, dictionary = mwvdict, verbose = TRUE)
+    dfm1 <- dfm(tokens(txt), dictionary = mwvdict, verbose = TRUE)
     expect_identical(
         as.matrix(dfm1),
         matrix(c(1, 0, 0, 0, 1, 0, 1, 0, 2, 1, 0, 0),
@@ -331,7 +328,7 @@ test_that("dfm(x, dictionary = mwvdict) works with multi-word values", {
     )
 
     # as thesaurus
-    dfm2 <- dfm(txt, thesaurus = mwvdict, verbose = TRUE)
+    dfm2 <- dfm(tokens(txt), thesaurus = mwvdict, verbose = TRUE)
     expect_identical(
         as.matrix(dfm2),
         matrix(c(1, 0, 0, 0, 1, 0, 1, 0, 2, 1, 0, 0,
@@ -344,7 +341,7 @@ test_that("dfm(x, dictionary = mwvdict) works with multi-word values", {
 })
 
 test_that("dfm works with relational operators", {
-    testdfm <- dfm(c("This is an example.", "This is a second example."))
+    testdfm <- dfm(tokens(c("This is an example.", "This is a second example.")))
     expect_is(testdfm == 0, "lgCMatrix")
     expect_is(testdfm >= 0, "lgCMatrix")
     expect_is(testdfm <= 0, "lgCMatrix")
@@ -466,9 +463,9 @@ test_that("dfm's document counts in verbose message is correct", {
              d2 = "a c d x z",
              d3 = "x y",
              d4 = "f g")
-    expect_message(dfm(txt, remove = c("a", "f"), verbose = TRUE),
+    expect_message(dfm(tokens(txt), remove = c("a", "f"), verbose = TRUE),
                    "removed 2 features")
-    expect_message(dfm(txt, select = c("a", "f"), verbose = TRUE),
+    expect_message(dfm(tokens(txt), select = c("a", "f"), verbose = TRUE),
                    "kept 2 features")
 })
 
@@ -491,8 +488,8 @@ test_that("dfm head, tail work as expected", {
 })
 
 test_that("dfm print works with options as expected", {
-    dfmt <- dfm(data_corpus_inaugural[1:14],
-                remove_punct = FALSE, remove_numbers = FALSE, split_hyphens = TRUE)
+    dfmt <- dfm(tokens(data_corpus_inaugural[1:14],
+                remove_punct = FALSE, remove_numbers = FALSE, split_hyphens = TRUE))
     expect_output(
         print(dfmt, max_ndoc = 6, max_nfeat = 10, show_summary = TRUE),
         paste0("^Document-feature matrix of: 14 documents, 4,452 features \\(81\\.97% sparse\\) and 4 docvars",
@@ -538,11 +535,11 @@ test_that("cannot supply remove and select in one call (#793)", {
     corp <- corpus(txt, docvars = data.frame(grp = c(1, 1, 2)))
     toks <- tokens(corp)
     expect_error(
-        dfm(txt, select = "one", remove = "two"),
+        suppressWarnings(dfm(txt, select = "one", remove = "two")),
         "only one of select and remove may be supplied at once"
     )
     expect_error(
-        dfm(corp, select = "one", remove = "two"),
+        suppressWarnings(dfm(corp, select = "one", remove = "two")),
         "only one of select and remove may be supplied at once"
     )
     expect_error(
@@ -561,7 +558,7 @@ test_that("dfm with selection options produces correct output", {
     dfmt <- dfm(toks)
     feat <- c("b", "c", "d", "e", "f", "g")
     expect_message(
-        dfm(txt, remove = feat, verbose = TRUE),
+        suppressWarnings(dfm(txt, remove = feat, verbose = TRUE)),
         "removed 4 features"
     )
     expect_message(
@@ -584,29 +581,29 @@ test_that("dfm works with stem options", {
         c("run", "ran", "run")
     )
     expect_equal(
-        featnames(dfm(txt_english)),
+        featnames(dfm(tokens(txt_english))),
         c("running", "ran", "runs")
     )
     expect_equal(
-        featnames(dfm(txt_english, stem = TRUE)),
+        featnames(dfm(tokens(txt_english), stem = TRUE)),
         c("run", "ran")
     )
     expect_error(
-        dfm(txt_english, stem = c(TRUE, FALSE)),
+        dfm(tokens(txt_english), stem = c(TRUE, FALSE)),
         "The length of stem must be 1"
     )
-    
+
     quanteda_options(language_stemmer = "french")
     expect_equal(
         as.character(tokens_wordstem(tokens(txt_french))),
         rep("cour", 3)
     )
     expect_equal(
-        featnames(dfm(txt_french)),
+        featnames(dfm(tokens(txt_french))),
         c("courant", "courir", "cours")
     )
     expect_equal(
-        featnames(dfm(txt_french, stem = TRUE)),
+        featnames(dfm(tokens(txt_french), stem = TRUE)),
         "cour"
     )
     quanteda_options(reset = TRUE)
@@ -617,8 +614,8 @@ test_that("dfm verbose option prints correctly", {
     corp <- corpus(txt)
     toks <- tokens(txt)
     mydfm <- dfm(toks)
-    expect_message(dfm(txt, verbose = TRUE), "Creating a dfm from a character input")
-    expect_message(dfm(corp, verbose = TRUE), "Creating a dfm from a corpus input")
+    expect_message(suppressWarnings(dfm(txt, verbose = TRUE)), "Creating a dfm from a character input")
+    expect_message(suppressWarnings(dfm(corp, verbose = TRUE)), "Creating a dfm from a corpus input")
     expect_message(dfm(toks, verbose = TRUE), "Creating a dfm from a tokens input")
     expect_message(dfm(mydfm, verbose = TRUE), "Creating a dfm from a dfm input")
 })
@@ -627,20 +624,20 @@ test_that("dfm works with purrr::map (#928)", {
     skip_if_not_installed("purrr")
     a <- "a b"
     b <- "a a a b b"
-    expect_identical(
+    suppressWarnings(expect_identical(
         vapply(purrr::map(list(a, b), dfm), is.dfm, logical(1)),
         c(TRUE, TRUE)
-    )
-    expect_identical(
+    ))
+    suppressWarnings(expect_identical(
         vapply(purrr::map(list(corpus(a), corpus(b)), dfm), is.dfm, logical(1)),
         c(TRUE, TRUE)
-    )
+    ))
     expect_identical(
         vapply(purrr::map(list(tokens(a), tokens(b)), dfm), is.dfm, logical(1)),
         c(TRUE, TRUE)
     )
     expect_identical(
-        vapply(purrr::map(list(dfm(a), dfm(b)), dfm), is.dfm, logical(1)),
+        vapply(purrr::map(list(dfm(tokens(a)), dfm(tokens(b))), dfm), is.dfm, logical(1)),
         c(TRUE, TRUE)
     )
 })
@@ -658,13 +655,12 @@ test_that("dfm works when features are created (#946", {
     )
 
     expect_equal(
-        as.matrix(cbind(dfm("a b"), dfm("feat_1"))),
+        as.matrix(cbind(dfm(tokens("a b")), dfm(tokens("feat_1")))),
         matrix(c(1, 1, 1), nrow = 1, dimnames = list(docs = "text1", features = c("a", "b", "feat_1")))
     )
 })
 
 test_that("dfm warns of argument not used", {
-
     txt <- c(d1 = "a b c d e", d2 = "a a b c c c")
     corp <- corpus(txt)
     toks <- tokens(txt)
@@ -682,10 +678,10 @@ test_that("dfm warns of argument not used", {
 })
 
 test_that("dfm pass arguments to tokens, issue #1121", {
-
     txt <- data_char_sampletext
     corp <- corpus(txt)
 
+    suppressWarnings({
     expect_equal(dfm(txt, what = "character"),
                  dfm(tokens(corp, what = "character")))
 
@@ -697,7 +693,7 @@ test_that("dfm pass arguments to tokens, issue #1121", {
 
     expect_equivalent(dfm(txt, remove_punct = TRUE),
                       dfm(tokens(txt, remove_punct = TRUE)))
-
+    })
 })
 
 test_that("dfm error when a dfm is given to for feature selection when x is not a dfm, #1067", {
@@ -705,9 +701,9 @@ test_that("dfm error when a dfm is given to for feature selection when x is not 
     corp <- corpus(txt)
     toks <- tokens(txt)
     mx <- dfm(toks)
-    mx2 <- dfm(c("a b", "c"))
+    mx2 <- dfm(tokens(c("a b", "c")))
 
-    expect_error(dfm(txt, select = mx2),
+    expect_error(suppressMessages(dfm(txt, select = mx2)),
                 "selection on a dfm is only available when x is a dfm")
     expect_error(dfm(corp, select = mx2),
                 "selection on a dfm is only available when x is a dfm")
@@ -723,14 +719,15 @@ test_that("dfm error when a dfm is given to for feature selection when x is not 
 
 test_that("test topfeatures", {
     expect_identical(
-        topfeatures(dfm("a a a a b b b c c d"), scheme = "count"),
+        topfeatures(dfm(tokens("a a a a b b b c c d")), scheme = "count"),
         c(a = 4, b = 3, c = 2, d = 1)
     )
     expect_error(
-        topfeatures(dfm("a a a a b b b c c d"), "count"),
+        topfeatures(dfm(tokens("a a a a b b b c c d")), "count"),
         "n must be a number"
     )
     dfmat <- corpus(c("a b b c", "b d", "b c"), docvars = data.frame(numdv = c(1, 2, 1))) %>%
+        tokens() %>%
         dfm()
     expect_identical(
         topfeatures(dfmat, groups = "numdv"),
@@ -750,13 +747,12 @@ test_that("test topfeatures", {
 
 test_that("test sparsity", {
     expect_equal(
-        sparsity(dfm(c("a a a a  c c d", "b b b"))),
+        sparsity(dfm(tokens(c("a a a a  c c d", "b b b")))),
         0.5
     )
 })
 
 test_that("test null dfm is handled properly", {
-
     mx <- quanteda:::make_null_dfm()
 
     # constructor
@@ -803,12 +799,11 @@ test_that("test null dfm is handled properly", {
     expect_equal(rbind(mx, mx), mx)
     expect_equal(cbind(mx, mx), mx)
 
-    expect_output(print(mx), 
+    expect_output(print(mx),
                   "Document-feature matrix of: 0 documents, 0 features (0.00% sparse) and 0 docvars.", fixed = TRUE)
 })
 
 test_that("test empty dfm is handled properly (#1419)", {
-
     mx <- dfm_trim(data_dfm_lbgexample, 1000)
     docvars(mx) <- data.frame(var = c(1, 5, 3, 6, 6, 4))
 
@@ -856,14 +851,13 @@ test_that("test empty dfm is handled properly (#1419)", {
     expect_equal(ndoc(rbind(mx, mx)), ndoc(mx) * 2)
     expect_equal(ndoc(cbind(mx, mx)), ndoc(mx))
 
-    expect_output(print(mx), 
+    expect_output(print(mx),
                   "Document-feature matrix of: 6 documents, 0 features (0.00% sparse) and 1 docvar.", fixed = TRUE)
 })
 
 test_that("dfm raise nicer error message, #1267", {
-
     txt <- c(d1 = "one two three", d2 = "two three four", d3 = "one three four")
-    mx <- dfm(txt)
+    mx <- dfm(tokens(txt))
     expect_error(mx["d4"], "Subscript out of bounds")
     expect_error(mx["d4", ], "Subscript out of bounds")
     expect_error(mx[4], "Subscript out of bounds")
@@ -893,7 +887,6 @@ test_that("dfm raise nicer error message, #1267", {
 })
 
 test_that("dfm keeps non-existent types, #1278", {
-
     toks <- tokens("a b c")
     dict <- dictionary(list(A = "a", B = "b", Z = "z"))
 
@@ -909,8 +902,7 @@ test_that("dfm keeps non-existent types, #1278", {
 })
 
 test_that("arithmetic/linear operation works with dfm", {
-
-    mt <- dfm(c(d1 = "a a b", d2 = "a b b c", d3 = "c c d"))
+    mt <- dfm(tokens(c(d1 = "a a b", d2 = "a b b c", d3 = "c c d")))
     expect_true(is.dfm(mt + 2))
     expect_true(is.dfm(mt - 2))
     expect_true(is.dfm(mt * 2))
@@ -926,8 +918,7 @@ test_that("arithmetic/linear operation works with dfm", {
 })
 
 test_that("rbind and cbind wokrs with empty dfm", {
-
-    mt <- dfm(c(d1 = "a a b", d2 = "a b b c", d3 = "c c d"))
+    mt <- dfm(tokens(c(d1 = "a a b", d2 = "a b b c", d3 = "c c d")))
 
     expect_identical(docnames(rbind(mt, quanteda:::make_null_dfm())),
                      docnames(mt))
@@ -969,7 +960,7 @@ test_that("format_sparsity works correctly", {
 
 test_that("unused argument warning only happens only once (#1509)", {
     expect_warning(
-        dfm("some text", NOTARG = TRUE),
+        dfm(tokens("some text"), NOTARG = TRUE),
         "^NOTARG argument is not used\\.$"
     )
     expect_warning(
@@ -1008,7 +999,7 @@ test_that("dimnames are always character vectors", {
 })
 
 test_that("set_dfm_dimnames etc functions work", {
-    x <- dfm(c("a a b b c", "b b b c"))
+    x <- dfm(tokens(c("a a b b c", "b b b c")))
 
     quanteda:::set_dfm_featnames(x) <- paste0("feature", 1:3)
     expect_identical(featnames(x), c("feature1", "feature2", "feature3"))
@@ -1022,7 +1013,7 @@ test_that("set_dfm_dimnames etc functions work", {
 })
 
 test_that("dfm feature and document names have encoding", {
-    mt <- dfm(c("文書１" = "あ い い う", "文書２" = "え え え お"))
+    mt <- dfm(tokens(c("文書１" = "あ い い う", "文書２" = "え え え お")))
     expect_true(all(Encoding(colnames(mt)) == "UTF-8"))
     #expect_true(all(Encoding(rownames(mt)) == "UTF-8")) fix in new corpus
 
@@ -1045,40 +1036,40 @@ test_that("dfm feature and document names have encoding", {
 
 test_that("dfm verbose = TRUE works as expected", {
     expect_message(
-        tmp <- dfm(data_corpus_inaugural[1:3], verbose = TRUE),
+        tmp <- suppressWarnings(dfm(data_corpus_inaugural[1:3], verbose = TRUE)),
         "Creating a dfm from a corpus input"
     )
     expect_message(
-        tmp <- dfm(data_corpus_inaugural[1:3], verbose = TRUE),
+        tmp <- dfm(tokens(data_corpus_inaugural[1:3]), verbose = TRUE),
         "Finished constructing a 3 x 1,\\d{3} sparse dfm"
     )
     dict <- dictionary(list(pos = "good", neg = "bad", neg_pos = "not good", neg_neg = "not bad"))
     expect_message(
-        tmp <- dfm(data_corpus_inaugural[1:3], dictionary = dict, verbose = TRUE),
+        tmp <- dfm(tokens(data_corpus_inaugural[1:3]), dictionary = dict, verbose = TRUE),
         "applying a dictionary consisting of 4 keys"
     )
     expect_message(
-        tmp <- dfm(dfm(data_corpus_inaugural[1:3]), dictionary = dict, verbose = TRUE),
+        tmp <- dfm(dfm(tokens(data_corpus_inaugural[1:3])), dictionary = dict, verbose = TRUE),
         "applying a dictionary consisting of 4 keys"
     )
     expect_message(
-        tmp <- dfm(data_corpus_inaugural[1:3], groups = "President", verbose = TRUE),
+        tmp <- dfm(tokens(data_corpus_inaugural[1:3]), groups = "President", verbose = TRUE),
         "grouping texts"
     )
     expect_message(
-        tmp <- dfm(data_corpus_inaugural[1:2], stem = TRUE, verbose = TRUE),
+        tmp <- dfm(tokens(data_corpus_inaugural[1:2]), stem = TRUE, verbose = TRUE),
         "stemming types \\(English\\)"
     )
     expect_message(
-        tmp <- dfm(dfm(data_corpus_inaugural[1:2]), stem = TRUE, verbose = TRUE),
+        tmp <- dfm(dfm(tokens(data_corpus_inaugural[1:2])), stem = TRUE, verbose = TRUE),
         "stemming features \\(English\\)"
     )
     expect_message(
-        tmp <- dfm(dfm(data_corpus_inaugural[1:3]), groups = "President", verbose = TRUE),
+        tmp <- dfm(dfm(tokens(data_corpus_inaugural[1:3])), groups = "President", verbose = TRUE),
         "grouping texts"
     )
     expect_error(
-        dfm("one two three", remove = "one", select = "three"),
+        dfm(tokens("one two three"), remove = "one", select = "three"),
         "only one of select and remove may be supplied at once"
     )
 
@@ -1088,7 +1079,7 @@ test_that("dfm verbose = TRUE works as expected", {
 })
 
 test_that("dfm_sort works as expected", {
-    dfmat <- dfm(c(d1 = "z z x y a b", d3 = "x y y y c", d2 = "a z"))
+    dfmat <- dfm(tokens(c(d1 = "z z x y a b", d3 = "x y y y c", d2 = "a z")))
     expect_identical(
         featnames(dfm_sort(dfmat, margin = "features", decreasing = TRUE)),
         c("y", "z", "x", "a", "b", "c")
@@ -1108,7 +1099,7 @@ test_that("dfm_sort works as expected", {
 })
 
 test_that("test dfm transpose for #1903", {
-    dfmat <- dfm(c(d1 = "one two three", d2 = "two two three"))
+    dfmat <- dfm(tokens(c(d1 = "one two three", d2 = "two two three")))
     dfmat_t <- t(dfmat)
     expect_equal(
         names(dimnames(dfmat_t)),

--- a/tests/testthat/test-dfm_compress.R
+++ b/tests/testthat/test-dfm_compress.R
@@ -1,8 +1,6 @@
-context("test dfm_compress")
-
 test_that("dfm_compress: simple test", {
-    mat <- rbind(dfm(c("b A A", "C C a b B"), tolower = FALSE, verbose = FALSE),
-                 dfm("A C C C C C", tolower = FALSE, verbose = FALSE))
+    mat <- rbind(dfm(tokens(c("b A A", "C C a b B")), tolower = FALSE, verbose = FALSE),
+                 dfm(tokens("A C C C C C"), tolower = FALSE, verbose = FALSE))
     colnames(mat) <- char_tolower(featnames(mat))
     expect_equal(as.matrix(dfm_compress(mat, margin = "documents")),
                  matrix(c(1,1,3,0,5,2,0,1,0,1), nrow = 2,
@@ -20,9 +18,8 @@ test_that("dfm_compress: simple test", {
     )
 })
 
-
 test_that("dfm_compress: no effect if no compression needed", {
-    compactdfm <- dfm(data_corpus_inaugural[1:5], tolower = TRUE, verbose = FALSE)
+    compactdfm <- dfm(tokens(data_corpus_inaugural[1:5]), tolower = TRUE, verbose = FALSE)
     expect_equal(dim(compactdfm), dim(dfm_compress(compactdfm)))
 })
 
@@ -42,32 +39,11 @@ test_that("dfm_compress: empty documents are preserved", {
     expect_equal(rowSums(dfm_compress(testdfm))[3], c(d3 = 0))
 })
 
-#test_that("dfm_compress dfmDense: simple test", {
-#    mat <- rbind(dfm(c("b A A", "C C a b B"), tolower = FALSE, verbose = FALSE),
-#                 dfm("A C C C C C", tolower = FALSE, verbose = FALSE))
-#    # make into a dense object
-#    mat <- dfm_smooth(mat)
-#    colnames(mat) <- char_tolower(featnames(mat))
-#    expect_equal(as.matrix(dfm_compress(mat, margin = "documents")),
-#                 matrix(c(3,2,5,1,7,3,2,2,2,2), nrow = 2,
-#                        dimnames = list(docs = c("text1", "text2"), features = featnames(mat))))
-#    expect_equal(
-#        as.matrix(dfm_compress(mat, margin = "features")),
-#        matrix(c(3,4,2,4,3,3,1,3,6), nrow = 3,
-#               dimnames = list(docs = docnames(mat), features = c("b", "a", "c")))
-#    )
-#    expect_equal(
-#        as.matrix(dfm_compress(mat, margin = "both")),
-#        matrix(c(5,4,7,3,7,3), nrow = 2,
-#               dimnames = list(docs = c("text1", "text2"), features = c("b", "a", "c")))
-#    )
-#})
-
 test_that("dfm_compress preserves docvars (#1506)", {
     corp <- corpus(c(d1 = "A A A b c D D",
                  d2 = "b b b b D D D"),
                docvars = data.frame(bool = c(TRUE, FALSE)))
-    thedfm <- dfm(corp)
+    thedfm <- dfm(tokens(corp))
     # this ensures the existence of _document
     docnames(thedfm) <- docnames(thedfm)
     
@@ -87,7 +63,7 @@ test_that("dfm_compress preserves docvars (#1506)", {
 })
 
 test_that("add test for group_dfm with features and fill = TRUE", {
-    x <- dfm(c("a a b c d", "b c d e"))
+    x <- dfm(tokens(c("a a b c d", "b c d e")))
     colnames(x)[4] <- "e"
     expect_identical(
         as.matrix(quanteda:::group_dfm(x, fill = TRUE,

--- a/tests/testthat/test-dfm_group.R
+++ b/tests/testthat/test-dfm_group.R
@@ -1,7 +1,5 @@
-context("test dfm_group")
-
 test_that("test dfm_group", {
-    dfmt <- dfm(c("a b c c", "b c d", "a"))
+    dfmt <- dfm(tokens(c("a b c c", "b c d", "a")))
     expect_equivalent(
         as.matrix(dfm_group(dfmt, c("doc1", "doc1", "doc2"))),
         matrix(c(1, 1, 2, 0, 3, 0, 1, 0), nrow = 2, 
@@ -16,7 +14,7 @@ test_that("test dfm_group", {
 })
 
 test_that("dfm_group works with empty documents", {
-    dfmt <- dfm(c("a b c c", "b c d", ""))
+    dfmt <- dfm(tokens(c("a b c c", "b c d", "")))
     expect_equivalent(
         as.matrix(dfm_group(dfmt, c("doc1", "doc1", "doc2"))),
         matrix(c(1, 0, 2, 0, 3, 0, 1, 0), nrow = 2, 
@@ -33,7 +31,7 @@ test_that("dfm_group works with empty documents", {
 test_that("dfm_group works with docvars", {
     mycorpus <- corpus(c("a a b", "a b c c", "a c d d", "a c c d"),
                        docvars = data.frame(grp = c(1, 1, 2, 2)))
-    mydfm <- dfm(mycorpus)
+    mydfm <- dfm(tokens(mycorpus))
     expect_equal(
         colSums(dfm_group(mydfm, groups = "grp")),
         colSums(mydfm)
@@ -46,19 +44,19 @@ test_that("dfm.character groups works (#794)", {
     corp <- corpus(txt)
     toks <- tokens(corp)
     expect_equal(
-        dfm(txt, groups = grp),
+        suppressWarnings(dfm(txt, groups = grp)),
         dfm(toks, groups = grp)
     )
     expect_equal(
-        dfm(txt, groups = grp),
-        dfm(corp, groups = grp)
+        suppressWarnings(dfm(txt, groups = grp)),
+        dfm(tokens(corp), groups = grp)
     )
 })
 
 test_that("test dfm_group with factor levels, fill = TRUE and FALSE, #854", {
     corp <- corpus(c("a b c c", "b c d", "a"),
                    docvars = data.frame(grp = factor(c("A", "A", "B"), levels = LETTERS[1:4])))
-    dfmt <- dfm(corp)
+    dfmt <- dfm(tokens(corp))
     expect_equal(
         as.matrix(dfm_group(dfmt, groups = "grp", fill = FALSE)),
         matrix(c(1,2,3,1, 1,0,0,0), byrow = TRUE, nrow = 2, 
@@ -70,7 +68,7 @@ test_that("test dfm_group with factor levels, fill = TRUE and FALSE, #854", {
                dimnames = list(docs = c("A", "B", "C", "D"), features = letters[1:4]))
     )
     
-    dfmt <- dfm(c("a b c c", "b c d", "a"))
+    dfmt <- dfm(tokens(c("a b c c", "b c d", "a")))
     external_factor <- factor(c("text1", "text1", "text2"), 
                               levels = paste0("text", 0:3))
     expect_equal(
@@ -101,7 +99,7 @@ test_that("test dfm_group with non-factor grouping variable, with fill", {
     grp <- c("D", "D", "A", "C")
     corp <- corpus(c("a b c c", "b c d", "a", "b d d"),
                    docvars = data.frame(grp = grp, stringsAsFactors = FALSE))
-    dfmt <- dfm(corp)
+    dfmt <- dfm(tokens(corp))
     expect_equal(
         as.matrix(dfm_group(dfmt, groups = "grp", fill = FALSE)),
         matrix(c(1,0,0,0, 0,1,0,2, 1,2,3,1), byrow = TRUE, nrow = 3, 
@@ -131,7 +129,7 @@ test_that("test dfm_group with wrongly dimensioned groups variables", {
     grp <- c("D", "D", "A", "C")
     corp <- corpus(c("a b c c", "b c d", "a", "b d d"),
                    docvars = data.frame(grp = grp, stringsAsFactors = FALSE))
-    dfmt <- dfm(corp)
+    dfmt <- dfm(tokens(corp))
     expect_error(
         dfm_group(dfmt, groups = c(1, 1, 2, 3, 3), fill = FALSE),
         "groups must name docvars or provide data matching the documents in x"
@@ -157,7 +155,7 @@ test_that("test dfm_group keeps group-level variables", {
                                         var6 = as.Date(c("2018-01-01", "2015-03-01", "2015-03-01", "2012-12-15")),
                                         stringsAsFactors = FALSE))
     
-    dfmt <- dfm(corp)
+    dfmt <- dfm(tokens(corp))
     grp1 <- c("D", "D", "A", "C")
     expect_equal(
          dfm_group(dfmt, grp1)@docvars,
@@ -223,7 +221,7 @@ test_that("is_grouped is working", {
 })
 
 test_that("dfm_group resets weighting scheme to count (#1545)", {
-    mt1 <- dfm_weight(dfm(c("a b c c", "b c d", "a")), "boolean")
+    mt1 <- dfm_weight(dfm(tokens(c("a b c c", "b c d", "a"))), "boolean")
     expect_equal(mt1@meta$object$weight_tf$scheme, "boolean")
     
     mt2 <- dfm_group(mt1, c("doc1", "doc1", "doc2"))
@@ -238,7 +236,7 @@ test_that("force argument works as expected (#1545)", {
                      "He went out and bought pickles and onions",
                      "He stayed home instead."),
                    docvars = data.frame(grp = c(1, 1, 2)))
-    dfmat <- dfm(corp)
+    dfmat <- dfm(tokens(corp))
     dfmat_tfprop <- dfm_weight(dfmat, "prop")
     dfmat_tfidf <- dfm_tfidf(dfmat)
 
@@ -272,7 +270,7 @@ test_that("group_docvar drops list column (#1553)", {
                    docvars = data.frame(vec1 = c(1, 3, 3, 6),
                                         vec2 = c("a", "b", "b", "c"),
                                         stringsAsFactors = FALSE))
-    mt <- dfm(corp)
+    mt <- dfm(tokens(corp))
     expect_equal(docvars(dfm_group(mt, c(1, 2, 2, 3))),
                  data.frame(data.frame(vec1 = c(1, 3, 6),
                                        vec2 = c("a", "b", "c"),
@@ -284,33 +282,33 @@ test_that("restore original unit when groups = NULL", {
     corp <- corpus(data_corpus_inaugural) # normalize hyphens
     corp <- head(corp, 2)
     corp_sent <- corpus_reshape(corp)
-    dfmt_sent <- dfm(corp_sent)
+    dfmt_sent <- dfm(tokens(corp_sent))
     dfmt <- dfm_group(dfmt_sent)
     expect_equal(ndoc(corp), ndoc(dfmt))
     expect_equal(ndoc(corp_sent), ndoc(dfmt_sent))
-    expect_equal(as.matrix(dfmt), as.matrix(dfm(corp)))
+    expect_equal(as.matrix(dfmt), as.matrix(dfm(tokens(corp))))
 })
 
 test_that("dfm_group works with NA group labels", {
     corp <- corpus(c("Doc 1", "Doc 1b", "Doc2", "Doc 3 with NA", "Doc 4, more NA"),
                    docvars = data.frame(factorvar = c("Yes", "Yes", "No", NA, NA)))
     expect_identical(
-        dfm(corp, groups = "factorvar"),
-        dfm(corp[1:3], groups = "factorvar")
+        dfm(tokens(corp), groups = "factorvar"),
+        dfm(tokens(corp[1:3]), groups = "factorvar")
     )
     # expect_identical(
-    #     dfm(corp) %>% dfm_group(groups = "factorvar"),
-    #     dfm(corp[1:3]) %>% dfm_group(groups = "factorvar")
+    #     dfm(tokens(corp)) %>% dfm_group(groups = "factorvar"),
+    #     dfm(tokens(corp[1:3])) %>% dfm_group(groups = "factorvar")
     # )
 })
 
 test_that("displayed matrix rownames are correct after dfm_group (#1949)", {
     expect_identical(
-        docnames(dfm(letters[1:3], groups = c("x", "x", "y"))),
+        docnames(dfm(tokens(letters[1:3]), groups = c("x", "x", "y"))),
         c("x", "y")
     )
     expect_output(
-        print(dfm(letters[1:3], groups = c("x", "x", "y"))),
+        print(dfm(tokens(letters[1:3]), groups = c("x", "x", "y"))),
         paste0("Document-feature matrix of: 2 documents, 3 features (50.00% sparse) and 0 docvars.\n",
                "    features\n",
                "docs a b c\n",

--- a/tests/testthat/test-dfm_lookup.R
+++ b/tests/testthat/test-dfm_lookup.R
@@ -1,12 +1,9 @@
-context("test dfm_lookup")
-
 test_that("test dfm_lookup, issue #389", {
-
     toks <- tokens(data_corpus_inaugural[1:5])
     dict <- dictionary(list(Country = "united states",
                             HOR = c("House of Re*"),
-                            law = c('law*', 'constitution'), 
-                            freedom = c('free*', 'libert*')))
+                            law = c("law*", "constitution"),
+                            freedom = c("free*", "libert*")))
     expect_equal(featnames(dfm(tokens_lookup(toks, dictionary = dict), tolower = FALSE)),
                  c("Country", "HOR", "law", "freedom"))
     # expect_error(dfm_lookup(dfm(toks), dictionary = dict),
@@ -14,110 +11,104 @@ test_that("test dfm_lookup, issue #389", {
 
     dict2 <- dictionary(list(Country = "united",
                              HOR = c("House"),
-                             law = c('law*', 'constitution'), 
-                             freedom = c('free*', 'libert*')))
+                             law = c("law*", "constitution"),
+                             freedom = c("free*", "libert*")))
     expect_equal(as.numeric(dfm(toks, dictionary = dict2)[, "Country"]),
                  c(4, 1, 3, 0, 1))
-    
 })
 
 test_that("#459 apply a hierarchical dictionary to a dfm", {
-    
     txt <- c(d1 = "The United States is bordered by the Atlantic Ocean and the Pacific Ocean.",
              d2 = "The Supreme Court of the United States is seldom in a united state.")
-    testdfm <- dfm(txt)
-    dict <- dictionary(list('geo'=list(
+    testdfm <- dfm(tokens(txt))
+    dict <- dictionary(list("geo" = list(
         Countries = c("States"),
         oceans = c("Atlantic", "Pacific")),
-        'other'=list(
+        "other" = list(
             gameconsoles = c("Xbox", "Nintendo"),
             swords = c("States"))))
-    
+
     expect_equal(
         as.matrix(dfm_lookup(testdfm, dict, valuetype = "fixed", levels = 1)),
-        matrix(c(3, 1, 1, 1), ncol = 2, dimnames = list(docs = c("d1", "d2"), 
+        matrix(c(3, 1, 1, 1), ncol = 2, dimnames = list(docs = c("d1", "d2"),
                                                         features = c("geo", "other")))
     )
-    
+
     expect_equal(
         as.matrix(dfm_lookup(testdfm, dict, valuetype = "fixed", levels = 1:2)),
-        matrix(c(1, 1, 2, 0, 0, 0, 1, 1), ncol = 4, 
-               dimnames = list(docs = c("d1", "d2"), 
+        matrix(c(1, 1, 2, 0, 0, 0, 1, 1), ncol = 4,
+               dimnames = list(docs = c("d1", "d2"),
                                features = c("geo.Countries", "geo.oceans", "other.gameconsoles", "other.swords")))
     )
-    
-    
+
     expect_equal(
         as.matrix(dfm_lookup(testdfm, dict, valuetype = "fixed", levels = 2)),
-        matrix(c(1, 1, 2, 0, 0, 0, 1, 1), ncol = 4, 
-               dimnames = list(docs = c("d1", "d2"), 
+        matrix(c(1, 1, 2, 0, 0, 0, 1, 1), ncol = 4,
+               dimnames = list(docs = c("d1", "d2"),
                                features = c("Countries", "oceans", "gameconsoles", "swords")))
     )
-    
 })
 
 test_that("#459 extract the lower levels of a dictionary using a dfm", {
     txt <- c(d1 = "The United States has the Atlantic Ocean and the Pacific Ocean.",
              d2 = "Britain and Ireland have the Irish Sea and the English Channel.")
-    dict <- dictionary(list('US'=list(
+    dict <- dictionary(list("US" = list(
                                 Countries = c("States"),
                                 oceans = c("Atlantic", "Pacific")),
-                            'Europe'=list(
+                            "Europe" = list(
                                 Countries = c("Britain", "Ireland"),
                                 oceans = list(west = "Sea", east = "Channel"))))
-    
-    testdfm <- dfm(txt)
+
+    testdfm <- dfm(tokens(txt))
     expect_equal(as.matrix(dfm_lookup(testdfm, dict, levels = 1)),
                  matrix(c(3, 0, 0, 4), nrow = 2,
-                        dimnames = list(docs = c('d1', 'd2'), features = c('US', 'Europe'))))
+                        dimnames = list(docs = c("d1", "d2"), features = c("US", "Europe"))))
     expect_equal(as.matrix(dfm_lookup(testdfm, dict, levels = 2)),
                  matrix(c(1, 2, 2, 2), nrow = 2,
-                        dimnames = list(docs = c('d1', 'd2'), features = c('Countries', 'oceans'))))
+                        dimnames = list(docs = c("d1", "d2"), features = c("Countries", "oceans"))))
     expect_equal(as.matrix(dfm_lookup(testdfm, dict, levels = 1:2)),
                  matrix(c(1, 0, 2, 0, 0, 2, 0, 2), nrow = 2,
-                        dimnames = list(docs = c('d1', 'd2'), 
-                                        features = c('US.Countries', 'US.oceans', 'Europe.Countries', 'Europe.oceans'))))
+                        dimnames = list(docs = c("d1", "d2"),
+                                        features = c("US.Countries", "US.oceans",
+                                                     "Europe.Countries", "Europe.oceans"))))
     expect_equal(as.matrix(dfm_lookup(testdfm, dict, levels = 3)),
                  matrix(c(0, 1, 0, 1), nrow = 2,
-                        dimnames = list(docs = c('d1', 'd2'), features = c('west', 'east'))))
-    expect_equal(as.matrix(dfm_lookup(testdfm, dict, levels = c(1,3))),
+                        dimnames = list(docs = c("d1", "d2"), features = c("west", "east"))))
+    expect_equal(as.matrix(dfm_lookup(testdfm, dict, levels = c(1, 3))),
                  matrix(c(3, 0, 0, 2, 0, 1, 0, 1), nrow = 2,
-                        dimnames = list(docs = c('d1', 'd2'), 
-                                        features = c('US', 'Europe', 'Europe.west', 'Europe.east'))))
-    expect_equal(as.matrix(dfm_lookup(testdfm, dict, levels = c(2,3))),
+                        dimnames = list(docs = c("d1", "d2"),
+                                        features = c("US", "Europe", "Europe.west", "Europe.east"))))
+    expect_equal(as.matrix(dfm_lookup(testdfm, dict, levels = c(2, 3))),
                  matrix(c(1, 2, 2, 0, 0, 1, 0, 1), nrow = 2,
-                        dimnames = list(docs = c('d1', 'd2'), 
-                                        features = c('Countries', 'oceans', 'oceans.west', 'oceans.east'))))
-    expect_equal(as.matrix(dfm_lookup(testdfm, dict, levels = c(1,4))),
+                        dimnames = list(docs = c("d1", "d2"),
+                                        features = c("Countries", "oceans", "oceans.west", "oceans.east"))))
+    expect_equal(as.matrix(dfm_lookup(testdfm, dict, levels = c(1, 4))),
                  matrix(c(3, 0, 0, 4), nrow = 2,
-                        dimnames = list(docs = c('d1', 'd2'), features = c('US', 'Europe'))))
+                        dimnames = list(docs = c("d1", "d2"), features = c("US", "Europe"))))
     expect_equal(as.matrix(dfm_lookup(testdfm, dict, levels = 4)),
                  matrix(numeric(), nrow = 2, ncol = 0,
-                        dimnames = list(docs = c('d1', 'd2'), features = NULL)))
-    
+                        dimnames = list(docs = c("d1", "d2"), features = NULL)))
 })
 
 test_that("dfm_lookup raises error when dictionary has multi-word entries", {
     toks <- tokens(data_corpus_inaugural[1:5])
-    dict <- dictionary(list(Country = "united states"), separator = ' ')
+    dict <- dictionary(list(Country = "united states"), separator = " ")
     expect_equal(
-        featnames(dfm_lookup(dfm(tokens_ngrams(toks, n = 2, concatenator = " ")), dictionary = dict)), 
+        featnames(dfm_lookup(dfm(tokens_ngrams(toks, n = 2, concatenator = " ")), dictionary = dict)),
         c("Country")
     )
 })
 
 test_that("dfm_lookup works with multi-word keys, issue #704", {
-    
-    dict <- dictionary(list('en'=list('foreign policy' = 'foreign', 'domestic politics' = 'domestic')))
-    testdfm <- dfm(data_corpus_inaugural[1:5])
+    dict <- dictionary(list("en" = list("foreign policy" = "foreign", "domestic politics" = "domestic")))
+    testdfm <- dfm(tokens(data_corpus_inaugural[1:5]))
     expect_equal(featnames(dfm_lookup(testdfm, dict)),
                  c("en.foreign policy", "en.domestic politics"))
-    
 })
 
 test_that("dfm_lookup return dfm even if no matches, issue #704", {
-    dict <- dictionary(list('en'=list('foreign policy' = 'aaaaa', 'domestic politics' = 'bbbbb')))
-    dfmt <- dfm(data_corpus_inaugural[1:5])
+    dict <- dictionary(list("en" = list("foreign policy" = "aaaaa", "domestic politics" = "bbbbb")))
+    dfmt <- dfm(tokens(data_corpus_inaugural[1:5]))
     expect_identical(
         featnames(dfm_lookup(dfmt, dict)),
         c("en.foreign policy", "en.domestic politics")
@@ -129,27 +120,27 @@ test_that("dfm_lookup return dfm even if no matches, issue #704", {
 })
 
 test_that("dfm_lookup return all features even if no matches when exclusive = FALSE, issue #116", {
-    dict <- dictionary(list("en" = list("foreign policy" = "aaaaa", 
+    dict <- dictionary(list("en" = list("foreign policy" = "aaaaa",
                                         "domestic politics" = "bbbbb")))
-    testdfm <- dfm(data_corpus_inaugural[1:5])
+    testdfm <- dfm(tokens(data_corpus_inaugural[1:5]))
     expect_equivalent(testdfm, dfm_lookup(testdfm, dict, exclusive = FALSE))
 })
 
 test_that("dfm_lookup verbose output works correctly", {
     expect_message(
-        dfm_lookup(dfm(c(d1 = "a b c d", d2 = "c d e f g")), 
-               dictionary(list(one = "a", two = c("d", "e"))), verbose = TRUE),
+        dfm_lookup(dfm(tokens(c(d1 = "a b c d", d2 = "c d e f g"))),
+                   dictionary(list(one = "a", two = c("d", "e"))), verbose = TRUE),
         "applying a dictionary consisting of 2 keys"
     )
     expect_silent(
-        dfm_lookup(dfm(c(d1 = "a b c d", d2 = "c d e f g")), 
+        dfm_lookup(dfm(tokens(c(d1 = "a b c d", d2 = "c d e f g"))),
                    dictionary(list(one = "a", two = c("d", "e"))), verbose = FALSE)
     )
 })
 
 test_that("dfm_lookup with nomatch works", {
     txt <- c(d1 = "a c d d", d2 = "a a b c c c e f")
-    dfm1 <- dfm(txt)
+    dfm1 <- dfm(tokens(txt))
     dict <- dictionary(list(one = c("a", "b"), two = c("e", "f")))
 
     expect_equal(
@@ -158,7 +149,8 @@ test_that("dfm_lookup with nomatch works", {
     )
     expect_equal(
         as.matrix(dfm_lookup(dfm1, dict, nomatch = "_unmatched")),
-        matrix(c(1,3,0,2,3,3), nrow = 2, dimnames = list(docs = c("d1", "d2"), features = c("one", "two", "_unmatched")))
+        matrix(c(1, 3, 0, 2, 3, 3), nrow = 2, dimnames = list(docs = c("d1", "d2"),
+                                                              features = c("one", "two", "_unmatched")))
     )
     expect_warning(
         dfm_lookup(dfm1, dict, nomatch = "ANYTHING", exclusive = FALSE),
@@ -167,54 +159,53 @@ test_that("dfm_lookup with nomatch works", {
 })
 
 test_that("dfm_lookup works with exclusive = TRUE, #958", {
-    
     txt <- c("word word2 document documents documenting",
              "use using word word2")
     dict <- dictionary(list(
         document = "document*",
         use      = c("use", "using")
     ))
-    
-    mx <- dfm(txt)
+
+    mx <- dfm(tokens(txt))
     expect_equal(
         as.matrix(dfm_lookup(mx, dict, exclusive = TRUE)),
-        matrix(c(3,0,0,2), ncol = 2, dimnames = list(docs = c("text1", "text2"), 
-                                                     features = c("document", "use")))
+        matrix(c(3, 0, 0, 2), ncol = 2, dimnames = list(docs = c("text1", "text2"),
+                                                        features = c("document", "use")))
     )
     expect_equal(
         as.matrix(dfm_lookup(mx, dict, exclusive = FALSE, capkeys = TRUE)),
-        matrix(c(1,1,1,1,3,0,0,2), ncol = 4, dimnames = list(docs = c("text1", "text2"), 
-                                                             features = c("word", "word2", "DOCUMENT", "USE")))
+        matrix(c(1, 1, 1, 1, 3, 0, 0, 2), ncol = 4,
+               dimnames = list(docs = c("text1", "text2"), features = c("word", "word2", "DOCUMENT", "USE")))
     )
     expect_equal(
         as.matrix(dfm_lookup(mx, dict, exclusive = FALSE, capkeys = FALSE)),
-        matrix(c(1,1,1,1,3,0,0,2), ncol = 4, dimnames = list(docs = c("text1", "text2"), 
-                                                             features = c("word", "word2", "document", "use")))
+        matrix(c(1, 1, 1, 1, 3, 0, 0, 2), ncol = 4,
+               dimnames = list(docs = c("text1", "text2"),
+                               features = c("word", "word2", "document", "use")))
     )
 })
 
 test_that("dfm_lookup works with zero count features, #958", {
+    dict <- dictionary(list(A = "aa", B = "bb", D = "dd"))
+    mx1 <- as.dfm(matrix(c(0, 0, 0, 0, 1, 2), nrow = 2,
+                         dimnames = list(c("doc1", "doc2"), c("aa", "bb", "cc"))))
+    mx2 <- as.dfm(matrix(c(4, 5, 0, 0, 0, 0), nrow = 2,
+                         dimnames = list(c("doc1", "doc2"), c("aa", "bb", "cc"))))
 
-    dict <- dictionary(list(A = 'aa', B = 'bb', D = 'dd'))
-    mx1 <- as.dfm(matrix(c(0, 0 , 0, 0, 1, 2), nrow = 2, 
-                         dimnames = list(c("doc1", "doc2"), c("aa", "bb", "cc"))))
-    mx2 <- as.dfm(matrix(c(4, 5 , 0, 0, 0, 0), nrow = 2, 
-                         dimnames = list(c("doc1", "doc2"), c("aa", "bb", "cc"))))
-    
     expect_equal(as.matrix(dfm_lookup(mx1, dict, exclusive = TRUE)),
-                 matrix(c(0, 0 , 0, 0, 0, 0), nrow = 2, 
+                 matrix(c(0, 0, 0, 0, 0, 0), nrow = 2,
                         dimnames = list(docs = c("doc1", "doc2"), features = c("A", "B", "D"))))
-    
+
     expect_equal(as.matrix(dfm_lookup(mx2, dict, exclusive = TRUE)),
-                 matrix(c(4, 5 , 0, 0, 0, 0), nrow = 2, 
+                 matrix(c(4, 5, 0, 0, 0, 0), nrow = 2,
                         dimnames = list(docs = c("doc1", "doc2"), features = c("A", "B", "D"))))
-    
+
     expect_equal(as.matrix(dfm_lookup(mx1, dict, exclusive = FALSE)),
-                 matrix(c(0, 0 , 0, 0, 1, 2), nrow = 2, 
+                 matrix(c(0, 0, 0, 0, 1, 2), nrow = 2,
                         dimnames = list(docs = c("doc1", "doc2"), features = c("A", "B", "cc"))))
-    
+
     expect_equal(as.matrix(dfm_lookup(mx2, dict, exclusive = FALSE)),
-                 matrix(c(4, 5 , 0, 0, 0, 0), nrow = 2, 
+                 matrix(c(4, 5, 0, 0, 0, 0), nrow = 2,
                         dimnames = list(docs = c("doc1", "doc2"), features = c("A", "B", "cc"))))
 })
 
@@ -229,18 +220,17 @@ test_that("dfm_lookup works on a weighted dfm", {
 })
 
 test_that("dfm_lookup with nomatch works with key that do not appear in the text, #1347", {
-    
-    txt <- c("12032 Musgrave rd red hill", 
+    txt <- c("12032 Musgrave rd red hill",
              "13 rad street windermore park queensland",
-             "130 right road", 
+             "130 right road",
              "130 rtn road")
     toks <- tokens(txt)
-    dict <- dictionary(list(CR = c("rd", "red"), 
-                            CB = c("street", "feet"), 
+    dict <- dictionary(list(CR = c("rd", "red"),
+                            CB = c("street", "feet"),
                             CA = c("parl", "dark"))) # CA does not appear at all
     dfm_dict <- dfm_lookup(dfm(toks), dict, nomatch = "NONE")
     expect_identical(as.matrix(dfm_dict),
-                      matrix(c(2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 3, 5, 3, 3), 
+                      matrix(c(2, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 3, 5, 3, 3),
                              nrow = 4, dimnames = list(docs = c("text1", "text2", "text3", "text4"),
                                                        features = c("CR", "CB", "CA", "NONE"))))
 })

--- a/tests/testthat/test-dfm_match.R
+++ b/tests/testthat/test-dfm_match.R
@@ -1,10 +1,7 @@
-context("test dfm_match")
-
 test_that("dfm_match works", {
-
     txt <- c(doc1 = "aa bb BB cc DD ee",
              doc2 = "aa bb cc DD ee")
-    dfmat <- dfm(txt, tolower = FALSE)
+    dfmat <- dfm(tokens(txt), tolower = FALSE)
 
     dfmat_conf1 <- dfm_match(dfmat, c("aa", "zz", "xx", "bb"))
     expect_identical(
@@ -20,7 +17,7 @@ test_that("dfm_match works", {
         c("aa" = 2, "zz" = 0, "xx" = 0, "bb" = 2)
     )
 
-    dfmat_conf2 <- dfm_match(dfmat, featnames(dfm("aa zz xx bb")))
+    dfmat_conf2 <- dfm_match(dfmat, featnames(dfm(tokens("aa zz xx bb"))))
     expect_identical(
         featnames(dfmat_conf2),
         c("aa", "zz", "xx", "bb")
@@ -54,14 +51,12 @@ test_that("dfm_match works with padding", {
 })
 
 test_that("dfm_match coerce non-character feature", {
-    
     txt <- c(doc1 = "TRUE TRUE FALSE",
              doc2 = "1 2 100")
-    dfmat <- dfm(txt, tolower = FALSE)
+    dfmat <- dfm(tokens(txt), tolower = FALSE)
     expect_equal(featnames(dfm_match(dfmat, c(TRUE, FALSE))),
                  c("TRUE", "FALSE"))
     expect_equal(featnames(dfm_match(dfmat, c(100, 1))),
                  c("100", 1))
 
 })
-

--- a/tests/testthat/test-dfm_replace.R
+++ b/tests/testthat/test-dfm_replace.R
@@ -1,10 +1,7 @@
-context("test dfm_replace")
-
 test_that("test dfm_replace", {
-    
     txt <- c(doc1 = "aa bb BB cc DD ee",
              doc2 = "aa bb cc DD ee")
-    dfmt <- dfm(txt, tolower = FALSE)
+    dfmt <- dfm(tokens(txt), tolower = FALSE)
     
     # case-insensitive
     expect_equal(featnames(dfm_replace(dfmt, c('aa', 'bb'), c('a', 'b'), case_insensitive = TRUE)),

--- a/tests/testthat/test-dfm_sample.R
+++ b/tests/testthat/test-dfm_sample.R
@@ -1,7 +1,5 @@
-context("test dfm_sample")
-
 test_that("dfm_sample works as expected", {
-    mt <- dfm(data_corpus_inaugural[1:10], verbose = FALSE)
+    mt <- dfm(tokens(data_corpus_inaugural[1:10]), verbose = FALSE)
     expect_equal(ndoc(dfm_sample(mt, margin = "documents", size = 5)), 5)
     expect_equal(ndoc(dfm_sample(mt, margin = "documents", size = 15, replace = TRUE)), 15)
     expect_error(dfm_sample(mt, margin = "documents", size = 20),
@@ -14,7 +12,7 @@ test_that("dfm_sample works as expected", {
 
 test_that("dfm_sample for features works as expected", {
     suppressWarnings(RNGversion("3.5.3"))
-    dfmat <- dfm(c("a b c c d", "a a c c d d d"))
+    dfmat <- dfm(tokens(c("a b c c d", "a a c c d d d")))
     mat1 <- matrix(c(1, 0, 1, 0), nrow = 2, 
                    dimnames = list(docs = c("text1", "text2"), features = c("b", "b")))
     expect_identical({
@@ -32,7 +30,7 @@ test_that("dfm_sample for features works as expected", {
 
 test_that("dfm_sample default size arguments work as expected", {
     suppressWarnings(RNGversion("3.5.3"))
-    dfmat <- dfm(c("a b c c d", "a a c c d d d"))
+    dfmat <- dfm(tokens(c("a b c c d", "a a c c d d d")))
     
     mat1 <- matrix(rep(c(1, 1, 2, 1), 2), byrow = TRUE, nrow = 2,
                    dimnames = list(docs = c("text1.1", "text1.2"), features = letters[1:4]))

--- a/tests/testthat/test-dfm_select.R
+++ b/tests/testthat/test-dfm_select.R
@@ -1,9 +1,7 @@
-context("test dfm_select")
-
 txt <- c(doc1 = "a B c D e",
          doc2 = "a BBB c D e",
          doc3 = "Aaaa BBB cc")
-testdfm <- dfm(txt, tolower = FALSE)
+testdfm <- dfm(tokens(txt), tolower = FALSE)
 
 test_that("test dfm_select, fixed", {
     expect_equal(
@@ -128,7 +126,7 @@ test_that("longer selection than longer than features that exist (related to #44
 })
 
 test_that("test dfm_select with ngrams #589", {
-    ngramdfm <- dfm(c("of_the", "in_the", "to_the", "of_our", "and_the", " it_is", "by_the", "for_the"))
+    ngramdfm <- dfm(tokens(c("of_the", "in_the", "to_the", "of_our", "and_the", " it_is", "by_the", "for_the")))
     expect_equal(featnames(dfm_select(ngramdfm, pattern = c("of_the", "in_the"), valuetype = "fixed")),
                  c("of_the", "in_the"))
     expect_equal(featnames(dfm_select(ngramdfm, pattern = "*_the", valuetype = "glob")),
@@ -136,7 +134,7 @@ test_that("test dfm_select with ngrams #589", {
 })
 
 test_that("test dfm_select with ngrams concatenated with whitespace", {
-    ngramdfm <- dfm(c("of_the", "in_the", "to_the", "of_our", "and_the", " it_is", "by_the", "for_the"))
+    ngramdfm <- dfm(tokens(c("of_the", "in_the", "to_the", "of_our", "and_the", " it_is", "by_the", "for_the")))
     colnames(ngramdfm) <- stringi::stri_replace_all_fixed(colnames(ngramdfm), "_", " ")
     expect_equal(
         featnames(dfm_select(ngramdfm, pattern = c("of the", "in the"), valuetype = "fixed")),
@@ -150,8 +148,8 @@ test_that("test dfm_select with ngrams concatenated with whitespace", {
 
 test_that("dfm_select on a dfm returns equal feature sets", {
     txts <- c(d1 = "This is text one", d2 = "The second text", d3 = "This is text three")
-    dfmt1 <- dfm(txts[1:2])
-    dfmt2 <- dfm(txts[2:3])
+    dfmt1 <- dfm(tokens(txts[1:2]))
+    dfmt2 <- dfm(tokens(txts[2:3]))
     expect_warning({
         dfmt3 <- dfm_select(dfmt1, dfmt2)
     }, "pattern = dfm is deprecated")
@@ -159,7 +157,6 @@ test_that("dfm_select on a dfm returns equal feature sets", {
 })
 
 test_that("dfm_select removes padding", {
-
     txts <- c(d1 = "This is text one", d2 = "The second text", d3 = "This is text three")
     toks <- tokens(txts)
     toks <- tokens_remove(toks, stopwords(), padding = TRUE)
@@ -184,7 +181,7 @@ test_that("dfm_select returns empty dfm when not maching features", {
 
 test_that("dfm_remove works even when it does not remove anything, issue 711", {
     txts <- c(d1 = "This is text one", d2 = "The second text", d3 = "This is text three")
-    testdfm <- dfm(txts)
+    testdfm <- dfm(tokens(txts))
 
     expect_silent(dfm_remove(testdfm, c("xxx", "yyy", "x y")))
     expect_equal(featnames(dfm_remove(testdfm, c("xxx", "yyy", "x y"))),
@@ -192,7 +189,7 @@ test_that("dfm_remove works even when it does not remove anything, issue 711", {
 })
 
 test_that("dfm_select errors when dictionary has multi-word features, issue 775", {
-    dfm_inaug <- dfm(data_corpus_inaugural[50:58])
+    dfm_inaug <- dfm(tokens(data_corpus_inaugural[50:58]))
     testdict1 <- dictionary(list(eco = c("compan*", "factory worker*"),
                                  pol = c("political part*", "election*")),
                             separator = " ")
@@ -245,7 +242,7 @@ test_that("dfm_select errors when dictionary has multi-word features, issue 775"
 # })
 
 test_that("shortcut functions works", {
-    testdfm <- dfm(data_corpus_inaugural[1:5])
+    testdfm <- dfm(tokens(data_corpus_inaugural[1:5]))
     expect_equal(dfm_select(testdfm, stopwords("english"), selection = "keep"),
                  dfm_keep(testdfm, stopwords("english")))
     expect_equal(dfm_select(testdfm, stopwords("english"), selection = "remove"),
@@ -265,8 +262,8 @@ test_that("dfm_remove/keep fail if selection argument is used", {
 })
 
 test_that("dfm_remove works when selection is a dfm (#1320)", {
-    d1 <- dfm("a b b c c c d d d d")
-    d2 <- dfm("d d d a a")
+    d1 <- dfm(tokens("a b b c c c d d d d"))
+    d2 <- dfm(tokens("d d d a a"))
 
     expect_warning({
         d3 <- dfm_remove(d1, pattern = d2)
@@ -286,6 +283,6 @@ test_that("dfm_remove works when selection is a dfm (#1320)", {
 })
 
 test_that("really long words are not removed in tokens() (#1713)", {
-    dfmat <- dfm("one two DonaudampfschiffahrtselektrizittenhauptbetriebswerkbauunterbeamtengesellschaftXXX")
+    dfmat <- dfm(tokens("one two DonaudampfschiffahrtselektrizittenhauptbetriebswerkbauunterbeamtengesellschaftXXX"))
     expect_equivalent(nfeat(dfmat), 3)
 })

--- a/tests/testthat/test-dfm_subset.R
+++ b/tests/testthat/test-dfm_subset.R
@@ -1,7 +1,5 @@
-context("test dfm_subset")
-        
 test_that("dfm_subset works in a basic way", {
-    dfmat <- dfm(corpus_subset(data_corpus_inaugural, Year > 1980 & Year < 2018))
+    dfmat <- dfm(tokens(corpus_subset(data_corpus_inaugural, Year > 1980 & Year < 2018)))
     expect_equal(
         ndoc(dfm_subset(dfmat, Year > 2000)),
         5
@@ -29,7 +27,7 @@ test_that("dfm_subset works in a basic way", {
 })
 
 test_that("dfm_subset works with docvars", {
-    dfmat <- dfm(corpus_subset(data_corpus_inaugural, Year > 1900))
+    dfmat <- dfm(tokens(corpus_subset(data_corpus_inaugural, Year > 1900)))
     expect_equal(
         docvars(head(dfmat, 5))$President,
         c("McKinley", "Roosevelt", "Taft", "Wilson", "Wilson")

--- a/tests/testthat/test-dfm_trim.R
+++ b/tests/testthat/test-dfm_trim.R
@@ -1,8 +1,5 @@
-context("test dfm_trim")
-
 test_that("dfm_trim", {
-    
-    mydfm <- dfm(c(d1 = "a b c d e", d2 = "a a b b e f", d3 = "b c e e f f f"))
+    mydfm <- dfm(tokens(c(d1 = "a b c d e", d2 = "a a b b e f", d3 = "b c e e f f f")))
     s <- sum(mydfm)
     
     expect_equal(nfeat(dfm_trim(mydfm, min_termfreq = 0.5, termfreq_type = "quantile")), 4)
@@ -36,7 +33,8 @@ test_that("dfm_trim", {
 })
 
 test_that("dfm_trim works as expected", {
-    mydfm <- dfm(c("This is a sentence.", "This is a second sentence.", "Third sentence.", "Fouth sentence.", "Fifth sentence."))
+    mydfm <- dfm(tokens(c("This is a sentence.", "This is a second sentence.", 
+                          "Third sentence.", "Fouth sentence.", "Fifth sentence.")))
     expect_message(dfm_trim(mydfm, min_termfreq = 2, min_docfreq = 2, verbose = TRUE),
                    regexp = "Removing features occurring:")
     expect_message(dfm_trim(mydfm, min_termfreq = 2, min_docfreq = 2, verbose = TRUE),
@@ -48,7 +46,8 @@ test_that("dfm_trim works as expected", {
 })
 
 test_that("dfm_trim works as expected", {
-    mydfm <- dfm(c("This is a sentence.", "This is a second sentence.", "Third sentence.", "Fouth sentence.", "Fifth sentence."))
+    mydfm <- dfm(tokens(c("This is a sentence.", "This is a second sentence.", 
+                          "Third sentence.", "Fouth sentence.", "Fifth sentence.")))
     expect_message(dfm_trim(mydfm, max_termfreq = 2, max_docfreq = 2, verbose = TRUE),
                    regexp = "more than 2 times: 2")
     expect_message(dfm_trim(mydfm, max_termfreq = 2, max_docfreq = 2, verbose = TRUE),
@@ -59,13 +58,13 @@ test_that("dfm_trim works as expected", {
 })
 
 test_that("dfm_trim works without trimming arguments #509", {
-    mydfm <- dfm(c("This is a sentence.", "This is a second sentence.", "Third sentence."))
+    mydfm <- dfm(tokens(c("This is a sentence.", "This is a second sentence.", "Third sentence.")))
     expect_equal(dim(mydfm[-2, ]), c(2, 7))
     expect_equal(dim(dfm_trim(mydfm[-2, ], verbose = FALSE)), c(2, 6))
 })
 
 test_that("dfm_trim doesn't break because of duplicated feature names (#829)", {
-    mydfm <- dfm(c(d1 = "a b c d e", d2 = "a a b b e f", d3 = "b c e e f f f"))
+    mydfm <- dfm(tokens(c(d1 = "a b c d e", d2 = "a a b b e f", d3 = "b c e e f f f")))
     colnames(mydfm)[3] <- "b"
     expect_equal(
         as.matrix(dfm_trim(mydfm, min_termfreq = 1)),
@@ -85,8 +84,7 @@ test_that("dfm_trim doesn't break because of duplicated feature names (#829)", {
 })
 
 test_that("dfm_trim works with min_termfreq larger than total number (#1181)", {
-    
-    testdfm <- dfm(c(d1 = "a a a a b b", d2 = "a b b c"))
+    testdfm <- dfm(tokens(c(d1 = "a a a a b b", d2 = "a b b c")))
     expect_equal(dimnames(dfm_trim(testdfm, min_termfreq = 6)), 
                 list(docs = c("d1", "d2"), features = character())
     )
@@ -97,8 +95,8 @@ test_that("dfm_trim works with min_termfreq larger than total number (#1181)", {
 })
 
 test_that("dfm_trim works on previously weighted dfms (#1237)", {
-    dfm1 <- dfm(c("the quick brown fox jumps over the lazy dog", 
-                  "the quick brown foxy ox jumps over the lazy god"))
+    dfm1 <- dfm(tokens(c("the quick brown fox jumps over the lazy dog", 
+                  "the quick brown foxy ox jumps over the lazy god")))
     dfm2 <- dfm_tfidf(dfm1)
     expect_equal(
         suppressWarnings(
@@ -126,8 +124,8 @@ test_that("dfm_trim works on previously weighted dfms (#1237)", {
 })
 
 test_that("dfm_trim error with invalid input", {
-    dfmat <- dfm(c("the quick brown fox jumps over the lazy dog", 
-                  "the quick brown foxy ox jumps over the lazy god"))
+    dfmat <- dfm(tokens(c("the quick brown fox jumps over the lazy dog", 
+                  "the quick brown foxy ox jumps over the lazy god")))
     
     # min_termfreq
     expect_error(

--- a/tests/testthat/test-dfm_weight.R
+++ b/tests/testthat/test-dfm_weight.R
@@ -1,8 +1,6 @@
-context("test dfm_weight")
-
 test_that("dfm_weight works", {
     str <- c("apple is better than banana", "banana banana apple much better")
-    mydfm <- dfm(str, remove = stopwords("english"))
+    mydfm <- dfm(tokens(str), remove = stopwords("english"))
 
     expect_equivalent(round(as.matrix(dfm_weight(mydfm, scheme = "count")), 2),
                       matrix(c(1, 1, 1, 1, 1, 2, 0, 1), nrow = 2))
@@ -19,7 +17,7 @@ test_that("dfm_weight works", {
     # replication of worked example from
     # https://en.wikipedia.org/wiki/Tf-idf#Example_of_tf.E2.80.93idf
     str <- c("this is a  a sample", "this is another example another example example")
-    wikidfm <- dfm(str)
+    wikidfm <- dfm(tokens(str))
     expect_equal(
         as.matrix(dfm_tfidf(wikidfm, scheme_tf = "prop")),
         matrix(c(0, 0, 0, 0, 0.120412, 0, 0.060206, 0, 0, 0.08600857, 0, 0.1290129), nrow = 2,
@@ -36,7 +34,7 @@ test_that("dfm_weight works", {
 test_that("dfm_weight works with weights", {
     str <- c("apple is better than banana", "banana banana apple much better")
     w <- c(apple = 5, banana = 3, much = 0.5)
-    mydfm <- dfm(str, remove = stopwords("english"))
+    mydfm <- dfm(tokens(str), remove = stopwords("english"))
 
     expect_equivalent(as.matrix(dfm_weight(mydfm, weights = w)),
                       matrix(c(5, 5, 1, 1, 3, 6, 0, 0.5), nrow = 2))
@@ -59,8 +57,8 @@ test_that("dfm_weight works with weights", {
 })
 
 test_that("dfm_weight exceptions work", {
-    mydfm <- dfm(c("He went out to buy a car",
-                   "He went out and bought pickles and onions"))
+    mydfm <- dfm(tokens(c("He went out to buy a car",
+                   "He went out and bought pickles and onions")))
     mydfm_tfprop <- dfm_weight(mydfm, "prop")
     expect_error(
         dfm_tfidf(mydfm_tfprop),
@@ -77,9 +75,9 @@ test_that("dfm_weight exceptions work", {
 })
 
 test_that("docfreq works as expected", {
-    mydfm <- dfm(c("He went out to buy a car",
+    mydfm <- dfm(tokens(c("He went out to buy a car",
                    "He went out and bought pickles and onions",
-                   "He ate pickles in the car."))
+                   "He ate pickles in the car.")))
     expect_equivalent(
         docfreq(mydfm, scheme = "unary"),
         rep(1, ncol(mydfm))
@@ -119,8 +117,8 @@ test_that("docfreq works as expected", {
 })
 
 test_that("tf with logave now working as expected", {
-    mydfm <- dfm(c("He went out to buy a car",
-                   "He went out and bought pickles and onions"))
+    mydfm <- dfm(tokens(c("He went out to buy a car",
+                   "He went out and bought pickles and onions")))
     manually_calculated <-
         as.matrix((1 + log10(mydfm)) / (1 + log10(apply(mydfm, 1, function(x) sum(x) / sum(x > 0)))))
     manually_calculated[is.infinite(manually_calculated)] <- 0
@@ -131,8 +129,8 @@ test_that("tf with logave now working as expected", {
 })
 
 test_that("tfidf works with different log base", {
-    mydfm <- dfm(c("He went out to buy a car",
-                   "He went out and bought pickles and onions"))
+    mydfm <- dfm(tokens(c("He went out to buy a car",
+                   "He went out and bought pickles and onions")))
     expect_true(
         !identical(
             as.matrix(dfm_tfidf(mydfm)),
@@ -142,7 +140,7 @@ test_that("tfidf works with different log base", {
 })
 
 test_that("docfreq works when features have duplicated names (#829)", {
-    mydfm <- dfm(c(d1 = "a b c d e", d2 = "a a b b e f", d3 = "b e e f f f"))
+    mydfm <- dfm(tokens(c(d1 = "a b c d e", d2 = "a a b b e f", d3 = "b e e f f f")))
     colnames(mydfm)[3] <- "b"
     expect_equal(
         docfreq(mydfm),
@@ -151,8 +149,8 @@ test_that("docfreq works when features have duplicated names (#829)", {
 })
 
 test_that("dfm_weight works with zero-frequency features (#929)", {
-    d1 <- dfm(c("a b c", "a b c d"))
-    d2 <- dfm(letters[1:6])
+    d1 <- dfm(tokens(c("a b c", "a b c d")))
+    d2 <- dfm(tokens(letters[1:6]))
     dtest <- dfm_match(d1, featnames(d2))
 
     expect_equal(
@@ -176,7 +174,7 @@ test_that("dfm_weight works with zero-frequency features (#929)", {
 test_that("settings are recorded for tf-idf weightings", {
     txt <- c(text1 = "The new law included a capital gains tax, and an inheritance tax.",
              text2 = "New York City has raised a taxes: an income tax and a sales tax.")
-    dfmt <- dfm(txt, remove_punct = TRUE)
+    dfmt <- dfm(tokens(txt, remove_punct = TRUE))
     dfmt_tfidf <- dfm_tfidf(dfmt)
     expect_equal(dfmt_tfidf@meta$object$weight_tf$scheme, "count")
     expect_equal(dfmt_tfidf@meta$object$weight_df$scheme, "inverse")
@@ -194,9 +192,8 @@ test_that("settings are recorded for tf-idf weightings", {
 })
 
 test_that("weights argument works, issue 1150", {
-
     txt <- c("brown brown yellow green", "yellow green blue")
-    mt <- dfm(txt)
+    mt <- dfm(tokens(txt))
     w <- c(brown = 0.1, yellow = 0.3, green = 0.4, blue = 2)
 
     expect_equal(
@@ -222,7 +219,7 @@ test_that("weights argument works, issue 1150", {
 
     # test when a feature is not assigned a weight
     txt2 <- c(d1 = "brown brown yellow green black", d2 = "yellow green blue")
-    mt2 <- dfm(txt2)
+    mt2 <- dfm(tokens(txt2))
     w2 <- c(green = .1, blue = .2, brown = .3, yellow = .4)
     expect_equal(
         as.matrix(dfm_weight(mt2, weights = w2)),
@@ -232,8 +229,8 @@ test_that("weights argument works, issue 1150", {
 })
 
 test_that("deprecated dfm_weight argument values still work", {
-    mydfm <- dfm(c("He went out to buy a car",
-                   "He went out and bought pickles and onions"))
+    mydfm <- dfm(tokens(c("He went out to buy a car",
+                   "He went out and bought pickles and onions")))
 
     # frequency
     expect_identical(
@@ -311,7 +308,7 @@ test_that("dfm_weight invalid scheme produces error", {
 })
 
 test_that("featfreq() works", {
-    dfmat <- dfm(c(d1 = "a a a b", d2 = "a b c"))
+    dfmat <- dfm(tokens(c(d1 = "a a a b", d2 = "a b c")))
     expect_identical(
         featfreq(dfmat),
         c(a = 4, b = 2, c = 1)
@@ -319,7 +316,7 @@ test_that("featfreq() works", {
 })
 
 test_that("logsmooth works", {
-    dfmat <- dfm(c("a a a b c d d", "b b c d d d"))
+    dfmat <- dfm(tokens(c("a a a b c d d", "b b c d d d")))
     expect_equivalent(
         dfm_weight(dfmat, scheme = "logsmooth", smoothing = 0.5, base = exp(1)) %>% as.matrix(),
         matrix(log(c(3, 0, 1, 2, 1, 1, 2, 3) + 0.5), nrow = 2)

--- a/tests/testthat/test-dictionaries.R
+++ b/tests/testthat/test-dictionaries.R
@@ -1,5 +1,3 @@
-context("dictionary construction")
-
 test_that("dictionary constructors fail if all elements unnamed: explicit", {
     expect_error(dictionary(list(c("a", "b"), "c")),
                  "Dictionary elements must be named: a b c")

--- a/tests/testthat/test-docnames.R
+++ b/tests/testthat/test-docnames.R
@@ -1,5 +1,3 @@
-context("test docnames")
-
 test_that("docnames always return names even if there aren't", {
     corp <- corpus(c("aaa", "bbb", "ccc"))
     expect_equal(length(docnames(corp)), ndoc(corp))
@@ -58,7 +56,7 @@ test_that("special names<- operator works as planned", {
         attr(toks, "docvars")[["docname_"]]
     )
 
-    dfmat <- dfm(corpus(LETTERS[1:3], docnames = letters[1:3]))
+    dfmat <- dfm(tokens(corpus(LETTERS[1:3], docnames = letters[1:3])))
     rownames(dfmat)[1] <- "X"
     expect_identical(
         rownames(dfmat),

--- a/tests/testthat/test-docvars.R
+++ b/tests/testthat/test-docvars.R
@@ -1,5 +1,3 @@
-context("test docvars")
-
 test_that("make_docvars() works", {
     docvar1 <- quanteda:::make_docvars(0L, docname = character())
     docvar2 <- quanteda:::make_docvars(3L, docname = c("A", "B", "C"))
@@ -214,28 +212,6 @@ test_that("docvars is working with tokens", {
     )
 })
 
-test_that("metadoc for tokens works", {
-    skip("Until we resolve metadoc issues")
-    corp <- data_corpus_inaugural
-    expect_warning(
-        metadoc(corp, "language") <- "english",
-        "metadoc is deprecated"
-    )
-    suppressWarnings(metadoc(corp, "language") <- "english")
-    toks <- tokens(corp, include_docvars = TRUE)
-
-    expect_equal(docvars(toks), docvars(corp))
-    suppressWarnings(
-        expect_equal(metadoc(toks), metadoc(corp))
-    )
-
-    expect_equal(docvars(toks, "President"), docvars(corp, "President"))
-
-    # Subset
-    toks2 <- toks[docvars(toks, "_language") == "english"]
-    expect_equal(ndoc(toks2), nrow(docvars(toks2)))
-})
-
 test_that("docvars is working with dfm", {
     corp <- data_corpus_inaugural
     toks <- tokens(corp, include_docvars = TRUE)
@@ -244,12 +220,12 @@ test_that("docvars is working with dfm", {
     expect_equal(docvars(toks), docvars(thedfm))
     expect_equal(docvars(toks, "Party"), docvars(corp, "Party"))
 
-    thedfm2 <- dfm(corp)
+    thedfm2 <- dfm(tokens(corp))
     expect_equal(docvars(corp), docvars(thedfm2))
     expect_equal(docvars(corp, "Party"), docvars(thedfm2, "Party"))
 
     corp2 <- corpus_subset(corp, Party == "Democratic")
-    thedfm3 <- dfm(corp2)
+    thedfm3 <- dfm(tokens(corp2))
     expect_equal(docvars(corp2), docvars(thedfm3))
 })
 
@@ -269,7 +245,7 @@ test_that("creating tokens and dfms with empty docvars", {
         length(docvars(tokens(data_corpus_inaugural, include_docvars = FALSE))), 0
     )
     expect_equal(
-        length(docvars(dfm(data_corpus_inaugural, include_docvars = FALSE))), 0
+        length(docvars(dfm(tokens(data_corpus_inaugural), include_docvars = FALSE))), 0
     )
 })
 
@@ -298,10 +274,9 @@ test_that("dfm works works with one docvar", {
     mycorpus1 <- corpus(c(d1 = "This is sample document one.",
                           d2 = "Here is the second sample document."),
                         docvars = docv1)
-    dfm1 <- dfm(mycorpus1, include_docvars = TRUE)
+    dfm1 <- dfm(tokens(mycorpus1), include_docvars = TRUE)
     expect_equivalent(docvars(dfm1), docv1)
 })
-
 
 test_that("dfm works works with two docvars", {
     docv2 <- data.frame(dvar1 = c("A", "B"),
@@ -309,12 +284,11 @@ test_that("dfm works works with two docvars", {
     mycorpus2 <- corpus(c(d1 = "This is sample document one.",
                           d2 = "Here is the second sample document."),
                         docvars = docv2)
-    dfm2 <- dfm(mycorpus2, include_docvars = TRUE)
+    dfm2 <- dfm(tokens(mycorpus2), include_docvars = TRUE)
     expect_equivalent(docvars(dfm2), docv2)
 })
 
 test_that("object always have docvars in the same rows as documents", {
-
     txt <- data_char_ukimmig2010
     corp1 <- corpus(txt)
     expect_true(nrow(docvars(corp1)) == ndoc(corp1))
@@ -348,7 +322,7 @@ test_that("object always have docvars in the same rows as documents", {
     expect_true(nrow(docvars(toks4)) == ndoc(toks4))
     expect_true(all(row.names(docvars(toks4)) == seq_len(ndoc(toks4))))
 
-    dfm1 <- dfm(txt)
+    dfm1 <- dfm(tokens(txt))
     expect_true(nrow(docvars(dfm1)) == ndoc(dfm1))
     expect_true(all(row.names(docvars(dfm1)) == seq_len(ndoc(dfm1))))
 
@@ -356,7 +330,7 @@ test_that("object always have docvars in the same rows as documents", {
     expect_true(nrow(docvars(dfm2)) == ndoc(dfm2))
     expect_true(all(row.names(docvars(dfm2)) == seq_len(ndoc(dfm2))))
 
-    dfm3 <- dfm(corpus(txt))
+    dfm3 <- dfm(tokens(corpus(txt)))
     expect_true(nrow(docvars(dfm3)) == ndoc(dfm3))
     expect_true(all(row.names(docvars(dfm3)) == seq_len(ndoc(dfm3))))
 
@@ -401,7 +375,7 @@ test_that("assignment of NULL only drop columns", {
     docvars(toks) <- NULL
     expect_identical(dim(docvars(toks)), c(14L, 0L))
 
-    mt <- dfm(data_corpus_inaugural[1:14])
+    mt <- dfm(tokens(data_corpus_inaugural[1:14]))
     docvars(mt) <- NULL
     expect_identical(dim(docvars(mt)), c(14L, 0L))
 })
@@ -409,14 +383,14 @@ test_that("assignment of NULL only drop columns", {
 test_that("can assign docvars when value is a dfm (#1417)", {
     mycorp <- corpus(data_char_ukimmig2010)
 
-    thedfm <- dfm(mycorp)[, "the"]
+    thedfm <- dfm(tokens(mycorp))[, "the"]
     docvars(mycorp) <- thedfm
     expect_identical(
         docvars(mycorp),
         data.frame(the = as.vector(thedfm))
     )
 
-    anddfm <- dfm(mycorp)[, "and"]
+    anddfm <- dfm(tokens(mycorp))[, "and"]
     docvars(anddfm) <- anddfm
     expect_identical(
         docvars(anddfm),
@@ -442,7 +416,7 @@ test_that("docvar can be renamed (#1603)", {
     expect_identical(names(docvars(toks)),
                      c("year", "President", "forename", "Party"))
 
-    dfmat <- dfm(data_corpus_inaugural)
+    dfmat <- dfm(tokens(data_corpus_inaugural))
     names(docvars(dfmat))[c(1, 3)] <- c("year", "forename")
     expect_identical(names(docvars(dfmat)),
                      c("year", "President", "forename", "Party"))

--- a/tests/testthat/test-extractor.R
+++ b/tests/testthat/test-extractor.R
@@ -1,5 +1,3 @@
-context('test extractor')
-
 txt <- c(doc1 = "This is a sample text.\nIt has three lines.\nThe third line.",
          doc2 = "one\ntwo\tpart two\nthree\nfour.",
          doc3 = "A single sentence.",

--- a/tests/testthat/test-fcm.R
+++ b/tests/testthat/test-fcm.R
@@ -29,8 +29,8 @@ test_that("compare the output feature co-occurrence matrix to that of the text2v
 
 test_that("fcm works with character and tokens in the same way", {
     txt <- "A D A C E A D F E B A C E D"
-    fcmt_char <- fcm(txt, context = "window", count = "weighted",
-                    weights = c(3, 2, 1), window = 3)
+    fcmt_char <- fcm(tokens(txt), context = "window", count = "weighted",
+                     weights = c(3, 2, 1), window = 3)
     toks <- tokens(txt)
     fcmt_toks <- fcm(toks, context = "window", count = "weighted",
                     weights = c(3, 2, 1), window = 3)
@@ -57,7 +57,7 @@ test_that("fcm works with dfm and tokens in the same way", {
 
 test_that("not weighted", {
     txt <- "A D A C E A D F E B A C E D"
-    fcmt <- fcm(txt, context = "window", window = 3)
+    fcmt <- fcm(tokens(txt), context = "window", window = 3)
 
     mat <- matrix(c(4, 1, 4, 4, 5, 2,
                      0, 0, 1, 1, 2, 1,
@@ -72,7 +72,7 @@ test_that("not weighted", {
 
 test_that("weighted by default", {
     txt <- "A D A C E A D F E B A C E D"
-    fcmt <- fcm(txt, context = "window", count = "weighted", window = 3)
+    fcmt <- fcm(tokens(txt), context = "window", count = "weighted", window = 3)
 
     mat <- matrix(c(1.67, 1, 2.83, 3.33, 2.83, 0.83,
                      0, 0, 0.5, 0.33, 1.33, 0.50,
@@ -87,7 +87,8 @@ test_that("weighted by default", {
 
 test_that("customized weighting function", {
     txt <- "A D A C E A D F E B A C E D"
-    fcmt <- fcm(txt, context = "window", count = "weighted", weights = c(3, 2, 1), window = 3)
+    fcmt <- fcm(tokens(txt), context = "window", 
+                count = "weighted", weights = c(3, 2, 1), window = 3)
 
     mat <- matrix(c(6, 3, 9, 10, 10, 3,
                      0, 0, 2, 1, 4, 2,
@@ -169,7 +170,7 @@ test_that("ordered setting: boolean", {
 
 test_that("window = 2", {
     txt <- c("a a a b b c", "a a c e", "a c e f g")
-    fcm <- fcm(txt, context = "window", count = "boolean", window = 2)
+    fcm <- fcm(tokens(txt), context = "window", count = "boolean", window = 2)
     mat <- matrix(c(4, 1, 2, 2, 0, 0,
                    0, 2, 1, 0, 0, 0,
                    0, 0, 0, 2, 1, 0,
@@ -183,7 +184,7 @@ test_that("window = 2", {
 
 test_that("window = 3", {
     txt <- c("a a a b b c", "a a c e", "a c e f g")
-    fcm <- fcm(txt, context = "window", count = "boolean", window = 3)
+    fcm <- fcm(tokens(txt), context = "window", count = "boolean", window = 3)
     fcm <- fcm_sort(fcm)
     mat <- matrix(c(4, 1, 3, 2, 1, 0,
                     0, 2, 1, 0, 0, 0,
@@ -271,9 +272,9 @@ test_that("fcm print works as expected", {
 
 test_that("fcm works the same for different object types", {
     txt <- c("a a a b b c", "a a c e", "a c e f g")
-    expect_equivalent(fcm(txt), fcm(corpus(txt)))
-    expect_equivalent(fcm(tokens(txt)), fcm(corpus(txt)))
-    expect_identical(fcm(txt), fcm(tokens(txt)))
+    suppressWarnings(expect_equivalent(fcm(txt), fcm(corpus(txt))))
+    expect_equivalent(fcm(tokens(txt)), suppressWarnings(fcm(corpus(txt))))
+    expect_identical(suppressWarnings(fcm(txt)), fcm(tokens(txt)))
 })
 
 test_that("fcm expects error for wrong weight or window", {
@@ -290,7 +291,6 @@ test_that("fcm expects error for wrong weight or window", {
                      count = "weighted", weights = c(1, 2, 3)),
                  "The length of weights must be equal to the window size")
 })
-
 
 test_that("fcm works tokens with paddings, #788", {
     txt <- c("The quick brown fox jumped over the lazy dog.",
@@ -313,7 +313,6 @@ test_that("test empty object is handled properly", {
 })
 
 test_that("arithmetic/linear operation works with dfm", {
-
     mt <- fcm(dfm(tokens(c(d1 = "a a b", d2 = "a b b c", d3 = "c c d"))))
     expect_true(is.fcm(mt + 2))
     expect_true(is.fcm(mt - 2))
@@ -327,38 +326,35 @@ test_that("arithmetic/linear operation works with dfm", {
     expect_true(is.fcm(2 ^ mt))
     expect_true(is.fcm(t(mt)))
     expect_equal(rowSums(mt), colSums(t(mt)))
-
 })
 
 test_that("ordered is working correctly (#1413)", {
     expect_equivalent(
-        as.matrix(fcm(c("a b c", "a b c"), "window", window = 1, ordered = TRUE)),
+        as.matrix(fcm(tokens(c("a b c", "a b c")), "window", window = 1, ordered = TRUE)),
         matrix(c(0, 2, 0, 0, 0, 2, 0, 0, 0),
                nrow = 3, ncol = 3, byrow = TRUE))
 
     expect_equivalent(
-        as.matrix(fcm(c("a b c", "a b c"), "window", window = 2, ordered = TRUE)),
+        as.matrix(fcm(tokens(c("a b c", "a b c")), "window", window = 2, ordered = TRUE)),
         matrix(c(0, 2, 2, 0, 0, 2, 0, 0, 0),
                nrow = 3, ncol = 3, byrow = TRUE))
 
     expect_equivalent(
-        as.matrix(fcm(c("a b c", "c b a"), "window", window = 1, ordered = TRUE)),
+        as.matrix(fcm(tokens(c("a b c", "c b a")), "window", window = 1, ordered = TRUE)),
         matrix(c(0, 1, 0, 1, 0, 1, 0, 1, 0),
                nrow = 3, ncol = 3, byrow = TRUE))
 
     expect_equivalent(
-        as.matrix(fcm(c("a b c", "c b a"), "window", window = 2, ordered = TRUE)),
+        as.matrix(fcm(tokens(c("a b c", "c b a")), "window", window = 2, ordered = TRUE)),
         matrix(c(0, 1, 1, 1, 0, 1, 1, 1, 0),
                nrow = 3, ncol = 3, byrow = TRUE))
 
-    expect_equal(fcm(c("a b c", "a b c"), "window", window = 1, ordered = TRUE, tri = TRUE),
-                 fcm(c("a b c", "a b c"), "window", window = 1, ordered = TRUE, tri = FALSE))
-
+    expect_equal(fcm(tokens(c("a b c", "a b c")), "window", window = 1, ordered = TRUE, tri = TRUE),
+                 fcm(tokens(c("a b c", "a b c")), "window", window = 1, ordered = TRUE, tri = FALSE))
 })
 
-
 test_that("dimnames are always character vectors", {
-    mt <- fcm(c("a b c", "a b c"), "window", window = 1, ordered = TRUE)
+    mt <- fcm(tokens(c("a b c", "a b c")), "window", window = 1, ordered = TRUE)
     expect_identical(dimnames(mt[, character()]),
                      list(features = rownames(mt), features = character()))
     expect_identical(dimnames(mt[, FALSE]),
@@ -370,7 +366,7 @@ test_that("dimnames are always character vectors", {
 })
 
 test_that("fcm_setnames works", {
-    x <- fcm(c("a b c", "a b c"), "window", window = 1)
+    x <- fcm(tokens(c("a b c", "a b c")), "window", window = 1)
 
     quanteda:::set_fcm_featnames(x) <- paste0("feature", 1:3)
     expect_identical(featnames(x), c("feature1", "feature2", "feature3"))
@@ -378,9 +374,8 @@ test_that("fcm_setnames works", {
     quanteda:::set_fcm_dimnames(x) <- list(paste0("feature", 1:3), paste0("ALTFEAT", 1:3))
 })
 
-
 test_that("fcm feature names have encoding", {
-    mt <- fcm(c("文書１" = "あ い い う", "文書２" = "え え え お"))
+    mt <- fcm(tokens(c("文書１" = "あ い い う", "文書２" = "え え え お")))
     expect_true(all(Encoding(colnames(mt)) == "UTF-8"))
     expect_true(all(Encoding(rownames(mt)) == "UTF-8"))
 
@@ -394,7 +389,6 @@ test_that("fcm feature names have encoding", {
 })
 
 test_that("fcm raise nicer error message, #1267", {
-
     txt <- c(d1 = "one two three", d2 = "two three four", d3 = "one three four")
     mx <- fcm(dfm(tokens(txt)))
     expect_silent(mx[])

--- a/tests/testthat/test-fcm.R
+++ b/tests/testthat/test-fcm.R
@@ -1,5 +1,3 @@
-context("test fcm")
-
 test_that("compare the output feature co-occurrence matrix to that of the text2vec package", {
     skip_if_not_installed("text2vec")
     library("text2vec")
@@ -236,8 +234,8 @@ test_that("fcm works as expected for tokens_hashed", {
 })
 
 test_that("fcm print works as expected", {
-    dfmt <- dfm(data_corpus_inaugural[1:2],
-                remove_punct = FALSE, remove_numbers = FALSE, split_hyphens = TRUE)
+    dfmt <- dfm(tokens(data_corpus_inaugural[1:2],
+                remove_punct = FALSE, remove_numbers = FALSE, split_hyphens = TRUE))
     fcmt <- fcm(dfmt)
     expect_output(print(fcmt, max_nfeat = 6, show_summary = TRUE),
                   paste0("^Feature co-occurrence matrix of: 634 by 634 features\\.",
@@ -316,7 +314,7 @@ test_that("test empty object is handled properly", {
 
 test_that("arithmetic/linear operation works with dfm", {
 
-    mt <- fcm(dfm(c(d1 = "a a b", d2 = "a b b c", d3 = "c c d")))
+    mt <- fcm(dfm(tokens(c(d1 = "a a b", d2 = "a b b c", d3 = "c c d"))))
     expect_true(is.fcm(mt + 2))
     expect_true(is.fcm(mt - 2))
     expect_true(is.fcm(mt * 2))
@@ -398,7 +396,7 @@ test_that("fcm feature names have encoding", {
 test_that("fcm raise nicer error message, #1267", {
 
     txt <- c(d1 = "one two three", d2 = "two three four", d3 = "one three four")
-    mx <- fcm(dfm(txt))
+    mx <- fcm(dfm(tokens(txt)))
     expect_silent(mx[])
     expect_error(mx["five"], "Subscript out of bounds")
     expect_error(mx[, "five"], "Subscript out of bounds")

--- a/tests/testthat/test-fcm_methods.R
+++ b/tests/testthat/test-fcm_methods.R
@@ -1,5 +1,3 @@
-context("test fcm methods")
-
 toks_test <- tokens(c("b A A d", "C C a b B e"))
 fcmt_test <- fcm(toks_test, context = "document")
 

--- a/tests/testthat/test-fcm_methods.R
+++ b/tests/testthat/test-fcm_methods.R
@@ -38,7 +38,7 @@ test_that("fcm_toupper and fcm_compress work as expected",{
 txt <- c(doc1 = "a B c D e",
          doc2 = "a BBB c D e",
          doc3 = "Aaaa BBB cc")
-fcmt_test2 <- fcm(txt, context = "document", count = "frequency", tri = TRUE)
+fcmt_test2 <- fcm(tokens(txt), context = "document", count = "frequency", tri = TRUE)
 
 test_that("test fcm_select, fixed", {
     expect_equal(
@@ -160,7 +160,7 @@ test_that("test fcm_compress retains class", {
 })
 
 test_that("shortcut functions works", {
-    fcmt_test2 <- fcm(data_corpus_inaugural[1:5])
+    fcmt_test2 <- fcm(tokens(data_corpus_inaugural[1:5]))
     expect_equal(fcm_select(fcmt_test2, stopwords('english'), selection = 'keep'),
                  fcm_keep(fcmt_test2, stopwords('english')))
     expect_equal(fcm_select(fcmt_test2, stopwords('english'), selection = 'remove'),

--- a/tests/testthat/test-indexing.R
+++ b/tests/testthat/test-indexing.R
@@ -1,5 +1,3 @@
-context("test indexing")
-
 test_that("test dfm indexing", {
 
     x <- dfm(tokens(c("this contains lots of stopwords",
@@ -67,7 +65,7 @@ test_that("test dfm indexing with docvar selection", {
     testcorp <- corpus(c(d1 = "a b c d", d2 = "a a b e",
                          d3 = "b b c e", d4 = "e e f a b"),
                        docvars = data.frame(grp = c(1, 1, 2, 3)))
-    testdfm <- dfm(testcorp)
+    testdfm <- dfm(tokens(testcorp))
     expect_equal(
         docvars(testdfm[1:2, ]),
         data.frame(grp = c(1, 1))

--- a/tests/testthat/test-kwic.R
+++ b/tests/testthat/test-kwic.R
@@ -414,7 +414,7 @@ test_that("kwic works as expected with and without phrases", {
 
 test_that("kwic error when dfm is given, #1006", {
     toks <- tokens("a b c")
-    expect_error(kwic(toks, dfm("b c d")))
+    expect_error(kwic(toks, dfm(tokens("b c d"))))
 })
 
 test_that("keywords attribute is set correctly in textplot_kwic (#1514)", {

--- a/tests/testthat/test-message.R
+++ b/tests/testthat/test-message.R
@@ -1,5 +1,3 @@
-context("test messaging functions")
-
 test_that("msg works", {
     
     # no indices

--- a/tests/testthat/test-meta.R
+++ b/tests/testthat/test-meta.R
@@ -1,5 +1,3 @@
-context("test meta functions")
-
 test_that("meta/meta<- works user data", {
     txt <- c(d1 = "a b c", d2 = "x y z")
     corp <- corpus(txt, docvars = data.frame(dv = 1:2))

--- a/tests/testthat/test-nfunctions.R
+++ b/tests/testthat/test-nfunctions.R
@@ -1,5 +1,3 @@
-context("test nfunctions")
-
 test_that("test nsentence", {
     txt <- c(doc1 = "This is Mr. Smith.  He is married to Mrs. Jones.",
              doc2 = "Never, before: a colon!  Gimme a break.")
@@ -12,8 +10,8 @@ test_that("test nsentence", {
 })
 
 test_that("test ntype with dfm (#748)", {
-    d <- dfm(c(doc1 = "one two three",
-               doc2 = "one one one"))
+    d <- dfm(tokens(c(doc1 = "one two three",
+                      doc2 = "one one one")))
     expect_identical(
         ntype(d),
         c(doc1 = 3L, doc2 = 1L)

--- a/tests/testthat/test-object-builders.R
+++ b/tests/testthat/test-object-builders.R
@@ -1,5 +1,3 @@
-context("test object builder functions")
-
 test_that("corpus object builder retains class", {
     corp <- corpus(c("a / b", "a / b c", "abc"),
                    docvars = data.frame(dv = 11:13),

--- a/tests/testthat/test-object-robustness.R
+++ b/tests/testthat/test-object-robustness.R
@@ -1,5 +1,3 @@
-context("test robustness of new object class handling")
-
 test_that("corpus is/as methods work with old and new formats", {
     load("../data/pre_v2_objects/data_corpus_pre2.rda")
 
@@ -25,7 +23,7 @@ test_that("tokens is/as methods work with old and new formats", {
 
 test_that("dfm is/as methods work with old and new formats", {
     load("../data/pre_v2_objects/data_dfm_pre2.rda")
-    dfmt <- dfm(data_corpus_inaugural[1:2])
+    dfmt <- dfm(tokens(data_corpus_inaugural[1:2]))
 
     expect_true(is.dfm(data_dfm_pre2))
     expect_true(is.dfm(dfmt))
@@ -37,7 +35,7 @@ test_that("dfm is/as methods work with old and new formats", {
 
 test_that("fcm is/as methods work with old and new formats", {
     load("../data/pre_v2_objects/data_fcm_pre2.rda")
-    fcmt <- fcm(dfm(data_corpus_inaugural[1:2]))
+    fcmt <- fcm(dfm(tokens(data_corpus_inaugural[1:2])))
     
     expect_true(is.fcm(data_fcm_pre2))
     expect_true(is.fcm(fcmt))

--- a/tests/testthat/test-object2fixed.R
+++ b/tests/testthat/test-object2fixed.R
@@ -1,5 +1,3 @@
-context("test object2id")
-
 test_that("object2id is working with a list", {
     
     pat <- c('A', 'a b', 'xxx', 'C D', 'e f g')

--- a/tests/testthat/test-operators-for-core-objects.R
+++ b/tests/testthat/test-operators-for-core-objects.R
@@ -1,5 +1,3 @@
-context("test v2 core object operators")
-
 test_that("corpus core operators work for v2", {
     corp <- corpus_subset(data_corpus_inaugural, Year <= 1805)
     
@@ -60,7 +58,7 @@ test_that("tokens core operators work for v2", {
 })
 
 test_that("dfm core operators work for v2", {
-    dfmat <- dfm(corpus_subset(data_corpus_inaugural, Year <= 1805))
+    dfmat <- dfm(tokens(corpus_subset(data_corpus_inaugural, Year <= 1805)))
     
     # expect_is(dfmat["1793-Washington"], NA)
     # expect_identical(
@@ -84,7 +82,7 @@ test_that("dfm core operators work for v2", {
 })
 
 test_that("fcm core operators work for v2", {
-    dfmat <- dfm(corpus_subset(data_corpus_inaugural, Year <= 1805))
+    dfmat <- dfm(tokens(corpus_subset(data_corpus_inaugural, Year <= 1805)))
     fcmat <- fcm(dfm_trim(dfmat, min_termfreq = 20))
     
     # expect_is(fcmat[c("the", "and")], c(NA, NA))

--- a/tests/testthat/test-pattern2fixed.R
+++ b/tests/testthat/test-pattern2fixed.R
@@ -1,5 +1,3 @@
-context('test pattern2fixed')
-
 test_that("pattern2fixed converts regex patterns correctly", {
       
     regex <- list(c('^a$', '^b'), c('c'), c('d'), c('b$'))

--- a/tests/testthat/test-patterns.R
+++ b/tests/testthat/test-patterns.R
@@ -1,7 +1,4 @@
-context("test patterns")
-
 test_that("character vector works consistently on tokens", {
-
     toks <- tokens(c("a b c d e a_b_c d e"))
     feat <- c("a", "b", "c")
     expect_equivalent(
@@ -22,8 +19,7 @@ test_that("character vector works consistently on tokens", {
 })
 
 test_that("character vector works consistently on dfm", {
-
-    mx <- dfm(c("a b c d e a_b_c d e"))
+    mx <- dfm(tokens(c("a b c d e a_b_c d e")))
     feat <- c("a", "b", "c")
 
     expect_equivalent(
@@ -36,7 +32,6 @@ test_that("character vector works consistently on dfm", {
 })
 
 test_that("character vector with whitespace works consistently on tokens", {
-
     txt <- c("a b c d e a_b_c d e")
     toks <- tokens(txt)
     toksch <- as.character(toks)
@@ -75,8 +70,7 @@ test_that("character vector with whitespace works consistently on tokens", {
 })
 
 test_that("character vector with whitespace works consistently on dfm", {
-
-    mx <- dfm(c("a b c d e a_b_c d e"))
+    mx <- dfm(tokens(c("a b c d e a_b_c d e")))
     feat <- "a b c"
     expect_equivalent(
         featnames(dfm_select(mx, pattern = feat)),
@@ -88,7 +82,6 @@ test_that("character vector with whitespace works consistently on dfm", {
 })
 
 test_that("character vector with whitespace and wildcard works consistent on tokens", {
-
     toks <- tokens(c("a b c d e a_b_c d e"))
     toksch <- as.character(toks)
     feat <- "* d e"
@@ -123,11 +116,9 @@ test_that("character vector with whitespace and wildcard works consistent on tok
         nrow(kwic(toks, pattern = feat)),
         0
     )
-
 })
 
 test_that("list works consistently on tokens", {
-
     toks <- tokens(c("a b c d e a_b_c d e"))
     feat <- list(c("a", "b", "c"))
     expect_equivalent(
@@ -191,8 +182,7 @@ test_that("dictionary works consistently on tokens", {
 })
 
 test_that("dictionary works consistently on dfm", {
-
-    mx <- dfm(c("a b c d e a_b_c d e"))
+    mx <- dfm(tokens(c("a b c d e a_b_c d e")))
     dict <- dictionary(list(ABC = "a_b_c", D = "d", E = "e"))
     expect_equivalent(
         featnames(dfm_select(mx, pattern = dict)),

--- a/tests/testthat/test-phrases.R
+++ b/tests/testthat/test-phrases.R
@@ -1,5 +1,3 @@
-context("test phrase() function")
-
 test_that("test phrase for character", {
     txt <- c("capital gains tax", "one two", "three")
     expect_equivalent(

--- a/tests/testthat/test-quanteda_options.R
+++ b/tests/testthat/test-quanteda_options.R
@@ -1,5 +1,3 @@
-context("test quanteda_options")
-
 test_that("quanteda_options initialization works", {
     options('quanteda_initialized' = NULL)
     quanteda_options()

--- a/tests/testthat/test-spacyr-methods.R
+++ b/tests/testthat/test-spacyr-methods.R
@@ -1,5 +1,3 @@
-context("test spacyr methods")
-
 test_that("test quanteda methods for spacy_parsed objects", {
     load("../data/data_spacy_parsed.rda")
     expect_identical(docnames(data_spacy_parsed), "text1")

--- a/tests/testthat/test-stopwords.R
+++ b/tests/testthat/test-stopwords.R
@@ -1,7 +1,4 @@
-context("test stopwords.R")
-
 test_that("old stopwords are the same as the new", {
-
     load("../data/data_char_stopwords.rda")
     stopwords_old <- function(kind = "english", swdata) {
         if (!(kind %in% names(swdata)))
@@ -18,4 +15,3 @@ test_that("old stopwords are the same as the new", {
         stopwords("english", source = "smart")
     )
 })
-

--- a/tests/testthat/test-summary.R
+++ b/tests/testthat/test-summary.R
@@ -1,5 +1,3 @@
-context("test summary methods for objects")
-
 test_that("summary and print.summary work", {
     summary(data_corpus_inaugural[1:2])
     # a second time for the cache

--- a/tests/testthat/test-texts.R
+++ b/tests/testthat/test-texts.R
@@ -1,5 +1,3 @@
-context("test texts")
-
 txt_test <- c(d1 = "This is first document", 
               d2 = "This makes up a second text.",
               d3 = "something completely different")

--- a/tests/testthat/test-tokens.R
+++ b/tests/testthat/test-tokens.R
@@ -1,5 +1,3 @@
-context("test tokens")
-
 test_that("as.tokens list version works as expected", {
     txt <- c(doc1 = "The first sentence is longer than the second.",
              doc2 = "Told you so.")
@@ -370,18 +368,18 @@ test_that("tokens arguments works with values from parent frame (#721)", {
     )
 
     expect_identical(
-        dfm("This contains 99 numbers.", remove_numbers = T),
-        dfm("This contains 99 numbers.", remove_numbers = TRUE)
+        dfm(tokens("This contains 99 numbers."), remove_numbers = T),
+        dfm(tokens("This contains 99 numbers."), remove_numbers = TRUE)
     )
 
     val <- FALSE
     expect_identical(
         tokens("This contains 99 numbers.", remove_numbers = val),
-        tokens("This contains 99 numbers.", remove_numbers = F)
+        tokens("This contains 99 numbers.", remove_numbers = FALSE)
     )
     expect_identical(
-        dfm("This contains 99 numbers.", remove_numbers = val),
-        dfm("This contains 99 numbers.", remove_numbers = F)
+        dfm(tokens("This contains 99 numbers."), remove_numbers = val),
+        dfm(tokens("This contains 99 numbers."), remove_numbers = FALSE)
     )
 })
 
@@ -507,12 +505,14 @@ test_that("split_hyphens is working correctly", {
     corp <- data_corpus_inaugural[1:2]
     toks <- tokens(corp)
 
+    suppressWarnings({
     expect_equal(dfm(corp), dfm(toks))
     expect_equal(dfm(corp, remove_punct = TRUE), dfm(toks, remove_punct = TRUE))
     expect_equal(
         setdiff(featnames(dfm(corp)), featnames(dfm(toks))),
         character()
     )
+    })
 })
 
 test_that("tokens works as expected with NA, and blanks", {

--- a/tests/testthat/test-tokens_chunk.R
+++ b/tests/testthat/test-tokens_chunk.R
@@ -1,5 +1,3 @@
-context("test tokens_chunk")
-
 test_that("tokens_chunk works", {
     txt <- c(d1 = "a b c d", d2 = "e f g")
 

--- a/tests/testthat/test-tokens_compound.R
+++ b/tests/testthat/test-tokens_compound.R
@@ -1,5 +1,3 @@
-context("test tokens_compound")
-
 test_that("tokens_compound join tokens correctly", {
 
     txt <- c("a b c d e f g", "A B C D E F G", "A b C d E f G",
@@ -177,7 +175,7 @@ test_that("tokens_compound works as expected with dictionaries", {
 
 test_that("tokens_compound error when dfm is given, #1006", {
     toks <- tokens("a b c")
-    expect_error(tokens_compound(toks, dfm("b c d")))
+    expect_error(tokens_compound(toks, dfm(tokens("b c d"))))
 })
 
 test_that("tokens_compound window is working", {

--- a/tests/testthat/test-tokens_group.R
+++ b/tests/testthat/test-tokens_group.R
@@ -1,5 +1,3 @@
-context("test tokens_group")
-
 test_that("test that tokens_group is working", {
     txt <- c("a b c d", "e f g h", "A B C", "X Y Z")
     toks <- tokens(txt)

--- a/tests/testthat/test-tokens_lookup.R
+++ b/tests/testthat/test-tokens_lookup.R
@@ -1,6 +1,3 @@
-context('test tokens_lookup')
-
-
 txt <- c(d1 = "The United States is bordered by the Atlantic Ocean and the Pacific Ocean.",
          d2 = "The Supreme Court of the United States is seldom in a united state.",
          d3 = "It's Arsenal versus Manchester United, states the announcer.",

--- a/tests/testthat/test-tokens_ngrams.R
+++ b/tests/testthat/test-tokens_ngrams.R
@@ -1,5 +1,3 @@
-context('test tokens_ngrams')
-
 test_that("test that ngrams produces the results from Guthrie 2006", {
       toks <- tokens(c('insurgents killed in ongoing fighting'))
 

--- a/tests/testthat/test-tokens_recompile.R
+++ b/tests/testthat/test-tokens_recompile.R
@@ -1,5 +1,3 @@
-context("testing tokens_recompile")
-
 test_that("tokens_recompile: tokens_tolower", {
     toks1 <- tokens(c(one = "a b c d A B C D",
                       two = "A B C d"))

--- a/tests/testthat/test-tokens_replace.R
+++ b/tests/testthat/test-tokens_replace.R
@@ -1,5 +1,3 @@
-context("test tokens_replace")
-
 txt <- c(doc1 = "aa bb BB cc DD ee",
          doc2 = "aa bb cc DD ee")
 toks_test <- tokens(txt)

--- a/tests/testthat/test-tokens_sample.R
+++ b/tests/testthat/test-tokens_sample.R
@@ -1,5 +1,3 @@
-context("test tokens_sample")
-
 corp <- corpus(c(one = "Sentence one.  Sentence two.  Third sentence.",
                  two = "First sentence, doc2.  Second sentence, doc2."))
 corp_sent <- corpus_reshape(corp, to = "sentences")

--- a/tests/testthat/test-tokens_segment.R
+++ b/tests/testthat/test-tokens_segment.R
@@ -1,5 +1,3 @@
-context("test tokens_segment")
-
 test_that("tokens_segment works for sentences", {
     txt <- c(d1 = "Sentence one.  Second sentence is this one!\n
                    Here is the third sentence.",

--- a/tests/testthat/test-tokens_select.R
+++ b/tests/testthat/test-tokens_select.R
@@ -1,5 +1,3 @@
-context("test tokens_select")
-
 test_that("test that tokens_select is working", {
     txt <- c(doc1 = "This IS UPPER And Lower case",
              doc2 = "THIS is ALL CAPS aNd sand")
@@ -407,7 +405,7 @@ test_that("tokens_select works when window sizes are given ", {
 
 test_that("tokens_select error when dfm is given, #1006", {
     toks <- tokens("a b c")
-    expect_error(tokens_select(toks, dfm("b c d")))
+    expect_error(tokens_select(toks, dfm(tokens("b c d"))))
 })
 
 test_that("shortcut functions works", {

--- a/tests/testthat/test-tokens_split.R
+++ b/tests/testthat/test-tokens_split.R
@@ -1,5 +1,3 @@
-context("test tokens_split")
-
 test_that("tokens_split works", {
     toks <- tokens("a-a b+b B*B cc DD ee", what = "fastestword")
     expect_equal(as.list(tokens_split(toks, separator = "-", remove_separator = FALSE)),

--- a/tests/testthat/test-tokens_subset.R
+++ b/tests/testthat/test-tokens_subset.R
@@ -1,5 +1,3 @@
-context("test tokens_subset")
-        
 test_that("tokens_subset works in a basic way", {
     toks <- tokens(corpus_subset(data_corpus_inaugural, Year > 1980 & Year < 2018))
     expect_equal(

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,5 +1,3 @@
-context("test utils")
-
 test_that("message_select works as expected", {
     expect_message(
         quanteda:::message_select("remove", 10, 5, 0, 0),
@@ -75,7 +73,7 @@ test_that("get_package_version works", {
     load("../data/pre_v2_objects/data_dfm_pre2.rda")
     expect_true(quanteda:::get_object_version(data_dfm_pre2) == "1.4.0")
     expect_true(quanteda:::is_pre2(data_dfm_pre2))
-    expect_true(quanteda:::get_object_version(dfm("one")) > "1.4.9")
+    expect_true(quanteda:::get_object_version(dfm(tokens("one"))) > "1.4.9")
 })
 
 test_that("resample works with sizes", {

--- a/tests/testthat/test-validator.R
+++ b/tests/testthat/test-validator.R
@@ -1,5 +1,3 @@
-context("test validator")
-
 i1 <- 3L
 i2 <- -1L
 i3 <- c(-1L, 0L, 1L, 2L)

--- a/tests/testthat/test-wordstem.R
+++ b/tests/testthat/test-wordstem.R
@@ -1,5 +1,3 @@
-context("test wordstem")
-
 test_that("character wordstem test to test testing.", {
     expect_equal(char_wordstem("testing", "porter"), "test")
     expect_equal(char_wordstem("testing", "english"), "test")
@@ -7,12 +5,12 @@ test_that("character wordstem test to test testing.", {
 
 test_that("can wordstem dfms with zero features and zero docs", {
     # zero feature documents
-    dfmt1 <- dfm(c("one", "0"), stem = TRUE, remove_numbers = TRUE)
-    dfmt2 <- dfm(c("one", "!!"), stem = TRUE, remove_punct = TRUE)
+    dfmt1 <- dfm(tokens(c("one", "0")), stem = TRUE, remove_numbers = TRUE)
+    dfmt2 <- dfm(tokens(c("one", "!!")), stem = TRUE, remove_punct = TRUE)
     expect_equal(ndoc(dfmt1), ndoc(dfmt2), 2)
 
     # features with zero docfreq
-    dfmt3 <- dfm(c("stemming porter three", "stemming four five"))
+    dfmt3 <- dfm(tokens(c("stemming porter three", "stemming four five")))
     dfmt3[2, 4] <- 0
     dfmt3 <- as.dfm(dfmt3)
     dfm_wordstem(dfmt3, language = "english")

--- a/vignettes/pkgdown/quickstart_es.Rmd
+++ b/vignettes/pkgdown/quickstart_es.Rmd
@@ -247,7 +247,8 @@ Convertir los textos en tokens es una opción intermedia y la mayoría de los us
 corp_inaug_post1990 <- corpus_subset(data_corpus_inaugural, Year > 1990)
 
 # make a dfm
-dfmat_inaug_post1990 <- dfm(corp_inaug_post1990)
+dfmat_inaug_post1990 <- tokens(corp_inaug_post1990) %>%
+    dfm()
 dfmat_inaug_post1990[, 1:5]
 ```
 

--- a/vignettes/quickstart.Rmd
+++ b/vignettes/quickstart.Rmd
@@ -276,7 +276,8 @@ such as `tolower()` -- a separate function for lower-casing texts -- and removes
 corp_inaug_post1990 <- corpus_subset(data_corpus_inaugural, Year > 1990)
 
 # make a dfm
-dfmat_inaug_post1990 <- dfm(corp_inaug_post1990)
+dfmat_inaug_post1990 <- tokens(corp_inaug_post1990) %>%
+  dfm()
 dfmat_inaug_post1990[, 1:5]
 ```
 
@@ -355,7 +356,9 @@ dict <- dictionary(list(terror = c("terrorism", "terrorists", "threat"),
 
 We can use the dictionary when making the dfm:
 ```{r}
-dfmat_inaug_post1991_dict <- dfm(corp_inaug_post1991, dictionary = dict)
+dfmat_inaug_post1991_dict <- tokens(corp_inaug_post1991) %>%
+  tokens_lookup(dictionary = dict) %>%
+  dfm()
 dfmat_inaug_post1991_dict
 ```
 
@@ -374,8 +377,11 @@ dfmat_inaug_subset[, 1:10]
 
 ```{r fig.width = 6, fig.height = 3}
 library("quanteda.textstats")
-dfmat_inaug_post1980 <- dfm(corpus_subset(data_corpus_inaugural, Year > 1980),
-                            remove = stopwords("english"), stem = TRUE, remove_punct = TRUE)
+dfmat_inaug_post1980 <- corpus_subset(data_corpus_inaugural, Year > 1980) %>%
+  tokens(remove_punct = TRUE) %>%
+  tokens_wordstem(language = "en") %>%
+  tokens_remove(stopwords("en")) %>%
+  dfm()
 tstat_obama <- textstat_simil(dfmat_inaug_post1980,
                               dfmat_inaug_post1980[c("2009-Obama", "2013-Obama"), ],
                               margin = "documents", method = "cosine")
@@ -387,9 +393,11 @@ We can use these distances to plot a dendrogram, clustering presidents.
 First, load some data.
 ```{r, eval = FALSE}
 data_corpus_sotu <- readRDS(url("https://quanteda.org/data/data_corpus_sotu.rds"))
-dfmat_sotu <- dfm(corpus_subset(data_corpus_sotu, Date > as.Date("1980-01-01")),
-                  stem = TRUE, remove_punct = TRUE,
-                  remove = stopwords("english"))
+dfmat_sotu <- corpus_subset(data_corpus_sotu, Date > as.Date("1980-01-01")) %>%
+  tokens(remove_punct = TRUE) %>%
+  tokens_wordstem(language = "en") %>%
+  tokens_remove(stopwords("en")) %>%
+  dfm()
 dfmat_sotu <- dfm_trim(dfmat_sotu, min_termfreq = 5, min_docfreq = 3)
 ```
 


### PR DESCRIPTION
Addresses #2058.
- Attaches a deprecation warning to `dfm.corpus()`, `dfm.character()`, `fcm.character()`, and `fcm.corpus()`.
- Updates tests to call tokens first for these functions, except where we want to continue to test older methods, in which case it suppresses the warning.
- Updates  documentation, including examples.
- Also removes the `context()` from the header of the test files, since this is now discouraged in newer versions of **testthat**.

This was a bit of a nightmare not just for how extensively _we_ used these shortcut methods, but also by the future prospect of insane numbers of irritating warnings for the other users whose code will also issue endless warnings about this. I propose the following way around this: We add a `quanteda_options(strictness_warnings = c("never", "once", "always")` that issues none of these deprecation warnings for "never"; only the first time a method is called for "once"; and every time for "always". Default will be "once", so that it resets with every new session.

We could also add `kwic.corpus()`, `kwic.character()` to this PR.

I propose we resolve this, and add tests, and merge before returning to #2067. Although we could use the same `strictness_warning` for that as well.
