### PR TITLE
Set NULL to dimnanes in C++

### DIFF
--- a/inst/include/lib.h
+++ b/inst/include/lib.h
@@ -164,6 +164,7 @@ namespace quanteda{
         
         std::size_t l = tri.size();
         IntegerVector dim_ = IntegerVector::create(nrow, ncol);
+        List dimnames_ = List::create(R_NilValue, R_NilValue);
         IntegerVector i_(l), j_(l);
         NumericVector x_(l);
         
@@ -178,6 +179,7 @@ namespace quanteda{
             simil_.slot("j") = j_;
             simil_.slot("x") = x_;
             simil_.slot("Dim") = dim_;
+            simil_.slot("Dimnames") = dimnames_;
             simil_.slot("uplo") = "U";
             return simil_;
         } else {
@@ -186,6 +188,7 @@ namespace quanteda{
             simil_.slot("j") = j_;
             simil_.slot("x") = x_;
             simil_.slot("Dim") = dim_;
+            simil_.slot("Dimnames") = dimnames_;
             return simil_;
         }
     }


### PR DESCRIPTION
The segfault error below has disappeared from LSX test results soon after notification by the CRAN team.

```
 *** caught segfault ***
address (nil), cause 'unknown'
Error in qatd_cpp_fcm(x, length(type), weights, boolean, ordered) : 
  value of 'SET_ATTRIB' must be a pairlist or NULL, not a 'symbol'
Calls: fcm -> fcm.tokens -> qatd_cpp_fcm
Execution halted

 *** caught segfault ***
address (nil), cause 'unknown'
Error: no more error handlers available (recursive errors?); invoking 'abort' restart
* checking for unstated dependencies in ‘tests’ ... OK
* checking tests ...
  Running ‘testthat.R’ [128s/126s]
```

I suspect that it is related to how sparse matrices are created in C++ for `fcm()`. This is where the error is raised by [base R](http://mtweb.cs.ucl.ac.uk/mus/bin/install_R/R-3.1.1/src/main/memory.c).

```r
void (SET_ATTRIB)(SEXP x, SEXP v) {
    if(TYPEOF(v) != LISTSXP && TYPEOF(v) != NILSXP)
	error("value of 'SET_ATTRIB' must be a pairlist or NULL, not a '%s'",
	      type2char(TYPEOF(x)));
    FIX_REFCNT(x, ATTRIB(x), v);
    CHECK_OLD_TO_NEW(x, v);
    ATTRIB(x) = v;
}
```
So, I assigned NULL to dimnames manually to make the S4 objects more valid.