### PR TITLE
Fix tokens group

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,7 @@ language handling, and customisation options.
 
 ## Bug fixes and stability enhancements
 
+* `tokens_group()` works efficiently even when the number of documents and groups are very large.
 
 # quanteda 3.3.1
 

--- a/R/tokens_group.R
+++ b/R/tokens_group.R
@@ -58,8 +58,8 @@ tokens_group.tokens_xptr <- function(x, groups = docid(x), fill = FALSE, env = N
     x <- tokens_subset(x, !is.na(groups))
     attrs <- attributes(x)
     groups <- groups[!is.na(groups)]
-
-    result <- cpp_tokens_group(x, groups, get_threads())
+    
+    result <- cpp_tokens_group(x, split(seq_along(groups), groups), get_threads())
     attrs[["docvars"]] <- group_docvars(attrs[["docvars"]], groups, field)
 
     rebuild_tokens(result, attrs)

--- a/man/head.dfm.Rd
+++ b/man/head.dfm.Rd
@@ -13,8 +13,7 @@
 \item{x}{a \link{dfm} object}
 
 \item{n}{an integer vector of length up to \code{dim(x)} (or 1,
-    for non-dimensioned objects).  A \code{logical} is silently coerced to
-    integer.  Values specify the indices to be
+    for non-dimensioned objects). Values specify the indices to be
     selected in the corresponding dimension (or along the length) of the
     object. A positive value of \code{n[i]} includes the first/last
     \code{n[i]} indices in that dimension, while a negative value

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -124,13 +124,13 @@ BEGIN_RCPP
 END_RCPP
 }
 // cpp_tokens_group
-TokensPtr cpp_tokens_group(TokensPtr xptr, IntegerVector groups_, const int thread);
+TokensPtr cpp_tokens_group(TokensPtr xptr, List groups_, const int thread);
 RcppExport SEXP _quanteda_cpp_tokens_group(SEXP xptrSEXP, SEXP groups_SEXP, SEXP threadSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< TokensPtr >::type xptr(xptrSEXP);
-    Rcpp::traits::input_parameter< IntegerVector >::type groups_(groups_SEXP);
+    Rcpp::traits::input_parameter< List >::type groups_(groups_SEXP);
     Rcpp::traits::input_parameter< const int >::type thread(threadSEXP);
     rcpp_result_gen = Rcpp::wrap(cpp_tokens_group(xptr, groups_, thread));
     return rcpp_result_gen;

--- a/src/tokens_group.cpp
+++ b/src/tokens_group.cpp
@@ -11,50 +11,48 @@ using namespace quanteda;
  * @param groups_ group index
  */
 
+typedef std::vector<int> Group;
+typedef std::vector<Group> Groups;
+
 // [[Rcpp::export]]
 TokensPtr cpp_tokens_group(TokensPtr xptr,
-                           IntegerVector groups_,
+                           List groups_,
                            const int thread = -1) {
     
     Texts texts = xptr->texts;
-    std::vector<int> groups = Rcpp::as< std::vector<int> >(groups_);
-    Types levels = Rcpp::as<Types>(groups_.attr("levels"));
-    
-    if (texts.size() != groups.size())
-        throw std::range_error("Invalid groups");
-    
+    Groups groups = Rcpp::as<Groups>(groups_);
+
     // pre-allocate memory
-    std::size_t G = levels.size();
+    std::size_t G = groups.size();
     std::size_t H = texts.size();
     std::vector<size_t> sizes(G);
-    for (std::size_t h = 0; h < H; h++) {
-        sizes[groups[h] - 1] += texts[h].size();
-    }
+    
     Texts temp(G);
     for (std::size_t g = 0; g < G; g++) {
-        temp[g].reserve(sizes[g]);  
+        std::size_t size = 0;
+        for (int h: groups[g]) {
+            if (h < 1 || H < h)
+                throw std::range_error("Invalid groups");
+            size += texts[h - 1].size();
+        }
+        temp[g].reserve(size);  
     }
-    
 
 #if QUANTEDA_USE_TBB
     tbb::task_arena arena(thread);
     arena.execute([&]{
        tbb::parallel_for(tbb::blocked_range<int>(0, G), [&](tbb::blocked_range<int> r) {
           for (int g = r.begin(); g < r.end(); ++g) {
-              for (std::size_t h = 0; h < H; h++) {
-                  if (g == groups[h] - 1) {
-                      temp[g].insert(temp[g].end(), texts[h].begin(), texts[h].end());
-                  }
+              for (std::size_t h: groups[g]) {
+                  temp[g].insert(temp[g].end(), texts[h - 1].begin(), texts[h - 1].end());
               }
           }
        });
     });
 #else
     for (std::size_t g = 0; g < G; g++) {
-        for (std::size_t h = 0; h < H; h++) {
-            if (g == groups[h] - 1) {
-                temp[g].insert(temp[g].end(), texts[h].begin(), texts[h].end());
-            }
+        for (std::size_t h: groups[g]) {
+            temp[g].insert(temp[g].end(), texts[h - 1.begin(), texts[h - 1].end());
         }
     }
 #endif


### PR DESCRIPTION
Due to the double loop in the current code for `tokens_group()`, R almost freezes when the number of documents (sentences) are very large (ndoc > 10M). 