### PR TITLE
Fixe merge dictionary

### DIFF
--- a/R/dictionaries.R
+++ b/R/dictionaries.R
@@ -634,9 +634,8 @@ replace_dictionary_values <- function(dict, from, to) {
 merge_dictionary_values <- function(dict) {
     
     if (is.null(names(dict))) return(dict)
-    #dict_unique <- list()
     if (any(duplicated(names(dict)))) {
-        dict <- lapply(split(lis, names(dict)), function(x) {
+        dict <- lapply(split(dict, names(dict)), function(x) {
             names(x) <- NULL
             unlist(x, recursive = FALSE)
         })
@@ -647,35 +646,16 @@ merge_dictionary_values <- function(dict) {
             dict[[i]] <- list(unlist(dict_temp, use.names = FALSE))
         } else {
             is_value <- names(dict_temp) == ""
-            dict[[i]] <- c(
-                merge_dictionary_values(dict_temp[!is_value]),
-                list(unlist(dict_temp[is_value], use.names = FALSE))
-            )
+            dict[[i]] <- merge_dictionary_values(dict_temp[!is_value])
+            if (any(is_value)) {
+                dict[[i]] <- c(
+                    dict[[i]], 
+                    list(unlist(dict_temp[is_value], use.names = FALSE))
+                )
+            }
         }
     }
     return(dict)
-    # 
-    # name <- names(dict)
-    # if (is.null(name)) return(dict)
-    # dict_unique <- dict[!duplicated(name)]
-    # for (n in unique(name)) {
-    #     for (i in which(n == name & duplicated(name))) {
-    #         dict_unique[[n]] <- c(dict_unique[[n]], dict[[i]])
-    #     }
-    #     name_sub <- names(dict_unique[[n]])
-    #     if (is.null(name_sub)) {
-    #         is_value <- rep(TRUE, length(dict_unique[[n]]))
-    #     } else {
-    #         is_value <- name_sub == ""
-    #     }
-    #     if (any(is_value)) {
-    #         value <- unlist(dict_unique[[n]][is_value], use.names = FALSE)
-    #         dict_unique[[n]][is_value] <- NULL
-    #         dict_unique[[n]] <- c(dict_unique[[n]], list(value))
-    #     }
-    #     dict_unique[[n]] <- merge_dictionary_values(dict_unique[[n]])
-    # }
-    # return(dict_unique)
 }
 
 #' Internal function to convert a list to a dictionary

--- a/R/dictionaries.R
+++ b/R/dictionaries.R
@@ -632,27 +632,50 @@ replace_dictionary_values <- function(dict, from, to) {
 #'              "A" = list("aa"))
 #' quanteda:::merge_dictionary_values(dict)
 merge_dictionary_values <- function(dict) {
-    name <- names(dict)
-    if (is.null(name)) return(dict)
-    dict_unique <- dict[!duplicated(name)]
-    for (n in unique(name)) {
-        for (i in which(n == name & duplicated(name))) {
-            dict_unique[[n]] <- c(dict_unique[[n]], dict[[i]])
-        }
-        name_sub <- names(dict_unique[[n]])
-        if (is.null(name_sub)) {
-            is_value <- rep(TRUE, length(dict_unique[[n]]))
-        } else {
-            is_value <- name_sub == ""
-        }
-        if (any(is_value)) {
-            value <- unlist(dict_unique[[n]][is_value], use.names = FALSE)
-            dict_unique[[n]][is_value] <- NULL
-            dict_unique[[n]] <- c(dict_unique[[n]], list(value))
-        }
-        dict_unique[[n]] <- merge_dictionary_values(dict_unique[[n]])
+    
+    if (is.null(names(dict))) return(dict)
+    #dict_unique <- list()
+    if (any(duplicated(names(dict)))) {
+        dict <- lapply(split(lis, names(dict)), function(x) {
+            names(x) <- NULL
+            unlist(x, recursive = FALSE)
+        })
     }
-    return(dict_unique)
+    for (i in seq_along(dict)) {
+        dict_temp <- dict[[i]]
+        if (is.null(names(dict_temp))) { # NULL if only values
+            dict[[i]] <- list(unlist(dict_temp, use.names = FALSE))
+        } else {
+            is_value <- names(dict_temp) == ""
+            dict[[i]] <- c(
+                merge_dictionary_values(dict_temp[!is_value]),
+                list(unlist(dict_temp[is_value], use.names = FALSE))
+            )
+        }
+    }
+    return(dict)
+    # 
+    # name <- names(dict)
+    # if (is.null(name)) return(dict)
+    # dict_unique <- dict[!duplicated(name)]
+    # for (n in unique(name)) {
+    #     for (i in which(n == name & duplicated(name))) {
+    #         dict_unique[[n]] <- c(dict_unique[[n]], dict[[i]])
+    #     }
+    #     name_sub <- names(dict_unique[[n]])
+    #     if (is.null(name_sub)) {
+    #         is_value <- rep(TRUE, length(dict_unique[[n]]))
+    #     } else {
+    #         is_value <- name_sub == ""
+    #     }
+    #     if (any(is_value)) {
+    #         value <- unlist(dict_unique[[n]][is_value], use.names = FALSE)
+    #         dict_unique[[n]][is_value] <- NULL
+    #         dict_unique[[n]] <- c(dict_unique[[n]], list(value))
+    #     }
+    #     dict_unique[[n]] <- merge_dictionary_values(dict_unique[[n]])
+    # }
+    # return(dict_unique)
 }
 
 #' Internal function to convert a list to a dictionary


### PR DESCRIPTION
Make `quanteda:::merge_dictionary_values()` faster for very large dictionaries.

```r
require(quanteda)
lis <- replicate(100000, sample(letters, 10), simplify = FALSE)
names(lis) <- paste0("key", seq_along(lis))
head(lis)

Dictionary object with 100000 key entries.
- [key1]:
  - v, f, q, n, i, u, j, z, x, g
- [key2]:
  - c, m, i, v, r, e, a, w, z, o
- [key3]:
  - f, t, w, c, o, i, n, z, v, x
- [key4]:
  - u, m, o, k, g, w, e, p, r, b
- [key5]:
  - c, u, w, d, l, z, h, j, g, p
- [key6]:
  - z, n, f, s, x, b, v, d, u, g
[ reached max_nkey ... 99,994 more keys ]
```

```
# old
> system.time({
+ dict <- dictionary(lis)
+ })
   user  system elapsed 
920.516   5.092 928.467

# new
> system.time({
+ dict <- dictionary(lis)
+ })
   user  system elapsed 
  2.779   0.000   2.968 
```