### PR TITLE
Fix pos

### DIFF
--- a/R/tokens_select.R
+++ b/R/tokens_select.R
@@ -189,6 +189,10 @@ tokens_select.tokens <- function(x, pattern = NULL,
 
     if (verbose) message_select(selection, length(ids), 0)
     if (length(window) == 1) window <- rep(window, 2)
+    if (length(startpos) > 1 || length(endpos) > 1) {
+        startpos <- rep(startpos, length.out = ndoc(x))
+        endpos <- rep(endpos, length.out = ndoc(x))
+    }
     if (selection == "keep") {
         result <- qatd_cpp_tokens_select(x, type, ids, 1, padding, window[1], window[2], startpos, endpos)
     } else {

--- a/tests/testthat/test-tokens_select.R
+++ b/tests/testthat/test-tokens_select.R
@@ -564,6 +564,12 @@ test_that("position arguments are working", {
              doc3 = c("a"))
     )
     expect_identical(
+        as.list(tokens_select(toks, "*", startpos = c(2), endpos = c(3, 2, 1))),
+        list(doc1 = c("b", "c"),
+             doc2 = c("b"),
+             doc3 = character())
+    )
+    expect_identical(
         as.list(tokens_select(toks, "*", startpos = c(1, 2, 2), endpos = c(3, 2, 1))),
         list(doc1 = c("a", "b", "c"),
              doc2 = c("b"),
@@ -586,6 +592,12 @@ test_that("position arguments are working", {
         list(doc1 = c("d", "e"),
              doc2 = c("a"),
              doc3 = character())
+    )
+    expect_identical(
+        as.list(tokens_remove(toks, "*", startpos = c(2), endpos = c(3, 2, 1))),
+        list(doc1 = c("a", "d", "e"),
+             doc2 = c("a", "c"),
+             doc3 = c("a"))
     )
     expect_identical(
         as.list(tokens_remove(toks, "*", startpos = c(1, 2, 2), endpos = c(3, 2, 1))),

--- a/tests/testthat/test-tokens_select.R
+++ b/tests/testthat/test-tokens_select.R
@@ -560,7 +560,7 @@ test_that("position arguments are working", {
     expect_identical(
         as.list(tokens_select(toks, "*", startpos = c(1, 2), endpos = c(3))),
         list(doc1 = c("a", "b", "c"),
-             doc2 = c("a", "b", "c"),
+             doc2 = c("b", "c"),
              doc3 = c("a"))
     )
     expect_identical(
@@ -584,7 +584,7 @@ test_that("position arguments are working", {
     expect_identical(
         as.list(tokens_remove(toks, "*", startpos = c(1, 2), endpos = c(3))),
         list(doc1 = c("d", "e"),
-             doc2 = character(),
+             doc2 = c("a"),
              doc3 = character())
     )
     expect_identical(


### PR DESCRIPTION
Fix a bug in ` tokens_select()`: only the first element is used when either `startpos` or `endpos` is a one-element vector.