### PR TITLE
Fix bug induced by #2161

### DIFF
--- a/R/dictionaries.R
+++ b/R/dictionaries.R
@@ -643,14 +643,14 @@ merge_dictionary_values <- function(dict) {
     for (i in seq_along(dict)) {
         dict_temp <- dict[[i]]
         if (is.null(names(dict_temp))) { # NULL if only values
-            dict[[i]] <- list(unlist(dict_temp, use.names = FALSE))
+            dict[[i]] <- list(unlist_character(dict_temp, use.names = FALSE))
         } else {
             is_value <- names(dict_temp) == ""
             dict[[i]] <- merge_dictionary_values(dict_temp[!is_value])
             if (any(is_value)) {
                 dict[[i]] <- c(
                     dict[[i]], 
-                    list(unlist(dict_temp[is_value], use.names = FALSE))
+                    list(unlist_character(dict_temp[is_value], use.names = FALSE))
                 )
             }
         }

--- a/R/dictionaries.R
+++ b/R/dictionaries.R
@@ -324,7 +324,7 @@ as.dictionary.data.frame <- function(x, format = c("tidytext"), separator = " ",
             stop("sentiment values are missing")
     }
 
-    dictionary(with(x, split(as.character(word), as.character(sentiment))),
+    dictionary(split(as.character(x$word), factor(x$sentiment)),
                separator = separator, tolower = tolower)
 }
 

--- a/R/pattern2fixed.R
+++ b/R/pattern2fixed.R
@@ -356,7 +356,7 @@ unlist_integer <- function(x, unique = FALSE, ...) {
 
 #' Unlist a list of character vectors safely
 #' @param x a list of integers
-#' @param unique if `TURE` remove duplicated elements
+#' @param unique if `TRUE` remove duplicated elements
 #' @param ... passed to `unlist`
 #' @keywords internal
 #' @return character vector

--- a/man/convert.Rd
+++ b/man/convert.Rd
@@ -68,7 +68,7 @@ always \code{TRUE}.}
 \item{docid_field}{character; the name of the column containing document
 names used when \code{to = "data.frame"}.  Unused for other conversions.}
 
-\item{pretty}{adds indentation whitespace to JSON output. Can be TRUE/FALSE or a number specifying the number of spaces to indent. See \code{\link[jsonlite]{prettify}}}
+\item{pretty}{adds indentation whitespace to JSON output. Can be TRUE/FALSE or a number specifying the number of spaces to indent. See \code{\link[jsonlite:prettify]{prettify()}}}
 }
 \value{
 A converted object determined by the value of \code{to} (see above).

--- a/man/unlist_character.Rd
+++ b/man/unlist_character.Rd
@@ -9,7 +9,7 @@ unlist_character(x, unique = FALSE, ...)
 \arguments{
 \item{x}{a list of integers}
 
-\item{unique}{if \code{TURE} remove duplicated elements}
+\item{unique}{if \code{TRUE} remove duplicated elements}
 
 \item{...}{passed to \code{unlist}}
 }

--- a/tests/testthat/test-as.dictionary.R
+++ b/tests/testthat/test-as.dictionary.R
@@ -84,6 +84,6 @@ test_that("options for tidytext only currently supported", {
     )
     expect_error(
         as.dictionary(df, format = "koRpus"),
-        "'arg' should be (one of )?\"tidytext\""
+        "'arg' should be (one of )?[“\"]tidytext[”\"]"
     )
 })

--- a/tests/testthat/test-as.dictionary.R
+++ b/tests/testthat/test-as.dictionary.R
@@ -84,7 +84,6 @@ test_that("options for tidytext only currently supported", {
     )
     expect_error(
         as.dictionary(df, format = "koRpus"),
-        "'arg' should be one of \"tidytext\"",
-        fixed = TRUE
+        "'arg' should be (one of )?\"tidytext\""
     )
 })

--- a/tests/testthat/test-as.dictionary.R
+++ b/tests/testthat/test-as.dictionary.R
@@ -84,7 +84,7 @@ test_that("options for tidytext only currently supported", {
     )
     expect_error(
         as.dictionary(df, format = "koRpus"),
-        "'arg' should be one of “tidytext”",
+        "'arg' should be one of \"tidytext\"",
         fixed = TRUE
     )
 })

--- a/tests/testthat/test-as.dictionary.R
+++ b/tests/testthat/test-as.dictionary.R
@@ -84,6 +84,7 @@ test_that("options for tidytext only currently supported", {
     )
     expect_error(
         as.dictionary(df, format = "koRpus"),
-        "\'arg\' should be one of [“\"]tidytext[”\"]"
+        "'arg' should be one of “tidytext”",
+        fixed = TRUE
     )
 })

--- a/tests/testthat/test-dictionaries.R
+++ b/tests/testthat/test-dictionaries.R
@@ -474,6 +474,14 @@ test_that("dictionary merge values in duplicate keys", {
 
 })
 
+test_that("dictionary allows empty keys", {
+  dict <- dictionary(list(A = "a", 
+                          B = list(), 
+                          C = character()))
+  expect_equal(names(dict),
+               c("A", "B", "C"))
+})
+
 test_that("object2id() preserves the order of keys and values", {
 
   type <- stopwords()


### PR DESCRIPTION
```r
> dictionary(list(A = "a", 
+                 B = list(), 
+                 C = character()))
Error in check_entries(dict) : 
  Non-character entries found in dictionary key 'B'
```
but it does not error if you apply this patch.