### PR TITLE
Small fixes for 3.3.1 CRAN update

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: quanteda
-Version: 3.3.0.9001
+Version: 3.3.1
 Title: Quantitative Analysis of Textual Data
 Description: A fast, flexible, and comprehensive framework for 
     quantitative text analysis in R.  Provides functionality for corpus management,

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,8 @@ for empty dimensions.
 
 * restores `readtext` object class method extensions, to work better with the **readtext** package.
 
+* Removes some unused internal methods, such as `docvars.kwic()` that were not exported despite matching exported generics.
+
 
 # quanteda 3.3.0
 

--- a/R/docvars.R
+++ b/R/docvars.R
@@ -252,11 +252,11 @@ docvars.dfm <- function(x, field = NULL) {
     select_docvars(x@docvars, field, user = TRUE, system = FALSE, drop = TRUE)
 }
 
-#' @noRd
-#' @keywords internal
-docvars.kwic <- function(x, field = NULL) {
-    select_docvars(attr(x, "docvars"), NULL)
-}
+# @noRd
+# @export
+# docvars.kwic <- function(x, field = NULL) {
+#     select_docvars(attr(x, "docvars"), NULL)
+# }
 
 #' @rdname docvars
 #' @param value the new values of the document-level variable

--- a/R/docvars.R
+++ b/R/docvars.R
@@ -254,7 +254,7 @@ docvars.dfm <- function(x, field = NULL) {
 
 #' @noRd
 #' @keywords internal
-docvars.kwic <- function(x) {
+docvars.kwic <- function(x, field = NULL) {
     select_docvars(attr(x, "docvars"), NULL)
 }
 

--- a/R/tokens_ngrams.R
+++ b/R/tokens_ngrams.R
@@ -48,8 +48,7 @@ tokens_ngrams.default <- function(x, n = 2L, skip = 0L, concatenator = "_") {
 ## the grammatical rules of quanteda (inputs character, outputs tokens),
 ## but starts with "tokens_"
 #' @importFrom stats complete.cases
-tokens_ngrams.character <- function(x, n = 2L, skip = 0L, concatenator = "_") {
-
+tokens_ngrams_character <- function(x, n = 2L, skip = 0L, concatenator = "_") {
     # trap condition where a "text" is a single NA
     if (is.na(x[1]) && length(x) == 1) return(NULL)
     if (any(stringi::stri_detect_charclass(x, "\\p{Z}")) & concatenator != " ")
@@ -85,7 +84,7 @@ char_ngrams.default <- function(x, n = 2L, skip = 0L, concatenator = "_") {
 
 #' @export
 char_ngrams.character <- function(x, n = 2L, skip = 0L, concatenator = "_") {
-    as.character(tokens_ngrams(x, n, skip, concatenator))
+    as.character(tokens_ngrams_character(x, n, skip, concatenator))
 }
 
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,19 +1,16 @@
 # Submission notes
 
-* Fixes a noSuggests caused by archived (and a week later restored) Suggested kage quanteda.textmodels
+*  Fixed a potential crash when calling `tokens_compound()` with patterns containing paddings (#2254).
+*  Updated for compatibility with (forthcoming) Matrix 1.5.5 handling of dimnames() 
+for empty dimensions.
+*  restores `readtext` object class method extensions, to work better with the **readtext** package.
+*  Removes some unused internal methods, such as `docvars.kwic()` that were not exported despite matching exported generics.
 
-* Adds testing under conditions of `_R_CHECK_DEPENDS_ONLY_=true`
-
-* Limits threads to the CRAN maximum.
-
-* Removes the C++ requirement.
-
-* Implements a new experimental tokenizer.
 
 ## Test environments
 
-* local macOS 13.2.1, R 4.2.3
-* Ubuntu 22.04 LTS, R 4.2.3
+* local macOS 13.2.1, R 4.3.0
+* Ubuntu 22.04 LTS, R 4.3.0
 * Windows release via devtools::check_win_release()
 * Windows devel via devtools::check_win_devel()
 * Windows oldrelease via devtools::check_win_oldrelease()

--- a/tests/testthat/test-tokens_ngrams.R
+++ b/tests/testthat/test-tokens_ngrams.R
@@ -53,7 +53,7 @@ test_that("test that ngrams produces the results from Guthrie 2006", {
 })
 
 test_that("test `tokens_ngrams` on characters", {
-    ngms <- quanteda:::tokens_ngrams.character(c('insurgents', 'killed', 'in', 'ongoing', 'fighting'))
+    ngms <- quanteda:::tokens_ngrams_character(c('insurgents', 'killed', 'in', 'ongoing', 'fighting'))
     charNgms <- char_ngrams(c('insurgents','killed', 'in', 'ongoing', 'fighting'))
     expect_equivalent(
         ngms,
@@ -65,10 +65,10 @@ test_that("test `tokens_ngrams` on characters", {
         c('insurgents_killed', 'killed_in', 'in_ongoing', 'ongoing_fighting')
     )
     
-    expect_warning(quanteda:::tokens_ngrams.character('insurgents killed', 'in', 'ongoing', 'fighting'), 
+    expect_warning(quanteda:::tokens_ngrams_character('insurgents killed', 'in', 'ongoing', 'fighting'), 
                  "whitespace detected: you may need to run tokens\\(\\) first")
     
-    expect_warning(quanteda:::tokens_ngrams.character(c('insurgents killed in ongoing fighting'), n = 1, skip = 1), 
+    expect_warning(quanteda:::tokens_ngrams_character(c('insurgents killed in ongoing fighting'), n = 1, skip = 1), 
                    "skip argument ignored for n = 1")
 })
 


### PR DESCRIPTION
Updates the NOTES and other items, but also removes some internal (non-exported) methods that matched exported generics. We were not using those methods anyway, and they were targeted for removal on our deprecations and slimming and trimming for 4.0 anyway.