### PR TITLE
Fix error in cpp_index_type when vectos for types and patters are very large

### DIFF
--- a/man/head.dfm.Rd
+++ b/man/head.dfm.Rd
@@ -13,8 +13,7 @@
 \item{x}{a \link{dfm} object}
 
 \item{n}{an integer vector of length up to \code{dim(x)} (or 1,
-    for non-dimensioned objects).  A \code{logical} is silently coerced to
-    integer.  Values specify the indices to be
+    for non-dimensioned objects). Values specify the indices to be
     selected in the corresponding dimension (or along the length) of the
     object. A positive value of \code{n[i]} includes the first/last
     \code{n[i]} indices in that dimension, while a negative value

--- a/src/pattern2fixed.cpp
+++ b/src/pattern2fixed.cpp
@@ -125,11 +125,11 @@ List cpp_index_types(const CharacterVector &patterns_,
     Types types = Rcpp::as<Types>(types_);
     
     MapIndex index;
-    for (size_t j = 0; j < patterns.size(); j++) {// [[Rcpp::export]]
+    for (size_t j = 0; j < patterns.size(); j++) {
         size_t n = 1;
         // estimate number of the matches
         if (glob) {
-            int len utf8_length(patterns[j]);
+            int len = utf8_length(patterns[j]);
             if (len > 0)
                 n = types.size() ^ (1 / len);
         }

--- a/src/pattern2fixed.cpp
+++ b/src/pattern2fixed.cpp
@@ -125,8 +125,12 @@ List cpp_index_types(const CharacterVector &patterns_,
     Types types = Rcpp::as<Types>(types_);
     
     MapIndex index;
-    for (size_t j = 0; j < patterns.size(); j++) {
-        index[patterns[j]].reserve(types.size());
+    for (size_t j = 0; j < patterns.size(); j++) {// [[Rcpp::export]]
+        size_t n == 1;
+        int len utf8_length(patterns[j]);
+        if (len > 0)
+            size_t n = types.size() ^ (1 / len);
+        index[patterns[j]].reserve(n);
         //Rcout << "Register: " << patterns[j] << "\n";
     }
     Configs confs = parse_patterns(patterns, glob);

--- a/src/pattern2fixed.cpp
+++ b/src/pattern2fixed.cpp
@@ -127,7 +127,7 @@ List cpp_index_types(const CharacterVector &patterns_,
     MapIndex index;
     for (size_t j = 0; j < patterns.size(); j++) {
         size_t n = 1;
-        // estimate number of the matches
+        // estimate the number of matches
         if (glob) {
             int len = utf8_length(patterns[j]);
             if (len > 0)

--- a/src/pattern2fixed.cpp
+++ b/src/pattern2fixed.cpp
@@ -126,10 +126,13 @@ List cpp_index_types(const CharacterVector &patterns_,
     
     MapIndex index;
     for (size_t j = 0; j < patterns.size(); j++) {// [[Rcpp::export]]
-        size_t n == 1;
-        int len utf8_length(patterns[j]);
-        if (len > 0)
-            size_t n = types.size() ^ (1 / len);
+        size_t n = 1;
+        // estimate number of the matches
+        if (glob) {
+            int len utf8_length(patterns[j]);
+            if (len > 0)
+                n = types.size() ^ (1 / len);
+        }
         index[patterns[j]].reserve(n);
         //Rcout << "Register: " << patterns[j] << "\n";
     }

--- a/tests/testthat/test-pattern2fixed.R
+++ b/tests/testthat/test-pattern2fixed.R
@@ -124,10 +124,21 @@ test_that("pattern2fixed converts emoji correctly", {
 
 test_that("index_types works fine with empty types", {
 
-    expect_silent(index_types("a*", character(), 'glob', FALSE))
-    expect_silent(index_types("a*", character(), 'fixed', FALSE))
-    expect_silent(index_types("a*", character(), 'regex', FALSE))
+    expect_type(quanteda:::index_types("a*", character(), 'glob', FALSE),
+                "list")
+    expect_type(quanteda:::index_types("a*", character(), 'fixed', FALSE),
+                "list")
+    expect_type(quanteda:::index_types("a*", character(), 'regex', FALSE),
+                "list")
+})
+
+test_that("index_types works fine with large vectors", {
     
+    pat <- unique(stringi::stri_rand_strings(100000, 1:10))
+    type <- unique(stringi::stri_rand_strings(1000000, 1:10))
+    expect_type(quanteda:::index_types(pat, type, 'fixed', FALSE),
+                "list")
+
 })
 
 test_that("glob patterns that contain regex special characters works", {


### PR DESCRIPTION
This should not happen anymore
```
> pat <- stringi::stri_rand_strings(1000000, 1:10)
> type <- stringi::stri_rand_strings(1000000, 1:10)
> quanteda:::cpp_index_types(pat, type, FALSE)
Error: std::bad_alloc
```
