### PR TITLE
Fixes #1961

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: quanteda
-Version: 3.2.5.9000
+Version: 3.2.5.9001
 Title: Quantitative Analysis of Textual Data
 Description: A fast, flexible, and comprehensive framework for 
     quantitative text analysis in R.  Provides functionality for corpus management,

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,8 @@
     
 * Added `user` and `system` arguments to `docvars()`, where `system = TRUE` returns internal document-level variables.
 
+* Indexing a dfm with empty feature names (`""`) is now possible.  Fixes #1961.
+
 ## Bug fixes and stability enhancements
 
 * `dfm_group()` now works correctly with an empty dfm (#2225).

--- a/R/dfm-subsetting.R
+++ b/R/dfm-subsetting.R
@@ -8,24 +8,32 @@ subset_dfm <- function(x, i, j, ..., drop) {
     if (!missing(i)) {
         index_row <- seq_len(nrow(x))
         names(index_row) <- rownames(x)
-        index_row <- index_row[i]
+        index_row <- if (is.character(i)) {
+            index_row[match(i, names(index_row))]
+        } else {
+            index_row[i]    
+        }
         if (any(is.na(index_row)))
             stop("Subscript out of bounds")
     }
     if (!missing(j)) {
         index_col <- seq_len(ncol(x))
         names(index_col) <- colnames(x)
-        index_col <- index_col[j]
+        index_col <- if (is.character(j)) {
+            index_col[match(j, names(index_col))] 
+        } else {
+            index_col[j]    
+        }
         if (any(is.na(index_col)))
             stop("Subscript out of bounds")
     }
 
     if (!missing(i) && missing(j)) {
-        x <- "["(as(x, "Matrix"), i, , drop = FALSE)
+        x <- "["(as(x, "Matrix"), index_row, , drop = FALSE)
     } else if (missing(i) && !missing(j)) {
-        x <- "["(as(x, "Matrix"), , j, drop = FALSE)
+        x <- "["(as(x, "Matrix"), , index_col, drop = FALSE)
     } else {
-        x <- "["(as(x, "Matrix"), i, j, drop = FALSE)
+        x <- "["(as(x, "Matrix"), index_row, index_col, drop = FALSE)
     }
 
     if (!missing(i))

--- a/R/tokens.R
+++ b/R/tokens.R
@@ -235,6 +235,7 @@ tokens.character <- function(x,
 #' @rdname tokens
 #' @noRd
 #' @importFrom stringi stri_startswith_fixed
+#' @importFrom utils getFromNamespace
 #' @export
 tokens.corpus <- function(x,
                           what = "word",

--- a/tests/testthat/test-dfm.R
+++ b/tests/testthat/test-dfm.R
@@ -1350,3 +1350,34 @@ test_that("features of DFM are always in the same order (#2100)", {
     expect_identical(c("a", "b", "c", "d"), featnames(dfmat3))
     
 })
+
+test_that("dfm with empty feature names work for subsetting", {
+    txt <- c(d1 = "a b c !", d2 = "a a b")
+    dfmat <- tokens(txt, padding = TRUE, remove_punct = TRUE) |>
+        dfm()
+    
+    # empty feature names
+    expect_identical(
+        as.matrix(dfmat[, ""]),
+        structure(c(1, 0), dim = 2:1, 
+                  dimnames = list(docs = c("d1", "d2"), 
+                                  features = ""))
+    )
+
+    # empty doc names
+    # although - this really should not be permitted
+    docnames(dfmat)[1] <- ""
+    expect_identical(
+        as.matrix(dfmat["", ]),
+        structure(c(1, 1, 1, 1), dim = c(1L, 4L), 
+                  dimnames = list(docs = "", 
+                                  features = c("", "a", "b", "c")))
+    )
+    
+    # both empty indexing
+    expect_identical(
+        as.matrix(dfmat["", ""]),
+        structure(1, dim = c(1L, 1L), 
+                  dimnames = list(docs = "", features = ""))
+    )
+})


### PR DESCRIPTION
Allows subsetting a dfm by character names even when that character name is empty, e.g. ""

Whether we _want_ to allow this is another matter.  We probably should for features, given padding.