### PR TITLE
Issue 2118

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -29,7 +29,7 @@
     - `ntype()` -- use `ntype(tokens(x))` instead; and. 
     - `ntoken()` -- use `ntoken(tokens(x))` instead.
 
-
+* `corpus.kwic()` is deprecated, with the suggestion to form a corpus from using `tokens_select(x, window = ...)` instead.
  
 ## Bug fixes and stability enhancements
 

--- a/R/corpus.R
+++ b/R/corpus.R
@@ -239,6 +239,7 @@ corpus.data.frame <- function(x, docid_field = "doc_id", text_field = "text",
 #'   "documents", one for "pre" and one for "post", with this designation saved
 #'   in a new docvar `context` and with the new number of documents
 #'   therefore being twice the number of rows in the kwic.
+#' @param concatenator character between tokens, default is the whitespace. 
 #' @param extract_keyword logical; if  `TRUE`, save the keyword matching
 #'   `pattern` as a new docvar `keyword`
 #' @examples
@@ -250,9 +251,20 @@ corpus.data.frame <- function(x, docid_field = "doc_id", text_field = "text",
 #' as.character(corpus(kw, split_context = FALSE))
 #'
 #' @export
-corpus.kwic <- function(x, split_context = TRUE, extract_keyword = TRUE, meta = list(), ...) {
+corpus.kwic <- function(x, split_context = TRUE, 
+                        extract_keyword = TRUE, meta = list(), 
+                        concatenator = " ",
+                        ...) {
+    
+    lifecycle::deprecate_warn(
+        when = "4.0", 
+        what = "corpus.kwic()",
+        details = 'Please use `tokens_select(window)` instead.'
+    )
+    
     split_context <- check_logical(split_context)
     extract_keyword <- check_logical(extract_keyword)
+    concatenator <- check_character(concatenator)
     check_dots(...)
     
     x <- as.data.frame(x)
@@ -271,7 +283,7 @@ corpus.kwic <- function(x, split_context = TRUE, extract_keyword = TRUE, meta = 
         result <- pre + post
         if (!extract_keyword) docvars(result, "keyword") <- NULL
     } else {
-        result <- corpus(paste0(x[["pre"]], x[["keyword"]], x[["post"]]),
+        result <- corpus(paste(x[["pre"]], x[["keyword"]], x[["post"]], sep = concatenator),
                          docnames = x[["docname"]], meta = meta, unique_docnames = FALSE)
         docnames(result) <- paste0(x[["docname"]], ".L", x[["from"]])
         if (extract_keyword) docvars(result, "keyword") <- x[["keyword"]]

--- a/man/corpus.Rd
+++ b/man/corpus.Rd
@@ -37,7 +37,14 @@ corpus(x, ...)
   ...
 )
 
-\method{corpus}{kwic}(x, split_context = TRUE, extract_keyword = TRUE, meta = list(), ...)
+\method{corpus}{kwic}(
+  x,
+  split_context = TRUE,
+  extract_keyword = TRUE,
+  meta = list(),
+  concatenator = " ",
+  ...
+)
 
 \method{corpus}{Corpus}(x, ...)
 }
@@ -81,6 +88,8 @@ therefore being twice the number of rows in the kwic.}
 
 \item{extract_keyword}{logical; if  \code{TRUE}, save the keyword matching
 \code{pattern} as a new docvar \code{keyword}}
+
+\item{concatenator}{character between tokens, default is the whitespace.}
 }
 \value{
 A \linkS4class{corpus} class object containing the original texts,

--- a/man/head.dfm.Rd
+++ b/man/head.dfm.Rd
@@ -13,7 +13,8 @@
 \item{x}{a \link{dfm} object}
 
 \item{n}{an integer vector of length up to \code{dim(x)} (or 1,
-    for non-dimensioned objects). Values specify the indices to be
+    for non-dimensioned objects).  A \code{logical} is silently coerced to
+    integer.  Values specify the indices to be
     selected in the corresponding dimension (or along the length) of the
     object. A positive value of \code{n[i]} includes the first/last
     \code{n[i]} indices in that dimension, while a negative value

--- a/man/head.dfm.Rd
+++ b/man/head.dfm.Rd
@@ -13,8 +13,7 @@
 \item{x}{a \link{dfm} object}
 
 \item{n}{an integer vector of length up to \code{dim(x)} (or 1,
-    for non-dimensioned objects).  A \code{logical} is silently coerced to
-    integer.  Values specify the indices to be
+    for non-dimensioned objects). Values specify the indices to be
     selected in the corresponding dimension (or along the length) of the
     object. A positive value of \code{n[i]} includes the first/last
     \code{n[i]} indices in that dimension, while a negative value

--- a/tests/testthat/test-corpus.R
+++ b/tests/testthat/test-corpus.R
@@ -64,12 +64,21 @@ test_that("corpus constructors works for kwic", {
     )
 
     # test text handling for punctuation - there should be no space before the ?
-    corp <- tokens(data_char_sampletext, what = "word", remove_separators = FALSE) |>
+    corp1 <- tokens(data_char_sampletext, what = "word", remove_separators = FALSE) |>
       kwic("econom*", window = 10, separator = "") |>
-      corpus(split_context = FALSE, extract_keyword = FALSE)
+      corpus(split_context = FALSE, extract_keyword = FALSE, concatenator = "")
     expect_identical(
-        as.character(corp)[2],
+        as.character(corp1)[2],
         c("text1.L390" = "it is decimating the domestic economy? As we are tired ")
+    )
+    
+    # concatenator is working
+    corp2 <- tokens(data_char_sampletext, what = "word", remove_separators = TRUE) |>
+        kwic("econom*", window = 5) |>
+        corpus(split_context = FALSE, extract_keyword = FALSE)
+    expect_identical(
+        as.character(corp2)[2],
+        c("text1.L202" = "it is decimating the domestic economy ? As we are tired")
     )
 
     # ; and !
@@ -77,7 +86,8 @@ test_that("corpus constructors works for kwic", {
     toks1 <- tokens(txt1, what = "word", remove_separators = FALSE)
     kw1 <- kwic(toks1, "a", window = 10, separator = "")
     expect_equivalent(
-        as.character(corpus(kw1, split_context = FALSE)), txt1
+        as.character(corpus(kw1, split_context = FALSE, concatenator = "")), 
+        txt1
     )
 
     # quotes
@@ -85,25 +95,29 @@ test_that("corpus constructors works for kwic", {
     toks2 <- tokens(txt2, what = "word", remove_separators = FALSE)
     kw2 <- kwic(toks2, "a", window = 10, separator = "")
     expect_equivalent(
-        as.character(corpus(kw2, split_context = FALSE)), txt2
+        as.character(corpus(kw2, split_context = FALSE, concatenator = "")), 
+        txt2
     )
     txt3 <- "This \"is\" only a test!"
     toks3 <- tokens(txt3, what = "word", remove_separators = FALSE)
     kw3 <- kwic(toks3, "a", window = 10, separator = "")
     expect_equivalent(
-        as.character(corpus(kw3, split_context = FALSE)), txt3
+        as.character(corpus(kw3, split_context = FALSE, concatenator = "")), 
+        txt3
     )
     txt4 <- 'This "is" only (a) test!'
     toks4 <- tokens(txt4, what = "word", remove_separators = FALSE)
     kw4 <- kwic(toks4, "a", window = 10, separator = "")
     expect_equivalent(
-        as.character(corpus(kw4, split_context = FALSE)), txt4
+        as.character(corpus(kw4, split_context = FALSE, concatenator = "")), 
+        txt4
     )
     txt5 <- "This is only (a) test!"
     toks5 <- tokens(txt5, what = "word", remove_separators = FALSE)
     kw5 <- kwic(toks5, "a", window = 10, separator = "")
     expect_equivalent(
-        as.character(corpus(kw5, split_context = FALSE)), txt5
+        as.character(corpus(kw5, split_context = FALSE, concatenator = "")), 
+        txt5
     )
     expect_error(corpus(kw, split_context = logical(), extract_keyword = FALSE))
     expect_error(corpus(kw, extract_keyword = logical()))

--- a/tests/testthat/test-corpus.R
+++ b/tests/testthat/test-corpus.R
@@ -40,6 +40,12 @@ test_that("print works", {
 test_that("corpus constructors works for kwic", {
     kw <- kwic(tokens(data_char_sampletext), "econom*")
 
+    # deprecated
+    lifecycle::expect_deprecated(
+        corpus(kw),
+        "`corpus.kwic()` was deprecated in quanteda 4.0.", fixed = TRUE
+    )
+    
     # split_context = TRUE, extract_keyword = TRUE
     corp <- corpus(kw, split_context = TRUE, extract_keyword = TRUE)
     expect_is(corp, "corpus")


### PR DESCRIPTION
I added `concatenator` to `corpus.kwic()` as in #2118. It might be nice to use `lifecycle::expect_deprecated()` in other tests too.