### PR TITLE
Imporve segid generation

### DIFF
--- a/R/corpus-methods.R
+++ b/R/corpus-methods.R
@@ -158,7 +158,7 @@ c.corpus <- function(..., recursive = FALSE) {
 
     build_corpus(
         unclass(x)[index],
-        docvars = reshape_docvars(attrs[["docvars"]], index, drop_docid),
+        docvars = reshape_docvars(attrs[["docvars"]], index, drop_docid = drop_docid),
         meta = attrs[["meta"]],
         class = attrs[["class"]]
     )

--- a/R/corpus_reshape.R
+++ b/R/corpus_reshape.R
@@ -61,12 +61,12 @@ corpus_reshape.corpus <- function(x, to = c("sentences", "paragraphs", "document
         } else {
             temp[["text"]] <- unlist_character(lapply(temp[["text"]], paste0, collapse = "\n\n"))
         }
-        attrs[["docvars"]] <- reshape_docvars(attrs[["docvars"]], !duplicated(docnum))
+        attrs[["docvars"]] <- reshape_docvars(attrs[["docvars"]], !duplicated(docnum), unique = TRUE)
         unit <- "documents"
     } else {
         temp <- segment_texts(x,  pattern = NULL, extract_pattern = FALSE,
                               omit_empty = FALSE, what = to, ...)
-        attrs[["docvars"]] <- reshape_docvars(attrs[["docvars"]], temp[["docnum"]])
+        attrs[["docvars"]] <- reshape_docvars(attrs[["docvars"]], temp[["docnum"]], unique = FALSE)
         unit <- to
     }
     build_corpus(

--- a/R/dfm-subsetting.R
+++ b/R/dfm-subsetting.R
@@ -29,7 +29,7 @@ subset_dfm <- function(x, i, j, ..., drop) {
     }
 
     if (!missing(i))
-        attrs[["docvars"]] <- reshape_docvars(attrs[["docvars"]], index_row, ...)
+        attrs[["docvars"]] <- reshape_docvars(attrs[["docvars"]], index_row, unique = FALSE, ...)
 
     build_dfm(
         x, colnames(x),

--- a/R/docvars.R
+++ b/R/docvars.R
@@ -138,8 +138,8 @@ reshape_docvars <- function(x, i = NULL, unique = FALSE, drop_docid = TRUE) {
         x[["docname_"]] <- as.character(x[["docid_"]])
     } else {
         if (any(duplicated(x[["docname_"]]))) {
-            segids <- lapply(split(x[["segid_"]], x[["docid_"]]), FUN = rank, ties.method = "first")
-            x[["segid_"]] <- as.integer(unlist(segids, use.names = FALSE))
+            x[["segid_"]] <- as.integer(stats::ave(x[["segid_"]], x[["docid_"]], 
+                                                   FUN = function(y) rank(y, ties.method = "first")))
             x[["docname_"]] <- paste0(x[["docid_"]], ".", x[["segid_"]])
         }
     }

--- a/R/docvars.R
+++ b/R/docvars.R
@@ -129,15 +129,19 @@ make_docvars <- function(n, docname = NULL, unique = TRUE, drop_docid = TRUE) {
 #' @param i numeric or logical vector for subsetting/duplicating rows
 #' @inheritParams make_docvars
 #' @keywords internal
-reshape_docvars <- function(x, i = NULL, drop_docid = TRUE) {
+reshape_docvars <- function(x, i = NULL, unique = FALSE, drop_docid = TRUE) {
     if (is.null(i)) return(x)
     x <- x[i, , drop = FALSE]
-    if (any(duplicated(i))) {
-        temp <- make_docvars(nrow(x), x[["docid_"]], unique = TRUE, drop_docid)
-        x[c("docname_", "docid_", "segid_")] <- temp
+    if (drop_docid)
+        x[["docid_"]] <- droplevels(x[["docid_"]])
+    if (unique) {
+        x[["docname_"]] <- as.character(x[["docid_"]])
     } else {
-        if (drop_docid)
-            x[["docid_"]] <- droplevels(x[["docid_"]])
+        if (any(duplicated(x[["docname_"]]))) {
+            segids <- lapply(split(x[["segid_"]], x[["docid_"]]), FUN = rank, ties.method = "first")
+            x[["segid_"]] <- as.integer(unlist(segids, use.names = FALSE))
+            x[["docname_"]] <- paste0(x[["docid_"]], ".", x[["segid_"]])
+        }
     }
     rownames(x) <- NULL
     return(x)

--- a/R/tokens-methods.R
+++ b/R/tokens-methods.R
@@ -128,7 +128,7 @@ print.tokens <- function(x, max_ndoc = quanteda_options("print_tokens_max_ndoc")
     result <- build_tokens(
         unclass(x)[index],
         attrs[["types"]],
-        docvars = reshape_docvars(attrs[["docvars"]], index, drop_docid),
+        docvars = reshape_docvars(attrs[["docvars"]], index, drop_docid = drop_docid),
         meta = attrs[["meta"]],
         class = attrs[["class"]]
     )

--- a/man/reshape_docvars.Rd
+++ b/man/reshape_docvars.Rd
@@ -4,12 +4,15 @@
 \alias{reshape_docvars}
 \title{Internal function to subset or duplicate docvar rows}
 \usage{
-reshape_docvars(x, i = NULL, drop_docid = TRUE)
+reshape_docvars(x, i = NULL, unique = FALSE, drop_docid = TRUE)
 }
 \arguments{
 \item{x}{docvar data.frame}
 
 \item{i}{numeric or logical vector for subsetting/duplicating rows}
+
+\item{unique}{if \code{TRUE}, names must be all unique. If \code{FALSE}, documents with the same
+names are treated as segments from the same document and given serial number.}
 
 \item{drop_docid}{if \code{TRUE}, drop unused names of documents.}
 }

--- a/tests/testthat/test-docnames.R
+++ b/tests/testthat/test-docnames.R
@@ -135,12 +135,18 @@ test_that("docnames are the same after subsetting (#2127)", {
     # preserve order of segid 
     expect_identical(docnames(corp[c("doc1.1", "doc1.3", "doc1.1")]), c("doc1.1", "doc1.3", "doc1.2"))
     expect_identical(docnames(corp[c(1, 3, 1)]), c("doc1.1", "doc1.3", "doc1.2"))
+    expect_identical(docnames(corp[c("doc2.1", "doc1.2", "doc2.1")]), c("doc2.1", "doc1.1", "doc2.2"))
+    expect_identical(docnames(corp[c(4, 2, 4)]), c("doc2.1", "doc1.1", "doc2.2"))
     
     expect_identical(docnames(toks[c("doc1.1", "doc1.3", "doc1.1")]), c("doc1.1", "doc1.3", "doc1.2"))
     expect_identical(docnames(toks[c(1, 3, 1)]), c("doc1.1", "doc1.3", "doc1.2"))
+    expect_identical(docnames(toks[c("doc2.1", "doc1.2", "doc2.1")]), c("doc2.1", "doc1.1", "doc2.2"))
+    expect_identical(docnames(toks[c(4, 2, 4)]), c("doc2.1", "doc1.1", "doc2.2"))
     
     expect_identical(docnames(dfmat[c("doc1.1", "doc1.3", "doc1.1"),]), c("doc1.1", "doc1.3", "doc1.2"))
     expect_identical(docnames(dfmat[c(1, 3, 1),]), c("doc1.1", "doc1.3", "doc1.2"))
+    expect_identical(docnames(dfmat[c("doc2.1", "doc1.2", "doc2.1"),]), c("doc2.1", "doc1.1", "doc2.2"))
+    expect_identical(docnames(dfmat[c(4, 2, 4),]), c("doc2.1", "doc1.1", "doc2.2"))
 })
 
     

--- a/tests/testthat/test-docnames.R
+++ b/tests/testthat/test-docnames.R
@@ -112,23 +112,35 @@ test_that("docnames are alwyas unique", {
 
 
 test_that("docnames are the same after subsetting (#2127)", {
-    corp <- corpus_reshape(data_corpus_inaugural[1])
+    
+    corp <- corpus(c(doc1 = "This is a sentence.  Another sentence.  Yet another.", 
+                     doc2 = "Premiere phrase.  Deuxieme phrase."))
+    corp <- corpus_reshape(corp)
     toks <- tokens(corp)
     dfmat <- dfm(toks)
-    dname <- c("1789-Washington.2", "1789-Washington.3")
+
+    # do not change docnames
+    expect_identical(docnames(corp[c("doc1.2", "doc2.1", "doc2.2")]), c("doc1.2", "doc2.1", "doc2.2"))
+    expect_identical(docnames(corp[c(2, 4, 5)]), c("doc1.2", "doc2.1", "doc2.2"))
+    expect_identical(docnames(corp[c(FALSE, TRUE, FALSE, TRUE, TRUE)]), c("doc1.2", "doc2.1", "doc2.2"))
     
-    expect_identical(docnames(corp[dname]), dname)
-    expect_identical(docnames(corp[dname[1]]), dname[1])
-    expect_identical(docnames(corp[2:3]), dname)
-    expect_identical(docnames(corp[2]), dname[1])
+    expect_identical(docnames(toks[c("doc1.2", "doc2.1", "doc2.2")]), c("doc1.2", "doc2.1", "doc2.2"))
+    expect_identical(docnames(toks[c(2, 4, 5)]), c("doc1.2", "doc2.1", "doc2.2"))
+    expect_identical(docnames(toks[c(FALSE, TRUE, FALSE, TRUE, TRUE)]), c("doc1.2", "doc2.1", "doc2.2"))
     
-    expect_identical(docnames(toks[dname]), dname)
-    expect_identical(docnames(toks[dname[1]]), dname[1])
-    expect_identical(docnames(toks[2:3]), dname)
-    expect_identical(docnames(toks[2]), dname[1])
+    expect_identical(docnames(dfmat[c("doc1.2", "doc2.1", "doc2.2"),]), c("doc1.2", "doc2.1", "doc2.2"))
+    expect_identical(docnames(dfmat[c(2, 4, 5),]), c("doc1.2", "doc2.1", "doc2.2"))
+    expect_identical(docnames(dfmat[c(FALSE, TRUE, FALSE, TRUE, TRUE),]), c("doc1.2", "doc2.1", "doc2.2"))
     
-    expect_identical(docnames(dfmat[dname,]), dname)
-    expect_identical(docnames(dfmat[dname[1],]), dname[1])
-    expect_identical(docnames(dfmat[2:3,]), dname)
-    expect_identical(docnames(dfmat[2,]), dname[1])
+    # preserve order of segid 
+    expect_identical(docnames(corp[c("doc1.1", "doc1.3", "doc1.1")]), c("doc1.1", "doc1.3", "doc1.2"))
+    expect_identical(docnames(corp[c(1, 3, 1)]), c("doc1.1", "doc1.3", "doc1.2"))
+    
+    expect_identical(docnames(toks[c("doc1.1", "doc1.3", "doc1.1")]), c("doc1.1", "doc1.3", "doc1.2"))
+    expect_identical(docnames(toks[c(1, 3, 1)]), c("doc1.1", "doc1.3", "doc1.2"))
+    
+    expect_identical(docnames(dfmat[c("doc1.1", "doc1.3", "doc1.1"),]), c("doc1.1", "doc1.3", "doc1.2"))
+    expect_identical(docnames(dfmat[c(1, 3, 1),]), c("doc1.1", "doc1.3", "doc1.2"))
 })
+
+    

--- a/tests/testthat/test-docvars.R
+++ b/tests/testthat/test-docvars.R
@@ -29,11 +29,11 @@ test_that("make_docvars() works", {
 
 })
 
-test_that("reshape_docvars() words", {
+test_that("reshape_docvars() works", {
     
     docvar1 <- data.frame("docname_" = c("doc1", "doc2"),
                           "docid_" = factor(c("doc1", "doc2")),
-                          "segid_" = c(1, 2), stringsAsFactors = FALSE)
+                          "segid_" = c(1, 1), stringsAsFactors = FALSE)
     
     expect_identical(
         quanteda:::reshape_docvars(docvar1, c(1, 2))[["docname_"]],


### PR DESCRIPTION
In #2128, `reshape_docvars()` assigns sequential values to `segid_` when duplicated indices are found. This PR improves that by generating unique `segid_` that preserve the original order. This is useful, for example, when users want to sort the documents in original order.