### PR TITLE
Avoid segfault error when patterns have paddings in v3.3

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: quanteda
-Version: 3.3.0
+Version: 3.3.0.9000
 Title: Quantitative Analysis of Textual Data
 Description: A fast, flexible, and comprehensive framework for 
     quantitative text analysis in R.  Provides functionality for corpus management,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# quanteda 3.3.1
+
+## Bug fixes and stability enhancements
+
+* Fixed a potential crash when calling `tokens_compound()` with patterns containing paddings (#2254).
+
+
 # quanteda 3.3.0
 
 ## Changes and additions

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ data](https://cdn.rawgit.com/quanteda/quanteda/master/images/quanteda_logo.svg)]
 
 [![CRAN
 Version](https://www.r-pkg.org/badges/version/quanteda)](https://CRAN.R-project.org/package=quanteda)
-[![](https://img.shields.io/badge/devel%20version-3.3.0-royalblue.svg)](https://github.com/quanteda/quanteda)
+[![](https://img.shields.io/badge/devel%20version-3.3.0.9000-royalblue.svg)](https://github.com/quanteda/quanteda)
 [![Downloads](https://cranlogs.r-pkg.org/badges/quanteda)](https://CRAN.R-project.org/package=quanteda)
 [![Total
 Downloads](https://cranlogs.r-pkg.org/badges/grand-total/quanteda?color=orange)](https://CRAN.R-project.org/package=quanteda)

--- a/src/tokens_compound.cpp
+++ b/src/tokens_compound.cpp
@@ -197,8 +197,12 @@ List qatd_cpp_tokens_compound(const List &texts_,
     Ngrams comps = Rcpp::as<Ngrams>(compounds_);
     std::vector<std::size_t> spans(comps.size());
     for (size_t g = 0; g < comps.size(); g++) {
-        set_comps.insert(comps[g]);
-        spans[g] = comps[g].size();
+        Ngram comp = comps[g];
+        // ignore patterns with paddings
+        if (std::find(comp.begin(), comp.end(), 0) == comp.end()) {
+            set_comps.insert(comp);
+            spans[g] = comp.size();
+        }
     }
     sort(spans.begin(), spans.end());
     spans.erase(unique(spans.begin(), spans.end()), spans.end());

--- a/tests/testthat/test-tokens_compound.R
+++ b/tests/testthat/test-tokens_compound.R
@@ -270,3 +270,24 @@ test_that("tokens_compound window is working", {
   )
 
 })
+
+
+test_that("tokens_compound ignores padding", {
+    
+    toks <- tokens("a b c d e")
+    toks <- tokens_remove(toks, "b", padding = TRUE)
+    
+    toks_comp1 <- tokens_compound(toks, list(c("", "c"), c("d", "e")))
+    expect_equal(
+        as.character(toks_comp1),
+        c("a", "", "c", "d_e")
+    )
+    
+    col <- data.frame(collocation = c(" c", "d e"))
+    class(col) <- c("collocations", "textstat", "data.frame")
+    toks_comp2 <- tokens_compound(toks, col)
+    expect_equal(
+        as.character(toks_comp2),
+        c("a", "", "c", "d_e")
+    )
+})


### PR DESCRIPTION
We should update the v3.3 because it leads to a nasty crash.