### PR TITLE
Fix CRAN issue on suggested pkgs in CHECK

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,6 +27,7 @@ Depends:
     methods
 Imports:
     fastmatch,
+    jsonlite,
     magrittr,
     Matrix (>= 1.5-0),
     Rcpp (>= 0.12.12),
@@ -58,8 +59,6 @@ Suggests:
     stm,
     text2vec,
     topicmodels,
-    jsonlite,
-    quanteda,
     tibble,
     tidytext,
     xtable,

--- a/tests/testthat/test-convert.R
+++ b/tests/testthat/test-convert.R
@@ -276,6 +276,7 @@ test_that("triplet converter works", {
 })
 
 test_that("omit_empty works as expected (#1600", {
+    skip_if_not_installed("tm")
     dfmat <- as.dfm(matrix(c(1, 0, 2, 0,
                              0, 0, 1, 2,
                              0, 0, 0, 0,


### PR DESCRIPTION
I had to make two changes due to a new CRAN policy of being stricter with packages that are Suggested.
I moved **jsonlite** from Suggests to Imports. It has no imports (since it's one of Jeroen's packages) so doesn't bloat the package. We also need this as a core functionality because of how we are exporting items to JSON to get them to work with pytorch. But @koheiw I wanted to make sure you're ok with it.

I added this to my .Renviron to make this part of all future testing:
```
_R_CHECK_DEPENDS_ONLY_=true
```

The message from CRAN today (although I'd just passed all tests on their own systems! `devtools::check_win_devel()` etc)

```
Thanks, we see when

set _R_CHECK_DEPENDS_ONLY_=true

is used (i.e. withou installed suggested packages):



* checking examples ... [5s] ERROR
Running examples in 'quanteda-Ex.R' failed
The error most likely occurred in:

> base::assign(".ptime", proc.time(), pos = "CheckExEnv")
> ### Name: convert
> ### Title: Convert quanteda objects to non-quanteda formats
> ### Aliases: convert convert.dfm convert.corpus
>
> ### ** Examples
>
> ## convert a dfm
>
> toks <- corpus_subset(data_corpus_inaugural, Year > 1970) %>%
+     tokens()
> dfmat1 <- dfm(toks)
>
> # austin's wfm format
> identical(dim(dfmat1), dim(convert(dfmat1, to = "austin")))
[1] TRUE
>
> # stm package format
> stmmat <- convert(dfmat1, to = "stm")
> str(stmmat)
List of 3
$ documents:List of 13
 ..$ 1973-Nixon  : int [1:2, 1:515] 2 2 6 96 7 17 8 69 20 1 ...
 ..$ 1977-Carter : int [1:2, 1:501] 2 4 4 1 5 1 6 65 7 11 ...
 ..$ 1981-Reagan : int [1:2, 1:850] 2 20 6 174 7 9 8 130 19 1 ...
 ..$ 1985-Reagan : int [1:2, 1:876] 2 6 3 1 4 1 5 1 6 177 ...
 ..$ 1989-Bush   : int [1:2, 1:756] 2 6 6 166 7 7 8 142 25 2 ...
 ..$ 1993-Clinton: int [1:2, 1:605] 2 4 6 139 8 81 29 1 42 5 ...
 ..$ 1997-Clinton: int [1:2, 1:726] 2 4 6 131 7 13 8 108 18 1 ...
 ..$ 2001-Bush   : int [1:2, 1:592] 2 2 6 110 7 2 8 96 30 1 ...
 ..$ 2005-Bush   : int [1:2, 1:734] 2 6 3 1 6 120 7 2 8 98 ...
 ..$ 2009-Obama  : int [1:2, 1:900] 1 1 2 2 6 130 7 22 8 118 ...
 ..$ 2013-Obama  : int [1:2, 1:786] 6 99 7 13 8 89 13 1 25 1 ...
 ..$ 2017-Trump  : int [1:2, 1:547] 2 2 3 1 6 96 7 11 8 88 ...
 ..$ 2021-Biden  : int [1:2, 1:744] 2 10 6 147 8 210 9 1 10 1 ...
$ vocab    : chr [1:3618] "!" "\"" "'" "(" ...
$ meta     :'data.frame':	13 obs. of  4 variables:
 ..$ Year     : int [1:13] 1973 1977 1981 1985 1989 1993 1997 2001 2005 2009 ...
 ..$ President: chr [1:13] "Nixon" "Carter" "Reagan" "Reagan" ...
 ..$ FirstName: chr [1:13] "Richard Milhous" "Jimmy" "Ronald" "Ronald" ...
 ..$ Party    : Factor w/ 6 levels "Democratic","Democratic-Republican",..: 5 1 5 5 5 1 1 5 5 1 ...
>
> # triplet
> tripletmat <- convert(dfmat1, to = "tripletlist")
> str(tripletmat)
List of 3
$ document : chr [1:9132] "1973-Nixon" "1981-Reagan" "1989-Bush" "2005-Bush" ...
$ feature  : chr [1:9132] "mr" "mr" "mr" "mr" ...
$ frequency: num [1:9132] 3 3 6 1 1 69 52 130 124 142 ...
>
> ## Not run:
> ##D # tm's DocumentTermMatrix format
> ##D tmdfm <- convert(dfmat1, to = "tm")
> ##D str(tmdfm)
> ##D
> ##D # topicmodels package format
> ##D str(convert(dfmat1, to = "topicmodels"))
> ##D
> ##D # lda package format
> ##D str(convert(dfmat1, to = "lda"))
> ## End(Not run)
>
> ## convert a corpus into a data.frame
>
> corp <- corpus(c(d1 = "Text one.", d2 = "Text two."),
+                docvars = data.frame(dvar1 = 1:2, dvar2 = c("one", "two"),
+                                     stringsAsFactors = FALSE))
> convert(corp, to = "data.frame")
 doc_id      text dvar1 dvar2
1     d1 Text one.     1   one
2     d2 Text two.     2   two
> convert(corp, to = "json")
Error in loadNamespace(x) : there is no package called 'jsonlite'
Calls: convert ... loadNamespace -> withRestarts -> withOneRestart -> doWithOneRestart
Execution halted



* checking tests ... [71s] ERROR
 Running 'spelling.R' [0s]
 Running 'testthat.R' [71s]
Running the tests in 'tests/testthat.R' failed.
Complete output:
 > Sys.setenv("R_TESTS" = "")
 > Sys.setenv("_R_CHECK_LENGTH_1_CONDITION_" = TRUE)
 >
 > library(testthat)
 > library(quanteda)
 Package version: 3.3.0
 Unicode version: 13.0
 ICU version: 69.1
 Parallel computing: 56 of 56 threads used.
 See https://quanteda.io/ for tutorials and examples.
 >
 > # for strong tests for Matrix deprecations
 > options(Matrix.warnDeprecatedCoerce = 2)
 >
 > ops <- quanteda_options()
 > quanteda_options(reset = TRUE)
 > test_check("quanteda")
 [ FAIL 1 | WARN 2 | SKIP 33 | PASS 3084 ] 
```