### PR TITLE
Issue 2127

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 * Improved and more consistent handling of empty corpus, tokens and dfm objects, to address #2110.
 * `rbind.dfm()` now preserves docvars (#2109).
 * Document name for Biden's 2021 Inaugural Address in `data_corpus_inaugural` is now consistent with all other documents.
+* Fix #2127 that caused subsetting to change document names.
 
 # quanteda 3.0
 

--- a/R/corpus_trim.R
+++ b/R/corpus_trim.R
@@ -44,15 +44,18 @@ corpus_trim.corpus <- function(x, what = c("sentences", "paragraphs", "documents
 
     # segment corpus
     temp <- corpus_reshape(x, to = what)
-
+    
+    if (length(temp) == 0)
+        return(x)
+    
     # exclude based on lengths
-    length <- ntoken(temp, remove_punct = TRUE)
+    len <- ntoken(temp, remove_punct = TRUE)
     if (!is.null(max_ntoken)) {
         max_ntoken <- check_integer(max_ntoken)
     } else {
-        max_ntoken <- max(length)
+        max_ntoken <- max(len)
     }
-    result <- corpus_subset(temp, length >= min_ntoken & length <= max_ntoken)
+    result <- corpus_subset(temp, len >= min_ntoken & len <= max_ntoken)
 
     # exclude based on regular expression match
     if (!is.null(exclude_pattern)) {

--- a/R/docvars.R
+++ b/R/docvars.R
@@ -132,8 +132,13 @@ make_docvars <- function(n, docname = NULL, unique = TRUE, drop_docid = TRUE) {
 reshape_docvars <- function(x, i = NULL, drop_docid = TRUE) {
     if (is.null(i)) return(x)
     x <- x[i, , drop = FALSE]
-    temp <- make_docvars(nrow(x), x[["docid_"]], unique = TRUE, drop_docid)
-    x[c("docname_", "docid_", "segid_")] <- temp
+    if (any(duplicated(i))) {
+        temp <- make_docvars(nrow(x), x[["docid_"]], unique = TRUE, drop_docid)
+        x[c("docname_", "docid_", "segid_")] <- temp
+    } else {
+        if (drop_docid)
+            x[["docid_"]] <- droplevels(x[["docid_"]])
+    }
     rownames(x) <- NULL
     return(x)
 }

--- a/man/as.data.frame.dfm.Rd
+++ b/man/as.data.frame.dfm.Rd
@@ -27,11 +27,7 @@ data.frame, defaults \code{docnames(x)}.  Set to \code{NULL} to exclude.}
 \item{docid_field}{character; the name of the column containing document
 names used when \code{to = "data.frame"}.  Unused for other conversions.}
 
-\item{check.names}{logical.  If \code{TRUE} then the names of the
-    variables in the data frame are checked to ensure that they are
-    syntactically valid variable names and are not duplicated.
-    If necessary they are adjusted (by \code{\link[base]{make.names}})
-    so that they are.}
+\item{check.names}{logical; passed to the \code{\link[base]{data.frame}()} call.}
 }
 \description{
 Deprecated function to convert a dfm into a data.frame.

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -6,6 +6,11 @@
 
 using namespace Rcpp;
 
+#ifdef RCPP_USE_GLOBAL_ROSTREAM
+Rcpp::Rostream<true>&  Rcpp::Rcout = Rcpp::Rcpp_cout_get();
+Rcpp::Rostream<false>& Rcpp::Rcerr = Rcpp::Rcpp_cerr_get();
+#endif
+
 // qatd_cpp_fcm
 S4 qatd_cpp_fcm(const Rcpp::List& texts_, const int n_types, const NumericVector& weights_, const bool boolean, const bool ordered);
 RcppExport SEXP _quanteda_qatd_cpp_fcm(SEXP texts_SEXP, SEXP n_typesSEXP, SEXP weights_SEXP, SEXP booleanSEXP, SEXP orderedSEXP) {

--- a/tests/testthat/test-docnames.R
+++ b/tests/testthat/test-docnames.R
@@ -112,7 +112,7 @@ test_that("docnames are alwyas unique", {
 
 
 test_that("docnames are the same after subsetting (#2127)", {
-    corp <- corpus_reshape(data_corpus_inaugural)
+    corp <- corpus_reshape(data_corpus_inaugural[1])
     toks <- tokens(corp)
     dfmat <- dfm(toks)
     dname <- c("1789-Washington.2", "1789-Washington.3")

--- a/tests/testthat/test-docnames.R
+++ b/tests/testthat/test-docnames.R
@@ -109,3 +109,26 @@ test_that("docnames are alwyas unique", {
     expect_false(any(duplicated((docnames(dfmat3)))))
     expect_identical(docnames(dfmat3), dfmat3@Dimnames[["docs"]])
 })
+
+
+test_that("docnames are the same after subsetting (#2127)", {
+    corp <- corpus_reshape(data_corpus_inaugural)
+    toks <- tokens(corp)
+    dfmat <- dfm(toks)
+    dname <- c("1789-Washington.2", "1789-Washington.3")
+    
+    expect_identical(docnames(corp[dname]), dname)
+    expect_identical(docnames(corp[dname[1]]), dname[1])
+    expect_identical(docnames(corp[2:3]), dname)
+    expect_identical(docnames(corp[2]), dname[1])
+    
+    expect_identical(docnames(toks[dname]), dname)
+    expect_identical(docnames(toks[dname[1]]), dname[1])
+    expect_identical(docnames(toks[2:3]), dname)
+    expect_identical(docnames(toks[2]), dname[1])
+    
+    expect_identical(docnames(dfmat[dname,]), dname)
+    expect_identical(docnames(dfmat[dname[1],]), dname[1])
+    expect_identical(docnames(dfmat[2:3,]), dname)
+    expect_identical(docnames(dfmat[2,]), dname[1])
+})

--- a/tests/testthat/test-docvars.R
+++ b/tests/testthat/test-docvars.R
@@ -32,7 +32,7 @@ test_that("make_docvars() works", {
 test_that("reshape_docvars() words", {
     
     docvar1 <- data.frame("docname_" = c("doc1", "doc2"),
-                          "docid_" = c("doc1", "doc2"),
+                          "docid_" = factor(c("doc1", "doc2")),
                           "segid_" = c(1, 2), stringsAsFactors = FALSE)
     
     expect_identical(
@@ -45,7 +45,7 @@ test_that("reshape_docvars() words", {
     )
     
     docvar2 <- data.frame("docname_" = c("doc1.1", "doc1.2"),
-                          "docid_" = c("doc1", "doc1"),
+                          "docid_" = factor(c("doc1", "doc1")),
                           "segid_" = c(1, 1))
     expect_identical(
         quanteda:::reshape_docvars(docvar2, c(1, 2))[["docname_"]],


### PR DESCRIPTION
Address #2127 by updating `segid_` only when subsetting indices are duplicated. There are other ways (e.g. allowing duplicated docnames) to solve the bug, but  this is the most conservative approach.

```r
> corp[c("1789-Washington.2", "1789-Washington.3")]
Corpus consisting of 2 documents and 4 docvars.
1789-Washington.2 :
"On the one hand, I was summoned by my Country, whose voice I..."

1789-Washington.3 :
"On the other hand, the magnitude and difficulty of the trust..."

> corp[c("1789-Washington.2", "1789-Washington.2")]
Corpus consisting of 2 documents and 4 docvars.
1789-Washington.1 :
"On the one hand, I was summoned by my Country, whose voice I..."

1789-Washington.2 :
"On the one hand, I was summoned by my Country, whose voice I..."
```

