### PR TITLE
Issue 1978

### DIFF
--- a/R/corpus_segment.R
+++ b/R/corpus_segment.R
@@ -137,7 +137,7 @@ corpus_segment.corpus <- function(x, pattern = "##*",
     } else {
         docvars <- select_docvars(attrs[["docvars"]], user = FALSE, system = TRUE)
     }
-    docvars <- reshape_docvars(docvars, temp[["docnum"]])
+    docvars <- reshape_docvars(docvars, temp[["docnum"]], drop_docid = FALSE)
     if (extract_pattern)
         docvars[["pattern"]] <- temp[["pattern"]]
 

--- a/tests/testthat/test-corpus_reshape.R
+++ b/tests/testthat/test-corpus_reshape.R
@@ -1,10 +1,16 @@
 test_that("corpus_reshape works for sentences", {
     corp <- corpus(c(textone = "This is a sentence.  Another sentence.  Yet another.", 
-                     texttwo = "Premiere phrase.  Deuxieme phrase."), 
-                   docvars = data.frame(country = factor(c("UK", "USA")), year=c(1990, 2000)))
+                     texttwo = "Premiere phrase.  Deuxieme phrase.",
+                     textthree = ""), 
+                   docvars = data.frame(country = factor(c("UK", "US", "ZA")), year=c(1990, 2000, 2020)))
     corp_reshaped <- corpus_reshape(corp, to = "sentences")
+    expect_equal(docid(corp_reshaped),
+                 factor(c("textone", "textone", "textone", "texttwo", "texttwo", "textthree"),
+                        levels = c("textone", "texttwo", "textthree")))
     expect_equal(as.character(corp_reshaped)[4], c(texttwo.1 = "Premiere phrase."))
-    expect_equal(docvars(corp_reshaped, "country"), factor(c("UK", "UK", "UK", "USA", "USA")))
+    expect_equal(as.character(corp_reshaped)[6], c(textthree.1 = ""))
+    expect_equal(docvars(corp_reshaped, "country"), 
+                 factor(c("UK", "UK", "UK", "US", "US", "ZA"), levels = c("UK", "US", "ZA")))
 })
 
 test_that("corpus_reshape works for paragraphs", {

--- a/tests/testthat/test-corpus_segment.R
+++ b/tests/testthat/test-corpus_segment.R
@@ -55,19 +55,23 @@ test_that("corpus_segment works with blank before tag", {
     expect_equal(as.character(summ[1, "Text"]), "text1.1")
 })
 
-
 test_that("corpus_segment works with use_docvars TRUE or FALSE", {
     corp <- corpus(c(d1 = "##TEST One two ##TEST2 Three",
-                     d2 = "##TEST3 Four"),
-                     docvars = data.frame(test = c("A", "B"), stringsAsFactors = FALSE))
+                     d2 = "##TEST3 Four", 
+                     d3 = ""),
+                     docvars = data.frame(test = c("A", "B", "B"), stringsAsFactors = FALSE))
     corp_seg1 <- corpus_segment(corp, "##[A-Z0-9]+", valuetype = "regex", 
                                 pattern_position = "before", extract_pattern = TRUE, 
                                 use_docvars = TRUE)
     expect_equal(docvars(corp_seg1, "test"), c("A", "A", "B"))
+    expect_equal(docid(corp_seg1), 
+                 factor(c("d1", "d1", "d2"), levels = c("d1", "d2", "d3")))
     
     corp_seg2 <- corpus_segment(corp, "##[A-Z0-9]+", valuetype = "regex", 
                                 pattern_position = "before", extract_pattern = TRUE, use_docvars = FALSE)
     expect_error(docvars(corp_seg2, "test"))
+    expect_equal(docid(corp_seg2), 
+                 factor(c("d1", "d1", "d2"), levels = c("d1", "d2", "d3")))
 })
 
 test_that("char_segment works with Japanese texts", {


### PR DESCRIPTION
Using recently added `drop_docid = FALSE`, stop `corpus_reshape()` and `corpus_segment()` to forget original documents. It should solve #1978.