### PR TITLE
Fix #2189

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,7 +19,7 @@
 ## Bug fixes and stability enhancements
 
 * `dfm_group()` now works correctly with an empty dfm (#2225).
-
+* `convert(x, to = "stm")` no longer vulnerable to large numbers of removed features as in #2189.
 
 # quanteda 3.2.5
 

--- a/R/convert.R
+++ b/R/convert.R
@@ -321,13 +321,13 @@ dfm2stm <- function(x, docvars = NULL, omit_empty = TRUE) {
     empty_docs <- rowSums(x) == 0
     if (omit_empty) {
         if (sum(empty_docs) > 0)
-            warning("Dropped empty document(s): ",
-                    paste0(docnames(x)[empty_docs], collapse = ", "))
+            warning("Dropped ", format(length(empty_docs), big.mark = ","), 
+                                       " empty document(s)")
 
         empty_feats <- colSums(x) == 0
         if (sum(empty_feats) > 0)
-            warning("zero-count features: ",
-                    paste0(featnames(x)[empty_feats], collapse = ", "))
+            warning("Dropped " , format(length(empty_feats), big.mark = ","), 
+                                       " zero-count feature(s)")
 
         x <- x[!empty_docs, !empty_feats]
         docvars <- docvars[!empty_docs, , drop = FALSE]

--- a/tests/testthat/test-convert.R
+++ b/tests/testthat/test-convert.R
@@ -121,22 +121,24 @@ test_that("test stm converter: under extreme situations ", {
                              0, 0, 1, 2,
                              0, 0, 0, 0,
                              1, 2, 3, 4), byrow = TRUE, nrow = 4))
-    expect_warning(convert(dfmat1, to = "stm"), "Dropped empty document\\(s\\): text3")
+    expect_warning(
+        convert(dfmat1, to = "stm"), 
+        "Dropped 4 empty document(s)",
+        fixed = TRUE
+    )
 
     #zero-count feature
     dfmat2 <- as.dfm(matrix(c(1, 0, 2, 0,
                              0, 0, 1, 2,
                              1, 0, 0, 0,
                              1, 0, 3, 4), byrow = TRUE, nrow = 4))
-    expect_warning(convert(dfmat2, to = "stm"), "zero-count features: feat2")
+    expect_warning(
+        convert(dfmat2, to = "stm"), 
+        "Dropped 4 zero-count feature(s)",
+        fixed = TRUE
+    )
 
-    # FAILING
-    # skip_if_not_installed("stm")
-    # require(stm)
-    # stm_model <- stm(documents = stmdfm$documents, vocab = stmdfm$vocab, K=3)
-    # expect_output(print(stm_model), "A topic model with 3 topics")
-
-    #when dfm is 0% sparse
+    # when dfm is 0% sparse
     stmdfm <- convert(as.dfm(matrix(c(1, 2, 3, 4, 5, 6, 7, 8, 9), ncol = 3)), to = "stm")
     expect_equal(length(stmdfm$documents), 3)
 })


### PR DESCRIPTION
Fixes #2189 

by only printing the number of empty documents or features removed when running

```r
convert(dfmat, to = "stm")
```

instead of listing all of the docnames or featnames that are removed.