### PR TITLE
Keep unigrams only when window is used

### DIFF
--- a/R/tokens_compound.R
+++ b/R/tokens_compound.R
@@ -98,10 +98,10 @@ tokens_compound.tokens <- function(x, pattern,
     attrs <- attributes(x)
     type <- types(x)
 
-    seqs_id <- object2id(pattern, type, valuetype, case_insensitive, remove_unigram = FALSE)
-    if (length(seqs_id) == 0) return(x) # do nothing
+    ids <- object2id(pattern, type, valuetype, case_insensitive, remove_unigram = all(window == 0))
+    if (length(ids) == 0) return(x) # do nothing
     if (length(window) == 1) window <- rep(window, 2)
-    result <- qatd_cpp_tokens_compound(x, seqs_id, type, concatenator, join, window[1], window[2])
+    result <- qatd_cpp_tokens_compound(x, ids, type, concatenator, join, window[1], window[2])
     field_object(attrs, "concatenator") <- concatenator
     rebuild_tokens(result, attrs)
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -6,6 +6,11 @@
 
 using namespace Rcpp;
 
+#ifdef RCPP_USE_GLOBAL_ROSTREAM
+Rcpp::Rostream<true>&  Rcpp::Rcout = Rcpp::Rcpp_cout_get();
+Rcpp::Rostream<false>& Rcpp::Rcerr = Rcpp::Rcpp_cerr_get();
+#endif
+
 // qatd_cpp_fcm
 S4 qatd_cpp_fcm(const Rcpp::List& texts_, const int n_types, const NumericVector& weights_, const bool boolean, const bool ordered);
 RcppExport SEXP _quanteda_qatd_cpp_fcm(SEXP texts_SEXP, SEXP n_typesSEXP, SEXP weights_SEXP, SEXP booleanSEXP, SEXP orderedSEXP) {


### PR DESCRIPTION
to make pattern matching more efficient. Address (#2130).