### PR TITLE
Avoid segfault error when patterns have paddings

### DIFF
--- a/src/tokens_compound.cpp
+++ b/src/tokens_compound.cpp
@@ -162,8 +162,12 @@ TokensPtr cpp_tokens_compound(TokensPtr xptr,
     Ngrams comps = Rcpp::as<Ngrams>(compounds_);
     std::vector<std::size_t> spans(comps.size());
     for (size_t g = 0; g < comps.size(); g++) {
-        set_comps.insert(comps[g]);
-        spans[g] = comps[g].size();
+        Ngram comp = comps[g];
+        // ignore patterns with paddings
+        if (std::find(comp.begin(), comp.end(), 0) == comp.end()) {
+            set_comps.insert(comp);
+            spans[g] = comp.size();
+        }
     }
     sort(spans.begin(), spans.end());
     spans.erase(unique(spans.begin(), spans.end()), spans.end());

--- a/tests/testthat/test-tokens_compound.R
+++ b/tests/testthat/test-tokens_compound.R
@@ -276,3 +276,24 @@ test_that("tokens_compound window is working", {
   )
 
 })
+
+test_that("tokens_compound ignores padding", {
+    
+    toks <- tokens("a b c d e")
+    toks <- tokens_remove(toks, "b", padding = TRUE)
+    
+    toks_comp1 <- tokens_compound(toks, list(c("", "c"), c("d", "e")))
+    expect_equal(
+        as.character(toks_comp1),
+        c("a", "", "c", "d_e")
+    )
+    
+    col <- data.frame(collocation = c(" c", "d e"))
+    class(col) <- c("collocations", "textstat", "data.frame")
+    toks_comp2 <- tokens_compound(toks, col)
+    expect_equal(
+        as.character(toks_comp2),
+        c("a", "", "c", "d_e")
+    )
+})
+


### PR DESCRIPTION
This does nothing do with recent changes. It is a very old bug.