### PR TITLE
Fixes for deprecated Matrix calls and for forthcoming Matrix 1.4-2

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: macOS-latest,   r: 'release'}
+#          - {os: macOS-latest,   r: 'release'}
           - {os: windows-latest, r: 'release'}
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'release'}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: quanteda
-Version: 3.2.2
+Version: 3.2.3
 Title: Quantitative Analysis of Textual Data
 Description: A fast, flexible, and comprehensive framework for 
     quantitative text analysis in R.  Provides functionality for corpus management,
@@ -69,7 +69,7 @@ BugReports: https://github.com/quanteda/quanteda/issues
 LazyData: TRUE
 VignetteBuilder: knitr
 Language: en-GB
-RoxygenNote: 7.2.0
+RoxygenNote: 7.2.1
 SystemRequirements: C++11
 Roxygen: list(markdown = TRUE)
 Collate: 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# quanteda 3.2.3
+
+## Bug fixes and stability enhancements
+
+* **Matrix** package calls updated for compatibility with **Matrix** 1.4.2. (#2182)
+* Changes to C++ code for `fcm()` to prevent some (chance) errors downstream in **LSX**. (#2181)
+
 # quanteda 3.2.2
 
 ## Bug fixes and stability enhancements

--- a/R/convert.R
+++ b/R/convert.R
@@ -205,7 +205,7 @@ NULL
 
 #' @rdname convert-wrappers
 dfm2austin <- function(x) {
-    result <- as.matrix(as(x, "unpackedMatrix"))
+    result <- as.matrix(as(x, "dMatrix"))
     names(dimnames(result))[2] <- "words"
     class(result) <- c("wfm", "matrix")
     return(result)

--- a/R/convert.R
+++ b/R/convert.R
@@ -205,7 +205,7 @@ NULL
 
 #' @rdname convert-wrappers
 dfm2austin <- function(x) {
-    result <- as.matrix(as(x, "dgeMatrix"))
+    result <- as.matrix(as(x, "unpackedMatrix"))
     names(dimnames(result))[2] <- "words"
     class(result) <- c("wfm", "matrix")
     return(result)
@@ -302,7 +302,7 @@ dfm2dtm <- function(x, omit_empty = TRUE) {
         stop("You must install the slam package for this conversion.")
 
     x <- as.dfm(x)
-    x <- as(x, "dgTMatrix")
+    x <- as(x, "TsparseMatrix")
     if (omit_empty)
         x <- x[rowSums(x) > 0, ]
     tm::as.DocumentTermMatrix(slam::as.simple_triplet_matrix(x), tm::weightTf)
@@ -336,7 +336,7 @@ dfm2stm <- function(x, docvars = NULL, omit_empty = TRUE) {
     }
 
     # convert counts to STM documents format
-    x <- as(x, "dgTMatrix")
+    x <- as(x, "TsparseMatrix")
     docs <- ijv.to.doc(x@i + 1, x@j + 1, x@x)
     names(docs) <- rownames(x)
     list(documents = docs, vocab = colnames(x), meta = docvars)
@@ -373,7 +373,7 @@ dfm2lsa <- function(x) {
 dfm2tripletlist <- function(x) {
     feat <- featnames(x)
     doc <- docnames(x)
-    x <- as(x, "dgTMatrix")
+    x <- as(x, "TsparseMatrix")
     list(
         document = doc[x@i + 1],
         feature = feat[x@j + 1],

--- a/R/dfm-classes.R
+++ b/R/dfm-classes.R
@@ -80,8 +80,8 @@ setMethod("rowMeans",
           signature = (x = "dfm"),
           function(x, ...) Matrix::rowMeans(as(x, "dgCMatrix"), ...))
 
-#' @param e1 first quantity in "+" operation for dfm
-#' @param e2 second quantity in "+" operation for dfm
+#' @param e1 first quantity in an \link[methods:S4groupGeneric]{Arith} operation for dfm
+#' @param e2 second quantity in an \link[methods:S4groupGeneric]{Arith} operation for dfm
 #' @rdname dfm-class
 setMethod("Arith", signature(e1 = "dfm", e2 = "numeric"),
           function(e1, e2) {
@@ -104,7 +104,6 @@ setMethod("Arith", signature(e1 = "numeric", e2 = "dfm"),
                      `^` = matrix2dfm(e1 ^ as(e2, "dgCMatrix"), e2@docvars, e2@meta)
               )
           })
-
 
 #' Coerce a dfm to a matrix or data.frame
 #'

--- a/R/dfm-methods.R
+++ b/R/dfm-methods.R
@@ -144,7 +144,8 @@ matrix2dfm <- function(x, docvars = NULL, meta = NULL) {
     
     if (nrow(x) == 0 && ncol(x) == 0) {
         # avoid coercion to ldiMatrix
-        x <- as(as(as(matrix(nrow = 0, ncol = 0), "dMatrix"), "generalMatrix"), "unpackedMatrix")
+        x <- Matrix(x, sparse = TRUE)
+        x <- as(as(as(x, "CsparseMatrix"), "generalMatrix"), "dMatrix")
     } else {
         x <- Matrix(x, sparse = TRUE)
     }

--- a/R/dfm-methods.R
+++ b/R/dfm-methods.R
@@ -285,12 +285,12 @@ NULL
 
 #' The `Compare` methods enable relational operators to be use with dfm.
 #' Relational operations on a dfm with a numeric will return a
-#' [dgCMatrix-class][Matrix::dgCMatrix-class] object.
+#' [lgCMatrix-class][Matrix::lgCMatrix-class] object.
 #' @rdname dfm-internal
 #' @param e1 a [dfm]
 #' @param e2 a numeric value to compare with values in a dfm
 #' @export
 #' @seealso [Comparison] operators
 setMethod("Compare", c("dfm", "numeric"), function(e1, e2) {
-    as(callGeneric(as(as(as(e1, "CsparseMatrix"), "generalMatrix"), "dMatrix"), e2), "CsparseMatrix")
+    as(callGeneric(as(e1, "CsparseMatrix"), e2), "CsparseMatrix")
 })

--- a/R/dfm-methods.R
+++ b/R/dfm-methods.R
@@ -143,9 +143,7 @@ matrix2dfm <- function(x, docvars = NULL, meta = NULL) {
         meta <- make_meta("dfm")
     
     if (nrow(x) == 0 && ncol(x) == 0) {
-        # avoid coercion to ldiMatrix
-        x <- Matrix(x, sparse = TRUE)
-        x <- as(as(as(x, "CsparseMatrix"), "generalMatrix"), "dMatrix")
+        x <- make_null_dfm()
     } else {
         x <- Matrix(x, sparse = TRUE)
     }

--- a/R/dfm-methods.R
+++ b/R/dfm-methods.R
@@ -293,5 +293,5 @@ NULL
 #' @export
 #' @seealso [Comparison] operators
 setMethod("Compare", c("dfm", "numeric"), function(e1, e2) {
-    as(callGeneric(as(e1, "dgCMatrix"), e2), "lgCMatrix")
+    as(callGeneric(as(as(as(e1, "CsparseMatrix"), "generalMatrix"), "dMatrix"), e2), "CsparseMatrix")
 })

--- a/R/dfm-methods.R
+++ b/R/dfm-methods.R
@@ -144,13 +144,13 @@ matrix2dfm <- function(x, docvars = NULL, meta = NULL) {
     
     if (nrow(x) == 0 && ncol(x) == 0) {
         # avoid coercion to ldiMatrix
-        x <- as(matrix(nrow = 0, ncol = 0), "dgeMatrix")
+        x <- as(as(as(matrix(nrow = 0, ncol = 0), "dMatrix"), "generalMatrix"), "unpackedMatrix")
     } else {
         x <- Matrix(x, sparse = TRUE)
     }
     
     build_dfm(
-        as(x, "dgCMatrix"),
+        as(as(as(x, "CsparseMatrix"), "generalMatrix"), "dMatrix"),
         featname,
         docvars = docvars,
         meta = meta

--- a/R/dfm.R
+++ b/R/dfm.R
@@ -34,7 +34,8 @@
 #'     tokens_remove("b", padding = TRUE)
 #' toks
 #' dfm(toks)
-#' dfm(toks, remove = "") # remove "pads"
+#' dfm(toks) %>%
+#'  dfm_remove(pattern = "") # remove "pads"
 #'
 #' # preserving case
 #' dfm(toks, tolower = FALSE)
@@ -383,7 +384,9 @@ make_null_dfm <- function(feature = NULL, document = NULL) {
         i = NULL,
         j = NULL,
         dims = c(length(document), length(feature))
-    ), "dgCMatrix")
+    ), "CsparseMatrix") %>%
+        as("generalMatrix") %>%
+        as("dMatrix")
 
     build_dfm(temp, feature,
               docvars = make_docvars(length(document), document))

--- a/R/dfm.R
+++ b/R/dfm.R
@@ -380,13 +380,11 @@ dfm.dfm <- function(x,
 make_null_dfm <- function(feature = NULL, document = NULL) {
     if (is.null(feature)) feature <- character()
     if (is.null(document)) document <- character()
-    temp <- as(sparseMatrix(
+    temp <- as(as(as(sparseMatrix(
         i = NULL,
         j = NULL,
         dims = c(length(document), length(feature))
-    ), "CsparseMatrix") %>%
-        as("generalMatrix") %>%
-        as("dMatrix")
+    ), "CsparseMatrix"), "generalMatrix"), "dMatrix")
 
     build_dfm(temp, feature,
               docvars = make_docvars(length(document), document))

--- a/R/dfm_group.R
+++ b/R/dfm_group.R
@@ -98,7 +98,7 @@ group_matrix <- function(x, documents = NULL, features = NULL, fill = FALSE) {
     if (!length(features) && !length(documents))
         return(x)
     attrs <- attributes(x)
-    x <- as(x, "dgTMatrix")
+    x <- as(x, "TsparseMatrix")
     if (is.null(features)) {
         featname <- x@Dimnames[[2]]
         j <- x@j + 1L

--- a/R/dfm_weight.R
+++ b/R/dfm_weight.R
@@ -413,7 +413,7 @@ dfm_tfidf.dfm <- function(x, scheme_tf = "count", scheme_df = "inverse",
 
     x <- dfm_weight(x, scheme = scheme_tf, base = base, force = force)
     v <- docfreq(x, scheme = scheme_df, base = base, ...)
-    j <- as(x, "dgTMatrix")@j + 1L
+    j <- as(x, "TsparseMatrix")@j + 1L
     x@x <- x@x * v[j]
     attrs <- attributes(x)
     field_object(attrs, "weight_df") <- c(

--- a/R/fcm-methods.R
+++ b/R/fcm-methods.R
@@ -72,7 +72,7 @@ fcm_sort.default <- function(x) {
 fcm_sort.fcm <- function(x) {
     x <- as.fcm(x)
     attrs <- attributes(x)
-    x <- as(x, "dgTMatrix")
+    x <- as(x, "TsparseMatrix")
     x <- x[order(rownames(x)), order(colnames(x))]
     if (field_object(attrs, "tri")) {
         swap <- x@i > x@j
@@ -142,7 +142,7 @@ matrix2fcm <- function(x, meta = NULL) {
     if (is.null(meta))
         meta <- make_meta("fcm")
     
-    build_fcm(as(Matrix(x, sparse = TRUE), "dgCMatrix"),
+    build_fcm(as(as(Matrix(x, sparse = TRUE), "generalMatrix"), "dMatrix"),
               rowname, colname,
               meta = meta)
 }

--- a/R/fcm-methods.R
+++ b/R/fcm-methods.R
@@ -6,11 +6,11 @@
 #' @export
 #' @examples
 #' # compress an fcm
-#' fcmat1 <- fcm(tokens("A D a C E a d F e B A C E D"), 
+#' fcmat1 <- fcm(tokens("A D a C E a d F e B A C E D"),
 #'              context = "window", window = 3)
 #' ## this will produce an error:
 #' # fcm_compress(fcmat1)
-#' 
+#'
 #' txt <- c("The fox JUMPED over the dog.",
 #'          "The dog jumped over the fox.")
 #' toks <- tokens(txt, remove_punct = TRUE)
@@ -38,11 +38,11 @@ fcm_compress.fcm <- function(x) {
 }
 
 #' Sort an fcm in alphabetical order of the features
-#' 
+#'
 #' Sorts an [fcm] in alphabetical order of the features.
-#' 
+#'
 #' @param x [fcm] object
-#' @return A [fcm] object whose features have been alphabetically sorted. 
+#' @return A [fcm] object whose features have been alphabetically sorted.
 #'   Differs from [fcm_sort()] in that this function sorts the fcm by
 #'   the feature labels, not the counts of the features.
 #' @export
@@ -53,14 +53,14 @@ fcm_compress.fcm <- function(x) {
 #' rownames(fcmat1)[3] <- colnames(fcmat1)[3] <- "Z"
 #' fcmat1
 #' fcm_sort(fcmat1)
-#' 
+#'
 #' # with tri = TRUE
 #' fcmat2 <- fcm(tokens(c("A X Y C B A", "X Y C A B B")), tri = TRUE)
 #' rownames(fcmat2)[3] <- colnames(fcmat2)[3] <- "Z"
 #' fcmat2
 #' fcm_sort(fcmat2)
 fcm_sort <- function(x) {
-    UseMethod("fcm_sort")    
+    UseMethod("fcm_sort")
 }
 
 #' @export
@@ -84,7 +84,7 @@ fcm_sort.fcm <- function(x) {
 }
 
 #' Coercion and checking functions for fcm objects
-#' 
+#'
 #' Convert an eligible input object into a fcm, or check whether an object is a
 #' fcm.  Current eligible inputs for coercion to a dfm are: [matrix],
 #' (sparse) [Matrix][Matrix::Matrix] and other [fcm] objects.
@@ -130,19 +130,16 @@ as.fcm.Matrix <- function(x) {
 #' @param slots slots a list of values to be assigned to slots
 #' @keywords internal
 matrix2fcm <- function(x, meta = NULL) {
-    
     rowname <- rownames(x)
     if (nrow(x) > length(rowname))
         rowname <- paste0(quanteda_options("base_featname"), seq_len(nrow(x)))
-    
+
     colname <- colnames(x)
     if (ncol(x) > length(colname))
         colname <- paste0(quanteda_options("base_featname"), seq_len(ncol(x)))
-    
+
     if (is.null(meta))
         meta <- make_meta("fcm")
-    
-    build_fcm(as(as(Matrix(x, sparse = TRUE), "generalMatrix"), "dMatrix"),
-              rowname, colname,
-              meta = meta)
+
+    build_fcm(x, rowname, colname, meta = meta)
 }

--- a/R/fcm.R
+++ b/R/fcm.R
@@ -176,7 +176,7 @@ fcm.dfm <- function(x, context = c("document", "window"),
         temp <- Matrix::triu(temp)
 
     result <- build_fcm(
-        as(temp, "CsparseMatrix"),
+        temp,
         featnames(x),
         count = count, context = context, margin = featfreq(x),
         weights = 1, tri = tri,
@@ -232,7 +232,7 @@ fcm.tokens <- function(x, context = c("document", "window"),
             }
         }
         result <- build_fcm(
-            as(temp, "CsparseMatrix"),
+            temp,
             type,
             count = count, context = context, margin = featfreq(dfm(x, tolower = FALSE)),
             weights = weights, ordered = ordered, tri = tri,

--- a/R/fcm.R
+++ b/R/fcm.R
@@ -144,7 +144,8 @@ fcm.dfm <- function(x, context = c("document", "window"),
     attrs <- attributes(x)
     if (!nfeat(x)) {
         result <- build_fcm(
-            as(make_null_dfm(), "dgCMatrix"), featnames(x), 
+            make_null_dfm(),
+            featnames(x), 
             count = count, context = context, margin = featfreq(x), 
             weights = 1, tri = tri,
             meta = attrs[["meta"]])
@@ -175,7 +176,8 @@ fcm.dfm <- function(x, context = c("document", "window"),
         temp <- Matrix::triu(temp)
 
     result <- build_fcm(
-        as(temp, "dgCMatrix"), featnames(x), 
+        as(as(temp, "generalMatrix"), "dMatrix"),
+        featnames(x), 
         count = count, context = context, margin = featfreq(x), 
         weights = 1, tri = tri,
         meta = attrs[["meta"]])
@@ -221,7 +223,7 @@ fcm.tokens <- function(x, context = c("document", "window"),
         type <- types(x)
         boolean <- count == "boolean"
         temp <- qatd_cpp_fcm(x, length(type), weights, boolean, ordered)
-        temp <- as(temp, "dgCMatrix")
+        temp <- as(as(as(temp, "CsparseMatrix"), "generalMatrix"), "dMatrix")
         if (!ordered) {
             if (tri) {
                 temp <- Matrix::triu(temp)
@@ -230,7 +232,8 @@ fcm.tokens <- function(x, context = c("document", "window"),
             }
         }
         result <- build_fcm(
-            as(temp, "dgCMatrix"), type,
+            as(as(as(temp, "CsparseMatrix"), "generalMatrix"), "dMatrix"), 
+            type,
             count = count, context = context, margin = featfreq(dfm(x, tolower = FALSE)), 
             weights = weights, ordered = ordered, tri = tri, 
             meta = attrs[["meta"]])

--- a/R/fcm.R
+++ b/R/fcm.R
@@ -63,18 +63,18 @@
 #'
 #'   `is.fcm(x)` returns `TRUE` if and only if its x is an object of
 #'   type [fcm].
-#' @references 
+#' @references
 #'   Momtazi, S., Khudanpur, S., & Klakow, D. (2010). "[A comparative study of
 #'   word co-occurrence for term clustering in language model-based sentence
 #'   retrieval.](https://aclanthology.org/N10-1046/)" *Human Language
 #'   Technologies: The 2010 Annual Conference of the North American Chapter of
 #'   the ACL*, Los Angeles, California, June 2010, 325-328.
-#'   
+#'
 #'   Jurafsky, D. & Martin, J.H. (2018). From *Speech and Language Processing:
 #'   An Introduction to Natural Language Processing, Computational Linguistics,
 #'   and Speech Recognition*. Draft of September 23, 2018 (Chapter 6, Vector
 #'   Semantics). Available at <https://web.stanford.edu/~jurafsky/slp3/>.
-#'   
+#'
 #'  Church, K. W. & P. Hanks (1990). [Word association norms, mutual
 #'  information, and lexicography](https://dl.acm.org/doi/10.5555/89086.89095).
 #'  *Computational Linguistics*, 16(1), 22-29.
@@ -133,29 +133,29 @@ fcm.dfm <- function(x, context = c("document", "window"),
                        weights = NULL,
                        ordered = FALSE,
                        tri = TRUE, ...) {
-    
+
     x <- as.dfm(x)
     context <- match.arg(context)
     count <- match.arg(count)
     window <- check_integer(window, min = 1)
     ordered <- check_logical(ordered)
     tri <- check_logical(tri)
-    
+
     attrs <- attributes(x)
     if (!nfeat(x)) {
         result <- build_fcm(
             make_null_dfm(),
-            featnames(x), 
-            count = count, context = context, margin = featfreq(x), 
+            featnames(x),
+            count = count, context = context, margin = featfreq(x),
             weights = 1, tri = tri,
             meta = attrs[["meta"]])
-        
+
         return(result)
     }
 
     if (context != "document")
         stop("fcm.dfm only works on context = \"document\"")
-    
+
     if (count == "weighted")
         stop("Cannot have weighted counts with context = \"document\"")
     if (count == "boolean") {
@@ -165,23 +165,23 @@ fcm.dfm <- function(x, context = c("document", "window"),
         m <- Matrix::colSums(x)
     }
     temp <- Matrix::crossprod(x)
-    
-    # correct self-cooccuerrace
+
+    # correct self-co-occurrence
     if (count == "boolean") {
         Matrix::diag(temp) <- m
     } else {
-        Matrix::diag(temp) <- (Matrix::diag(temp) - m) / 2    
+        Matrix::diag(temp) <- (Matrix::diag(temp) - m) / 2
     }
-    if (tri) 
+    if (tri)
         temp <- Matrix::triu(temp)
 
     result <- build_fcm(
-        as(as(temp, "generalMatrix"), "dMatrix"),
-        featnames(x), 
-        count = count, context = context, margin = featfreq(x), 
+        as(temp, "CsparseMatrix"),
+        featnames(x),
+        count = count, context = context, margin = featfreq(x),
         weights = 1, tri = tri,
         meta = attrs[["meta"]])
-    
+
     return(result)
 }
 
@@ -202,7 +202,7 @@ fcm.tokens <- function(x, context = c("document", "window"),
     window <- check_integer(window, min = 1)
     ordered <- check_logical(ordered)
     tri <- check_logical(tri)
-    
+
     attrs <- attributes(x)
     if (ordered)
         tri <- FALSE
@@ -223,7 +223,7 @@ fcm.tokens <- function(x, context = c("document", "window"),
         type <- types(x)
         boolean <- count == "boolean"
         temp <- qatd_cpp_fcm(x, length(type), weights, boolean, ordered)
-        temp <- as(as(as(temp, "CsparseMatrix"), "generalMatrix"), "dMatrix")
+        temp <- as(temp, "CsparseMatrix")
         if (!ordered) {
             if (tri) {
                 temp <- Matrix::triu(temp)
@@ -232,10 +232,10 @@ fcm.tokens <- function(x, context = c("document", "window"),
             }
         }
         result <- build_fcm(
-            as(as(as(temp, "CsparseMatrix"), "generalMatrix"), "dMatrix"), 
+            as(temp, "CsparseMatrix"),
             type,
-            count = count, context = context, margin = featfreq(dfm(x, tolower = FALSE)), 
-            weights = weights, ordered = ordered, tri = tri, 
+            count = count, context = context, margin = featfreq(dfm(x, tolower = FALSE)),
+            weights = weights, ordered = ordered, tri = tri,
             meta = attrs[["meta"]])
     }
     return(result)

--- a/R/object-builder.R
+++ b/R/object-builder.R
@@ -27,9 +27,9 @@ build_dfm <- function(x, features,
                       docvars = data.frame(), meta = list(), 
                       class = "dfm", ...) {
     result <- new(class,
-        as(x, "dgCMatrix"),
-        docvars = docvars,
-        meta = make_meta("dfm", inherit = meta, ...)
+                  as(as(as(x, "CsparseMatrix"), "generalMatrix"), "dMatrix"),
+                  docvars = docvars,
+                  meta = make_meta("dfm", inherit = meta, ...)
     )
     # set names directly to avoid NULL
     result@Dimnames <- list(
@@ -250,7 +250,7 @@ build_fcm <- function(x, features1, features2 = NULL,
                       meta = list(), 
                       class = "fcm", ...) {
     result <- new(class,
-                  as(x, "dgCMatrix"),
+                  as(as(as(x, "CsparseMatrix"), "generalMatrix"), "dMatrix"),
                   meta = make_meta("fcm", inherit = meta, ...)
     )
     # set names directly to avoid NULL

--- a/R/object-builder.R
+++ b/R/object-builder.R
@@ -27,7 +27,7 @@ build_dfm <- function(x, features,
                       docvars = data.frame(), meta = list(), 
                       class = "dfm", ...) {
     result <- new(class,
-                  as(as(as(x, "CsparseMatrix"), "generalMatrix"), "dMatrix"),
+                  as(x, "CsparseMatrix"),
                   docvars = docvars,
                   meta = make_meta("dfm", inherit = meta, ...)
     )

--- a/R/object-builder.R
+++ b/R/object-builder.R
@@ -27,7 +27,7 @@ build_dfm <- function(x, features,
                       docvars = data.frame(), meta = list(), 
                       class = "dfm", ...) {
     result <- new(class,
-                  as(x, "CsparseMatrix"),
+                  as(as(as(x, "CsparseMatrix"), "generalMatrix"), "dMatrix"),
                   docvars = docvars,
                   meta = make_meta("dfm", inherit = meta, ...)
     )

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,6 +1,7 @@
 # Submission notes
 
-Minor updates to v3.2.1 consisting of bug fixes and minor feature additions.
+Changes to Matrix package coercions required to avoid warnings in forthcoming
+Matrix 1.4-2 release.
 
 ## Test environments
 

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -23,6 +23,7 @@ Khudanpur
 Klakow
 LBG
 LIWC
+LSX
 Lexicoder
 MATTR
 MSTTR

--- a/man/dfm-class.Rd
+++ b/man/dfm-class.Rd
@@ -60,9 +60,9 @@ the calculations}
 
 \item{...}{additional arguments not used here}
 
-\item{e1}{first quantity in "+" operation for dfm}
+\item{e1}{first quantity in an \link[methods:S4groupGeneric]{Arith} operation for dfm}
 
-\item{e2}{second quantity in "+" operation for dfm}
+\item{e2}{second quantity in an \link[methods:S4groupGeneric]{Arith} operation for dfm}
 
 \item{i}{document names or indices for documents to extract.}
 

--- a/man/dfm.Rd
+++ b/man/dfm.Rd
@@ -54,7 +54,8 @@ toks <- tokens(c("a b c", "A B C D")) \%>\%
     tokens_remove("b", padding = TRUE)
 toks
 dfm(toks)
-dfm(toks, remove = "") # remove "pads"
+dfm(toks) \%>\%
+ dfm_remove(pattern = "") # remove "pads"
 
 # preserving case
 dfm(toks, tolower = FALSE)

--- a/man/dfm_compress.Rd
+++ b/man/dfm_compress.Rd
@@ -53,7 +53,7 @@ dim(dfmatsubset)
 dim(dfm_compress(dfmatsubset))
 
 # compress an fcm
-fcmat1 <- fcm(tokens("A D a C E a d F e B A C E D"), 
+fcmat1 <- fcm(tokens("A D a C E a d F e B A C E D"),
              context = "window", window = 3)
 ## this will produce an error:
 # fcm_compress(fcmat1)

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -4,7 +4,7 @@ Sys.setenv("_R_CHECK_LENGTH_1_CONDITION_" = TRUE)
 library(testthat)
 library(quanteda)
 
-# for strong texts for Matrix deprecations
+# for strong tests for Matrix deprecations
 options(Matrix.warnDeprecatedCoerce = 2)
 
 ops <- quanteda_options()

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -4,6 +4,9 @@ Sys.setenv("_R_CHECK_LENGTH_1_CONDITION_" = TRUE)
 library(testthat)
 library(quanteda)
 
+# for strong texts for Matrix deprecations
+options(Matrix.warnDeprecatedCoerce = 2)
+
 ops <- quanteda_options()
 quanteda_options(reset = TRUE)
 test_check("quanteda")

--- a/tests/testthat/test-fcm_methods.R
+++ b/tests/testthat/test-fcm_methods.R
@@ -184,10 +184,10 @@ test_that("as.fcm is working", {
                  nrow = 5, ncol = 5, byrow = TRUE)
 
     expect_true(is.fcm(as.fcm(mt1)))
-    expect_true(is.fcm(as.fcm(as(as(as(mt1, "dMatrix"), "triangularMatrix"), "CsparseMatrix") )))
+    expect_true(is.fcm(as.fcm(as(as(mt1, "CsparseMatrix"), "triangularMatrix"))))
     expect_true(is.fcm(as.fcm(as(mt1, "dgCMatrix"))))
-    expect_true(is.fcm(as.fcm(as(as(as(mt1, "dMatrix"), "generalMatrix"), "TsparseMatrix") )))
-    expect_true(is.fcm(as.fcm(as(as(as(mt1, "dMatrix"), "generalMatrix"), "unpackedMatrix") )))
+    expect_true(is.fcm(as.fcm(as(mt1, "TsparseMatrix"))))
+    expect_true(is.fcm(as.fcm(Matrix(mt1, sparse = FALSE))))
 
     mt2 <- matrix(c(1, 3, 1, 2, 2,
                     0, 1, 2, 0, 1,
@@ -199,7 +199,6 @@ test_that("as.fcm is working", {
 
     expect_error(as.fcm(mt2),
                 "matrix must have the same rownames and colnames")
-    expect_error(as.fcm(as(as(as(mt2, "dMatrix"), "generalMatrix"), "unpackedMatrix")),
+    expect_error(as.fcm(Matrix(mt2, sparse = FALSE)),
                 "matrix must have the same rownames and colnames")
-
 })

--- a/tests/testthat/test-fcm_methods.R
+++ b/tests/testthat/test-fcm_methods.R
@@ -2,33 +2,33 @@ toks_test <- tokens(c("b A A d", "C C a b B e"))
 fcmt_test <- fcm(toks_test, context = "document")
 
 test_that("fcm_compress works as expected, not working for 'window' context", {
-    fcmt <- fcm(toks_test, 
+    fcmt <- fcm(toks_test,
                 context = "window", window = 3)
-    expect_error(fcm_compress(fcmt), 
+    expect_error(fcm_compress(fcmt),
                  "fcm must be created with a document context")
 })
 
 test_that("fcm_tolower and fcm_compress work as expected", {
     fcmt_lc <- fcm_tolower(fcmt_test)
-    expect_equivalent(rownames(fcmt_lc), 
+    expect_equivalent(rownames(fcmt_lc),
                       c("b", "a", "d", "c", "e"))
-    mt <- matrix(c(1, 3, 1, 2, 2, 
-                     0, 1, 2, 0, 1, 
-                     0, 0, 0, 0, 0, 
-                     0, 0, 0, 1, 2, 
+    mt <- matrix(c(1, 3, 1, 2, 2,
+                     0, 1, 2, 0, 1,
+                     0, 0, 0, 0, 0,
+                     0, 0, 0, 1, 2,
                      0, 0, 0, 0, 0),
                    nrow = 5, ncol = 5, byrow = TRUE)
     expect_true(all(as.vector(Matrix::triu(fcmt_lc)) == as.vector(mt)))
 })
 
-test_that("fcm_toupper and fcm_compress work as expected",{
+test_that("fcm_toupper and fcm_compress work as expected", {
     fcmt_uc <- fcm_toupper(fcmt_test)
-    expect_equivalent(rownames(fcmt_uc), 
+    expect_equivalent(rownames(fcmt_uc),
                       c("B", "A", "D", "C", "E"))
-    mt <- matrix(c(1, 3, 1, 2, 2, 
-                     0, 1, 2, 0, 1, 
-                     0, 0, 0, 0, 0, 
-                     0, 0, 0, 1, 2, 
+    mt <- matrix(c(1, 3, 1, 2, 2,
+                     0, 1, 2, 0, 1,
+                     0, 0, 0, 0, 0,
+                     0, 0, 0, 1, 2,
                      0, 0, 0, 0, 0),
                    nrow = 5, ncol = 5, byrow = TRUE)
     expect_true(all(as.vector(Matrix::triu(fcmt_uc)) == as.vector(mt)))
@@ -46,15 +46,18 @@ test_that("test fcm_select, fixed", {
         c("a", "B", "c")
     )
     expect_equal(
-        featnames(fcm_select(fcmt_test2, c("a", "b", "c"), selection = "remove", valuetype = "fixed", verbose = FALSE)),
+        featnames(fcm_select(fcmt_test2, c("a", "b", "c"), selection = "remove",
+                             valuetype = "fixed", verbose = FALSE)),
         setdiff(featnames(fcmt_test2), c("a", "B", "c"))
     )
     expect_equal(
-        featnames(fcm_select(fcmt_test2, c("a", "b", "c"), selection = "keep", valuetype = "fixed", case_insensitive = FALSE, verbose = FALSE)),
+        featnames(fcm_select(fcmt_test2, c("a", "b", "c"), selection = "keep",
+                             valuetype = "fixed", case_insensitive = FALSE, verbose = FALSE)),
         c("a", "c")
     )
     expect_equal(
-        featnames(fcm_select(fcmt_test2, c("a", "b", "c"), selection = "remove", valuetype = "fixed", case_insensitive = FALSE, verbose = FALSE)),
+        featnames(fcm_select(fcmt_test2, c("a", "b", "c"), selection = "remove",
+                             valuetype = "fixed", case_insensitive = FALSE, verbose = FALSE)),
         setdiff(featnames(fcmt_test2), c("a", "c"))
     )
 #     expect_equal(
@@ -128,8 +131,8 @@ test_that("glob works if results in no features", {
 })
 
 test_that("longer selection than longer than features that exist (related to #447)", {
-    fcmt_test2 <- fcm(tokens(c(d1 = 'a b', d2 = 'a b c d e')))
-    feat <- c('b', 'c', 'd', 'e', 'f', 'g')
+    fcmt_test2 <- fcm(tokens(c(d1 = "a b", d2 = "a b c d e")))
+    feat <- c("b", "c", "d", "e", "f", "g")
     # bugs in C++ needs repeated tests
     expect_message(fcm_select(fcmt_test2, feat, verbose = TRUE),
                    "kept 4 features")
@@ -161,42 +164,42 @@ test_that("test fcm_compress retains class", {
 
 test_that("shortcut functions works", {
     fcmt_test2 <- fcm(tokens(data_corpus_inaugural[1:5]))
-    expect_equal(fcm_select(fcmt_test2, stopwords('english'), selection = 'keep'),
-                 fcm_keep(fcmt_test2, stopwords('english')))
-    expect_equal(fcm_select(fcmt_test2, stopwords('english'), selection = 'remove'),
-                 fcm_remove(fcmt_test2, stopwords('english')))
+    expect_equal(fcm_select(fcmt_test2, stopwords("english"), selection = "keep"),
+                 fcm_keep(fcmt_test2, stopwords("english")))
+    expect_equal(fcm_select(fcmt_test2, stopwords("english"), selection = "remove"),
+                 fcm_remove(fcmt_test2, stopwords("english")))
 })
 
 test_that("as.fcm is working", {
-    
+
     feat1 <- c("B", "A", "D", "C", "E")
     feat2 <- c("Z", "X", "N", "M", "K")
-    
-    mt1 <- matrix(c(1, 3, 1, 2, 2, 
-                   0, 1, 2, 0, 1, 
-                   0, 0, 0, 0, 0, 
-                   0, 0, 0, 1, 2, 
+
+    mt1 <- matrix(c(1, 3, 1, 2, 2,
+                   0, 1, 2, 0, 1,
+                   0, 0, 0, 0, 0,
+                   0, 0, 0, 1, 2,
                    0, 0, 0, 0, 0),
                  dimnames = list(feat1, feat1),
                  nrow = 5, ncol = 5, byrow = TRUE)
-    
+
     expect_true(is.fcm(as.fcm(mt1)))
-    expect_true(is.fcm(as.fcm(as(mt1, "dtCMatrix"))))
+    expect_true(is.fcm(as.fcm(as(as(as(mt1, "dMatrix"), "triangularMatrix"), "CsparseMatrix") )))
     expect_true(is.fcm(as.fcm(as(mt1, "dgCMatrix"))))
-    expect_true(is.fcm(as.fcm(as(mt1, "dgTMatrix"))))
-    expect_true(is.fcm(as.fcm(as(mt1, "dgeMatrix"))))
-    
-    mt2 <- matrix(c(1, 3, 1, 2, 2, 
-                    0, 1, 2, 0, 1, 
-                    0, 0, 0, 0, 0, 
-                    0, 0, 0, 1, 2, 
+    expect_true(is.fcm(as.fcm(as(as(as(mt1, "dMatrix"), "generalMatrix"), "TsparseMatrix") )))
+    expect_true(is.fcm(as.fcm(as(as(as(mt1, "dMatrix"), "generalMatrix"), "unpackedMatrix") )))
+
+    mt2 <- matrix(c(1, 3, 1, 2, 2,
+                    0, 1, 2, 0, 1,
+                    0, 0, 0, 0, 0,
+                    0, 0, 0, 1, 2,
                     0, 0, 0, 0, 0),
                   dimnames = list(feat1, feat2),
                   nrow = 5, ncol = 5, byrow = TRUE)
-    
-    expect_error(as.fcm(mt2), 
+
+    expect_error(as.fcm(mt2),
                 "matrix must have the same rownames and colnames")
-    expect_error(as.fcm(as(mt2, "dgeMatrix")),
+    expect_error(as.fcm(as(as(as(mt2, "dMatrix"), "generalMatrix"), "unpackedMatrix")),
                 "matrix must have the same rownames and colnames")
 
 })


### PR DESCRIPTION
- fixes deprecated `as()` calls (mostly `as(., "dgCMatrix")` which we'd used a lot)
- turns on errors for using deprecated versions using `options(Matrix.warnDeprecatedCoerce = 2)` in `testthat.R`
- works for forthcoming Matrix 1.4.2 release (tested from r-forge installation)