### PR TITLE
Fix regex for remove_url

### DIFF
--- a/R/tokenizers.R
+++ b/R/tokenizers.R
@@ -69,7 +69,7 @@ preserve_special <- function(x, split_hyphens = TRUE, split_tags = TRUE, verbose
     username <- quanteda_options("pattern_username")
     hashtag <- quanteda_options("pattern_hashtag")
     # preserves web and email address
-    address <- "(https?:\\/\\/(www\\.)?|@)[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-z]{2,4}\\b([-a-zA-Z0-9@:%_\\+.~#?&//=]*)"
+    address <- "(https?://|s?ftp://|www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-z]{2,4}\\b([-a-zA-Z0-9@:%_\\+.~#?&//=]*)"
 
     regex <- address
     if (!split_hyphens) {

--- a/R/tokens.R
+++ b/R/tokens.R
@@ -557,8 +557,8 @@ removals_regex <- function(separators = FALSE,
         regex[["symbols"]] <- "^\\p{S}$"
     if (numbers) # includes currency amounts and those containing , or . digit separators, and 100bn
         regex[["numbers"]] <- "^\\p{Sc}{0,1}\\p{N}+([.,]*\\p{N})*\\p{Sc}{0,1}$"
-    if (url)
-        regex[["url"]] <- "(?:^(?:https?://)?(?:www\\.)?[-a-zA-Z0-9]+(?:\\.[-a-zA-Z0-9]+)+(?:[/?#][-+a-zA-Z0-9@#:.%\\~=_\\&]+)*[/?#]?)|(^((https{0,1}|s{0,1}ftp)://))"
+    if (url) # the same patter for preserve_special
+        regex[["url"]] <- "(https?://|s?ftp://|www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-z]{2,4}\\b([-a-zA-Z0-9@:%_\\+.~#?&//=]*)"
     return(regex)
 }
 

--- a/tests/testthat/test-tokens-word4.R
+++ b/tests/testthat/test-tokens-word4.R
@@ -126,9 +126,9 @@ test_that("remove_url works as expected", {
              "www.r-project.org/about.html is a specific page without protocol",
              "https://www.google.com/search?q=quanteda+package is a google search",
              "ftp://user@host/foo/bar.txt is a FTP-hosted file",
-             "kohei.watanabe@quanteda.org is not an url")
-    toks <- tokens(txt) |> 
-        tokens_remove(c("^https?:", "^ftp:", "^www"), valuetype = "regex")
+             "kohei.watanabe@quanteda.org is an email address",
+             "The U.S. is not an url")
+    toks <- tokens(txt, remove_url = TRUE)
     expect_equal(
         as.list(toks),
         list(text1 = c("The", "URL", "was"),
@@ -137,7 +137,8 @@ test_that("remove_url works as expected", {
              text4 = c("is", "a", "specific", "page", "without", "protocol"),
              text5 = c("is", "a", "google", "search"),
              text6 = c("is", "a", "FTP-hosted", "file"),
-             text7 = c("kohei.watanabe@quanteda.org", "is", "not", "an", "url"))
+             text7 = c("is", "an", "email", "address"),
+             text8 = c("The", "U.S", ".", "is", "not", "an", "url"))
     )
 })
 


### PR DESCRIPTION
I noticed that the regex pattern induced in v.3.3 for `remove_url`  deletes acronyms.

```r
> tokens("the U.S. and Canada", remove_url = TRUE)
Tokens consisting of 1 document.
text1 :
[1] "the"    "."      "and"    "Canada"
```

The new pattern works like this, but I wonder if we want to remove email address. I so we need to updated the documentation.

```r
> txt <- c("The URL was http://t.co/something.",
+          "The URL was http://quanteda.io",
+          "https://github.com/quanteda/quanteda/issue/1 is another URL",
+          "www.r-project.org/about.html is a specific page without protocol",
+          "https://www.google.com/search?q=quanteda+package is a google search",
+          "ftp://user@host/foo/bar.txt is a FTP-hosted file",
+          "kohei.watanabe@quanteda.org is an email address",
+          "The U.S. is not an url")
> toks <- tokens(txt, remove_url = TRUE)
> as.list(toks)
$text1
[1] "The" "URL" "was"

$text2
[1] "The" "URL" "was"

$text3
[1] "is"      "another" "URL"    

$text4
[1] "is"       "a"        "specific" "page"     "without"  "protocol"

$text5
[1] "is"     "a"      "google" "search"

$text6
[1] "is"         "a"          "FTP-hosted" "file"      

$text7
[1] "is"      "an"      "email"   "address"

$text8
[1] "The" "."   "is"  "not" "an"  "url"
```