### PR TITLE
Use .empty() where appropriate

### DIFF
--- a/src/index.cpp
+++ b/src/index.cpp
@@ -10,7 +10,7 @@ Matches index(Text tokens,
                    const MultiMapNgrams &map_pats,
                    UintParam &N){
     
-    if(tokens.size() == 0) return {}; // return empty vector for empty text
+    if(tokens.empty()) return {}; // return empty vector for empty text
     
     Matches matches;
     matches.reserve(tokens.size());
@@ -100,7 +100,7 @@ DataFrame cpp_index(TokensPtr xptr,
     std::size_t j = 0;
     for (std::size_t h = 0; h < temp.size(); h++) {
         Matches matches = temp[h];
-        if (matches.size() == 0) continue;
+        if (matches.empty()) continue;
         Text tokens = texts[h];
         for (size_t i = 0; i < matches.size(); i++) {
             Match match = matches[i];

--- a/src/tokens_chunk.cpp
+++ b/src/tokens_chunk.cpp
@@ -7,7 +7,7 @@ Texts chunk(Text &tokens,
             const int size,
             const int overlap){
     
-    if (tokens.size() == 0) return {}; // return empty vector for empty text
+    if (tokens.empty()) return {}; // return empty vector for empty text
     
     std::size_t step;
     Texts chunks;

--- a/src/tokens_compound.cpp
+++ b/src/tokens_compound.cpp
@@ -20,7 +20,7 @@ Text join_comp(Text tokens,
                IdNgram &id_comp,
                const std::pair<int, int> &window){
     
-    if (tokens.size() == 0) return {}; // return empty vector for empty text
+    if (tokens.empty()) return {}; // return empty vector for empty text
     
     std::vector< bool > flags_link(tokens.size(), false); // flag tokens to join
     std::size_t match = 0;
@@ -56,12 +56,12 @@ Text join_comp(Text tokens,
         if (flags_link[i]) {
                 tokens_seq.push_back(tokens[i]);
         } else {
-            if (tokens_seq.size() > 0) {
+            if (tokens_seq.empty()) {
+                tokens_flat.push_back(tokens[i]);
+            } else {
                 tokens_seq.push_back(tokens[i]);
                 tokens_flat.push_back(ngram_id(tokens_seq, map_comps, id_comp)); // assign ID to ngram
                 tokens_seq.clear();
-            } else {
-                tokens_flat.push_back(tokens[i]);
             }
         }
     }
@@ -76,7 +76,7 @@ Text match_comp(Text tokens,
                 IdNgram &id_comp,
                 const std::pair<int, int> &window){
     
-    if (tokens.size() == 0) return {}; // return empty vector for empty text
+    if (tokens.empty()) return {}; // return empty vector for empty text
     
     std::vector< std::vector<unsigned int> > tokens_multi(tokens.size()); 
     std::vector< bool > flags_match(tokens.size(), false); // flag matched tokens
@@ -115,7 +115,7 @@ Text match_comp(Text tokens,
     Text tokens_flat;
     tokens_flat.reserve(match);
     for (auto &tokens_sub: tokens_multi) {
-        if (tokens_sub.size() > 0) {
+        if (!tokens_sub.empty()) {
             tokens_flat.insert(tokens_flat.end(), tokens_sub.begin(), tokens_sub.begin() + 1);
         }
     }

--- a/src/tokens_lookup.cpp
+++ b/src/tokens_lookup.cpp
@@ -10,7 +10,7 @@ Text lookup(Text tokens,
             const int &nomatch,
             const MultiMapNgrams &map_keys){
     
-    if (tokens.size() == 0) return {}; // return empty vector for empty text
+    if (tokens.empty()) return {}; // return empty vector for empty text
     
     // Match flag for each token
     std::vector<bool> flags_match_global(tokens.size(), false);

--- a/src/tokens_ngrams.cpp
+++ b/src/tokens_ngrams.cpp
@@ -9,7 +9,7 @@ Text skipgram(const Text &tokens,
               MapNgrams &map_ngram,
               IdNgram &id_ngram) {
     
-    if (tokens.size() == 0) return {}; // return empty vector for empty text
+    if (tokens.empty()) return {}; // return empty vector for empty text
     
     // Pre-allocate memory
     int size_reserve = 0;

--- a/src/tokens_replace.cpp
+++ b/src/tokens_replace.cpp
@@ -8,7 +8,7 @@ Text replace(Text tokens,
              MapNgrams &map_pat,
              Ngrams &ids_repls){
     
-    if (tokens.size() == 0) return {}; // return empty vector for empty text
+    if (tokens.empty()) return {}; // return empty vector for empty text
     
     std::vector< std::vector<unsigned int> > tokens_multi(tokens.size()); 
     std::vector< bool > flags_match(tokens.size(), false); // flag matched tokens
@@ -46,7 +46,7 @@ Text replace(Text tokens,
     Text tokens_flat;
     tokens_flat.reserve(match);
     for (auto &tokens_sub: tokens_multi) {
-        if (tokens_sub.size() > 0) {
+        if (!tokens_sub.empty()) {
             tokens_flat.insert(tokens_flat.end(), tokens_sub.begin(), tokens_sub.end());
         }
         //dev::print_ngram(tokens_sub);

--- a/src/tokens_restore.cpp
+++ b/src/tokens_restore.cpp
@@ -8,7 +8,7 @@ Text join_mark(Text tokens,
                MapNgrams &map_comps,
                IdNgram &id_comp){
     
-    if (tokens.size() == 0) return {}; // return empty vector for empty text
+    if (tokens.empty()) return {}; // return empty vector for empty text
     
     std::vector< std::vector<unsigned int> > tokens_multi(tokens.size()); 
     std::vector< bool > flags_match(tokens.size(), false); // flag matched tokens
@@ -51,7 +51,7 @@ Text join_mark(Text tokens,
     Text tokens_flat;
     tokens_flat.reserve(match);
     for (auto &tokens_sub: tokens_multi) {
-        if (tokens_sub.size() > 0) {
+        if (!tokens_sub.empty()) {
             tokens_flat.insert(tokens_flat.end(), tokens_sub.begin(), tokens_sub.begin() + 1);
         }
     }

--- a/src/tokens_segment.cpp
+++ b/src/tokens_segment.cpp
@@ -15,7 +15,7 @@ Segments segment(Text tokens,
                 const bool &remove,
                 const int &position){
     
-    if(tokens.size() == 0) return {}; // return empty vector for empty text
+    if(tokens.empty()) return {}; // return empty vector for empty text
     
     Targets targets;
     for (std::size_t span : spans) { // substitution starts from the longest sequences
@@ -30,7 +30,7 @@ Segments segment(Text tokens,
     }
     
     Segments segments;
-    if (targets.size() == 0) {
+    if (targets.empty()) {
         segments.push_back(std::make_tuple(0, tokens.size() - 1, -1, -1));
         N++;
         return segments;
@@ -138,7 +138,7 @@ TokensPtr cpp_tokens_segment(TokensPtr xptr,
     std::size_t j = 0;
     for (std::size_t h = 0; h < temp.size(); h++) {
         Segments targets = temp[h];
-        if (targets.size() == 0) continue;
+        if (targets.empty()) continue;
         Text tokens = texts[h];
         for (size_t i = 0; i < targets.size(); i++) {
             Segment target = targets[i];

--- a/src/tokens_select.cpp
+++ b/src/tokens_select.cpp
@@ -12,7 +12,7 @@ Text keep_token(Text tokens,
           const std::pair<int, int> &window,
           const std::pair<int, int> &pos){
     
-    if (tokens.size() == 0) return {}; // return empty vector for empty text
+    if (tokens.empty()) return {}; // return empty vector for empty text
     
     const unsigned int filler = UINT_MAX; // use upper limit as a filler
     
@@ -74,7 +74,7 @@ Text remove_token(Text tokens,
             const std::pair<int, int> &window,
             const std::pair<int, int> &pos){
 
-    if (tokens.size() == 0) return {}; // return empty vector for empty text
+    if (tokens.empty()) return {}; // return empty vector for empty text
     
     unsigned int filler = UINT_MAX; // use upper limit as a filler
     Text tokens_copy = tokens;


### PR DESCRIPTION
See https://releases.llvm.org/5.0.1/tools/clang/tools/extra/docs/clang-tidy/checks/readability-container-size-empty.html.