### PR TITLE
Fix pattern2fixed in v4

### DIFF
--- a/R/pattern2fixed.R
+++ b/R/pattern2fixed.R
@@ -125,17 +125,12 @@ search_glob <- function(pattern, types_search, case_insensitive, index = NULL) {
         return(which(stri_detect_regex(types_search, utils::glob2rx(pattern),
                                        case_insensitive = case_insensitive)))
     } else {
-        pos <- search_index(pattern, index)
-        if (length(pos)) {
-            #cat("Index search", pattern, "\n")
-            return(pos)
-        } else if (!is_indexed(pattern)) {
-            #cat("Regex search", pattern, "\n")
-            return(which(stri_detect_regex(types_search, utils::glob2rx(pattern),
-                                           case_insensitive = case_insensitive)))
+        if (is_indexed(pattern)) {
+            return(search_index(pattern, index))
         } else {
-            #cat("Not found\n")
-            return(integer())
+            l <- stri_detect_regex(types_search, utils::glob2rx(pattern),
+                                   case_insensitive = case_insensitive)
+            return(which(l))
         }
     }
 }

--- a/tests/testthat/test-pattern2fixed.R
+++ b/tests/testthat/test-pattern2fixed.R
@@ -85,7 +85,7 @@ test_that("pattern2fixed converts complex patterns correctly", {
     regex <- list(c('a...b'), c('c.*d'), c('e.+f'), c('^g[xyz]+h$'), c('z'), c('[0-9]'))
     glob <- list("<*>")
     type <- c('axxxb', 'cxxxd', 'exxxf', 'gyyyh', 'azzzb', 'a999b', 
-              "<*>", "<abc>", "<abc.12>")
+              "<*>", "<xxx>", "<xx.yy>")
     
     expect_setequal(
         pattern2fixed(regex, type, 'regex', case_insensitive = TRUE),
@@ -94,7 +94,7 @@ test_that("pattern2fixed converts complex patterns correctly", {
     
     expect_setequal(
         pattern2fixed(glob, type, 'glob', case_insensitive = TRUE),
-        list("<*>", "<abc>", "<abc.12>")
+        list("<*>", "<xxx>", "<xx.yy>")
     )
 })
 

--- a/tests/testthat/test-pattern2fixed.R
+++ b/tests/testthat/test-pattern2fixed.R
@@ -80,15 +80,22 @@ test_that("pattern2fixed converts regex patterns correctly", {
     
 })
 
-test_that("pattern2fixed converts complex regex patterns correctly", {
+test_that("pattern2fixed converts complex patterns correctly", {
     
     regex <- list(c('a...b'), c('c.*d'), c('e.+f'), c('^g[xyz]+h$'), c('z'), c('[0-9]'))
-    type <- c('axxxb', 'cxxxd', 'exxxf', 'gyyyh', 'azzzb', 'a999b')
+    glob <- list("<*>")
+    type <- c('axxxb', 'cxxxd', 'exxxf', 'gyyyh', 'azzzb', 'a999b', 
+              "<*>", "<abc>", "<abc.12>")
     
-    expect_identical(setdiff(
+    expect_setequal(
         pattern2fixed(regex, type, 'regex', case_insensitive = TRUE),
         list('axxxb', 'cxxxd', 'exxxf', 'gyyyh', 'azzzb', 'a999b')
-    ), list())
+    )
+    
+    expect_setequal(
+        pattern2fixed(glob, type, 'glob', case_insensitive = TRUE),
+        list("<*>", "<abc>", "<abc.12>")
+    )
 })
 
 test_that("pattern2fixed works with character class", {


### PR DESCRIPTION
This is a critical bug that leads `patter2fixed()` to ignore matching types `"<xxx>", "<xx.yy>"` when one of the types `<*>` is a the same as the glob pattern.