### PR TITLE
Fix #2103

### DIFF
--- a/R/fcm.R
+++ b/R/fcm.R
@@ -103,6 +103,7 @@ fcm <- function(x, context = c("document", "window"),
                 weights = NULL,
                 ordered = FALSE,
                 tri = TRUE, ...) {
+    check_dots(...)
     UseMethod("fcm")
 }
 

--- a/tests/testthat/test-fcm.R
+++ b/tests/testthat/test-fcm.R
@@ -440,3 +440,10 @@ test_that("margin is correct (#2176)" , {
   
 })
 
+test_that("unused arguments works for fcm (#2103)", {
+    toks <- tokens(c("a b c d e", "a a b n"))
+    expect_warning(
+        fcm(toks, notanargument = TRUE),
+        "notanargument argument is not used"
+    )
+})


### PR DESCRIPTION
Fixes #2103 (not catching extra arguments passed to `fcm()`)

We really should test this for every function, the same way we perform package-wide tests in `test-default-methods.R`.