### PR TITLE
Revert 2222

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,9 +13,8 @@
         - the URL pattern
     - creates a new tokens_restore(), implemented in C++, to replace the older `preserve_special()` that rejoined splits created by the default stringi tokeniser machinery.  
     - makes some technical improvements to internal tokenisation functions, such as moving the ellipsis to the end of the function, to allow more modularity in developing future tokenisers.
-    
-* Added `user` and `system` arguments to `docvars()`, where `system = TRUE` returns internal document-level variables.
 
+    
 ## Bug fixes and stability enhancements
 
 * `dfm_group()` now works correctly with an empty dfm (#2225).

--- a/R/docvars.R
+++ b/R/docvars.R
@@ -208,8 +208,6 @@ is_system_old <- function(x) {
 #' @param x [corpus], [tokens], or [dfm] object whose
 #'   document-level variables will be read or set
 #' @param field string containing the document-level variable name
-#' @param user if `TRUE`, returns user-defined fields.
-#' @param system if `TRUE`, returns system fields (`docid_`, `segid_`, `docname_`).
 #' @return `docvars` returns a data.frame of the document-level variables,
 #'   dropping the second dimension to form a vector if a single docvar is
 #'   returned.
@@ -224,34 +222,34 @@ is_system_old <- function(x) {
 #'
 #' @export
 #' @keywords corpus
-docvars <- function(x, field = NULL, user = TRUE, system = FALSE) {
+docvars <- function(x, field = NULL) {
     UseMethod("docvars")
 }
 
 #' @export
-docvars.default <- function(x, field = NULL, user = TRUE, system = FALSE) {
+docvars.default <- function(x, field = NULL) {
     check_class(class(x), "docvars")
 }
 
 #' @noRd
 #' @export
-docvars.corpus <- function(x, field = NULL, user = TRUE, system = FALSE) {
+docvars.corpus <- function(x, field = NULL) {
     x <- as.corpus(x)
-    select_docvars(attr(x, "docvars"), field, user = user, system = system, drop = TRUE)
+    select_docvars(attr(x, "docvars"), field, user = TRUE, system = FALSE, drop = TRUE)
 }
 
 #' @noRd
 #' @export
-docvars.tokens <- function(x, field = NULL, user = TRUE, system = FALSE) {
+docvars.tokens <- function(x, field = NULL) {
     x <- as.tokens(x)
-    select_docvars(attr(x, "docvars"), field, user = user, system = system, drop = TRUE)
+    select_docvars(attr(x, "docvars"), field, user = TRUE, system = FALSE, drop = TRUE)
 }
 
 #' @noRd
 #' @export
-docvars.dfm <- function(x, field = NULL, user = TRUE, system = FALSE) {
+docvars.dfm <- function(x, field = NULL) {
     x <- as.dfm(x)
-    select_docvars(x@docvars, field, user = user, system = system, drop = TRUE)
+    select_docvars(x@docvars, field, user = TRUE, system = FALSE, drop = TRUE)
 }
 
 #' @noRd

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -2,6 +2,10 @@
 
 * Fixes a noSuggests caused by archived (and a week later restored) Suggested kage quanteda.textmodels
 
+* Adds testing under conditions of `_R_CHECK_DEPENDS_ONLY_=true`
+
+* Limits threads to the CRAN maximum.
+
 * Removes the C++ requirement.
 
 * Implements a new experimental tokenizer.

--- a/man/docvars.Rd
+++ b/man/docvars.Rd
@@ -11,7 +11,7 @@
 \alias{$<-.dfm}
 \title{Get or set document-level variables}
 \usage{
-docvars(x, field = NULL, user = TRUE, system = FALSE)
+docvars(x, field = NULL)
 
 docvars(x, field = NULL) <- value
 
@@ -32,10 +32,6 @@ docvars(x, field = NULL) <- value
 document-level variables will be read or set}
 
 \item{field}{string containing the document-level variable name}
-
-\item{user}{if \code{TRUE}, returns user-defined fields.}
-
-\item{system}{if \code{TRUE}, returns system fields (\code{docid_}, \code{segid_}, \code{docname_}).}
 
 \item{value}{a vector of document variable values to be assigned to \code{name}}
 

--- a/tests/testthat/test-docvars.R
+++ b/tests/testthat/test-docvars.R
@@ -182,53 +182,50 @@ test_that("docvars with non-existent field names generate correct error messages
     )
 })
 
-test_that("docvars works with corps, tokens and dfm", {
+test_that("docvars is working with tokens", {
+    corp <- data_corpus_inaugural[1:58]
+    toks <- tokens(corp, include_docvars = TRUE)
+    expect_equal(docvars(toks), docvars(corp))
+    expect_equal(docvars(toks, "President"), docvars(corp, "President"))
     
+    # Subset
+    toks2 <- toks[docvars(toks, "Year") > 2000]
+    expect_equal(ndoc(toks2), nrow(docvars(toks2)))
+    
+    # Add field to meta-data
+    expect_equal(
+        docvars(quanteda:::"docvars<-"(toks2, "Type", "Speech"), "Type"),
+        rep("Speech", 5)
+    )
+    
+    # Remove meta-data
+    expect_output(
+        print(docvars(quanteda:::"docvars<-"(toks, field = NULL, NULL))),
+        "data frame with 0 columns and 58 rows"
+    )
+    
+    # Add fresh meta-data
+    expect_equal(
+        docvars(quanteda:::"docvars<-"(toks, field = "ID", 1:58), "ID"),
+        1:58
+    )
+})
+
+test_that("docvars is working with dfm", {
     corp <- data_corpus_inaugural
-    toks <- tokens(corp)
-    dfmt <- dfm(toks)
+    toks <- tokens(corp, include_docvars = TRUE)
+    thedfm <- dfm(toks)
     
-    # corpus
-    expect_equal(rownames(docvars(corp)), as.character(1:59))
-    expect_equal(colnames(docvars(corp)), 
-                 c("Year", "President", "FirstName", "Party"))
-    expect_equal(colnames(docvars(corp, system = TRUE)), 
-                 c("docname_", "docid_", "segid_",
-                   "Year", "President", "FirstName", "Party"))
-    expect_equal(colnames(docvars(corp, system = TRUE, user = FALSE)), 
-                 c("docname_", "docid_", "segid_"))
-    expect_equal(docvars(corp, "Party"),
-                 docvars(corp)$Party)
-    expect_equal(docvars(corp, c("docid_", "Party"), system = TRUE),
-                 docvars(corp, system = TRUE)[c("docid_", "Party")])
+    expect_equal(docvars(toks), docvars(thedfm))
+    expect_equal(docvars(toks, "Party"), docvars(corp, "Party"))
     
-    # tokens
-    expect_equal(rownames(docvars(toks)), as.character(1:59))
-    expect_equal(colnames(docvars(toks)), 
-                 c("Year", "President", "FirstName", "Party"))
-    expect_equal(colnames(docvars(toks, system = TRUE)), 
-                 c("docname_", "docid_", "segid_",
-                   "Year", "President", "FirstName", "Party"))
-    expect_equal(colnames(docvars(toks, system = TRUE, user = FALSE)), 
-                 c("docname_", "docid_", "segid_"))
-    expect_equal(docvars(toks, "Party"),
-                 docvars(toks)$Party)
-    expect_equal(docvars(toks, c("docid_", "Party"), system = TRUE),
-                 docvars(toks, system = TRUE)[c("docid_", "Party")])
+    thedfm2 <- dfm(tokens(corp))
+    expect_equal(docvars(corp), docvars(thedfm2))
+    expect_equal(docvars(corp, "Party"), docvars(thedfm2, "Party"))
     
-    # dfm 
-    expect_equal(rownames(docvars(dfmt)), as.character(1:59))
-    expect_equal(colnames(docvars(dfmt)), 
-                 c("Year", "President", "FirstName", "Party"))
-    expect_equal(colnames(docvars(dfmt, system = TRUE)), 
-                 c("docname_", "docid_", "segid_",
-                   "Year", "President", "FirstName", "Party"))
-    expect_equal(colnames(docvars(dfmt, system = TRUE, user = FALSE)), 
-                 c("docname_", "docid_", "segid_"))
-    expect_equal(docvars(dfmt, "Party"),
-                 docvars(dfmt)$Party)
-    expect_equal(docvars(dfmt, c("docid_", "Party"), system = TRUE),
-                 docvars(dfmt, system = TRUE)[c("docid_", "Party")])
+    corp2 <- corpus_subset(corp, Party == "Democratic")
+    thedfm3 <- dfm(tokens(corp2))
+    expect_equal(docvars(corp2), docvars(thedfm3))
 })
 
 test_that("$ returns docvars", {

--- a/vignettes/quickstart.Rmd
+++ b/vignettes/quickstart.Rmd
@@ -478,17 +478,19 @@ if (require("quanteda.textmodels") && require("quanteda.textplots")) {
 **quanteda** makes it very easy to fit topic models as well, e.g.:
 
 ```{r}
-quant_dfm <- tokens(data_corpus_irishbudget2010, remove_punct = TRUE, remove_numbers = TRUE) %>%
-  tokens_remove(stopwords("en")) %>%
-  dfm()
-quant_dfm <- dfm_trim(quant_dfm, min_termfreq = 4, max_docfreq = 10)
-quant_dfm 
+if (require("quanteda.textmodels")) {
+    quant_dfm <- tokens(data_corpus_irishbudget2010, remove_punct = TRUE, remove_numbers = TRUE) %>%
+        tokens_remove(stopwords("en")) %>%
+        dfm()
+    quant_dfm <- dfm_trim(quant_dfm, min_termfreq = 4, max_docfreq = 10)
+    quant_dfm 
+}
 ```
 
 Now we can fit the topic model and plot it:
 ```{r fig.width = 7, fig.height = 5}
-set.seed(100)
-if (require("stm")) {
+if (require("stm") && require("quanteda.textmodels")) {
+    set.seed(100)
     my_lda_fit20 <- stm(quant_dfm, K = 20, verbose = FALSE)
     plot(my_lda_fit20)    
 }


### PR DESCRIPTION
Undoes the docvars() new arguments created in #2222, but restored that branch so that it can be merged into master.

Preserves some of the original PR, by removing docvars() for .readtext objects, and keeps a few other aspects that were tidied up.