### PR TITLE
Fix time2

### DIFF
--- a/R/tokenizers.R
+++ b/R/tokenizers.R
@@ -69,8 +69,8 @@ preserve_special <- function(x, split_hyphens = TRUE, split_tags = TRUE, verbose
     username <- quanteda_options("pattern_username")
     hashtag <- quanteda_options("pattern_hashtag")
     # preserves web and email address
-    address <- "(https?://|s?ftp://|www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-z]{2,4}\\b([-a-zA-Z0-9@:%_\\+.~#?&//=]*)"
-
+    address <- "(https?:\\/\\/(www\\.)?|@)[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-z]{2,4}\\b([-a-zA-Z0-9@:%_\\+.~#?&//=]*)"
+    
     regex <- address
     if (!split_hyphens) {
         if (verbose) catm(" ...preserving hyphens\n")

--- a/R/tokenizers.R
+++ b/R/tokenizers.R
@@ -159,7 +159,7 @@ tokenize_word4 <- function(x, split_hyphens = FALSE, split_tags = FALSE, split_e
     hashtag <- quanteda_options("pattern_hashtag")
     
     ftp <- "s?ftp://[-+a-zA-Z0-9@#:.%~=_&/]+"
-    http <- "(https?://)?(www.)?[-a-zA-Z0-9]+(\\.[-a-zA-Z0-9]+)+([/?#][-+a-zA-Z0-9@#:.%~=_&]+)*[/?#]?"
+    http <- "(https?://|www\\.)[-a-zA-Z0-9]+(\\.[-a-zA-Z0-9]+)+([/?#][-+a-zA-Z0-9@#:.%~=_&]+)*[/?#]?"
     email <- "[-+a-zA-Z0-9_.]+@[-a-zA-Z0-9]+(\\.[-a-zA-Z0-9]+)*\\.[a-z]+"
     regex <- c(email, ftp, http)
     if (!split_tags) {

--- a/R/tokens.R
+++ b/R/tokens.R
@@ -161,9 +161,11 @@ tokens <-  function(x,
                     verbose = quanteda_options("verbose"),
                     ...,
                     xptr = FALSE) {
-    global$proc_time <- proc.time()
-    if (is.null(global$object_class))
+    
+    if (is.null(global$object_class)) {
         global$object_class <- class(x)[1]
+        global$proc_time <- proc.time()   
+    }
     UseMethod("tokens")
 }
 

--- a/R/tokens.R
+++ b/R/tokens.R
@@ -559,8 +559,8 @@ removals_regex <- function(separators = FALSE,
         regex[["symbols"]] <- "^\\p{S}$"
     if (numbers) # includes currency amounts and those containing , or . digit separators, and 100bn
         regex[["numbers"]] <- "^\\p{Sc}{0,1}\\p{N}+([.,]*\\p{N})*\\p{Sc}{0,1}$"
-    if (url) # the same patter for preserve_special
-        regex[["url"]] <- "(https?://|s?ftp://|www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-z]{2,4}\\b([-a-zA-Z0-9@:%_\\+.~#?&//=]*)"
+    if (url) 
+        regex[["url"]] <- "^(https?://|s?ftp://|www\\.)|^([-+a-zA-Z0-9_.]+@[-a-zA-Z0-9]+(\\.[-a-zA-Z0-9]+)*\\.[a-z]+)$"
     return(regex)
 }
 


### PR DESCRIPTION
I noticed that the regex for URLs is causing too many false matches. 
```r
> library(quanteda)
Package version: 4.0.0
Unicode version: 15.1
ICU version: 74.1
Parallel computing: 16 of 16 threads used.
See https://quanteda.io for tutorials and examples.
> require(stringi)
Loading required package: stringi
> require(quanteda)
> 
> http_old <- "(https?://)?(www.)?[-a-zA-Z0-9]+(\\.[-a-zA-Z0-9]+)+([/?#][-+a-zA-Z0-9@#:.%~=_&]+)*[/?#]?"
> http_new <- "(https?://|www\\.)[-a-zA-Z0-9]+(\\.[-a-zA-Z0-9]+)+([/?#][-+a-zA-Z0-9@#:.%~=_&]+)*[/?#]?"
> 
> corp <- data_corpus_inaugural
> microbenchmark::microbenchmark(
+     stri_extract_all_regex(corp, http_old),
+     stri_extract_all_regex(corp, http_new),
+     times = 10
+ )
Unit: milliseconds
                                   expr      min       lq      mean   median       uq      max
 stri_extract_all_regex(corp, http_old) 171.3431 172.1301 177.32917 174.5887 174.8342 207.1841
 stri_extract_all_regex(corp, http_new)   7.0310   7.2036   7.53631   7.2604   7.6251   9.1637
 neval
    10
    10
```

I also fixed the elapsed time in the verbose message.
```r
> system.time(
+ out <- tokens(corp2, verbose = TRUE)
+ )
Creating a tokens from a corpus object...
 ...starting tokenization
 ...tokenizing 1 of 1 blocks
 ...preserving hyphens
 ...preserving elisions
 ...preserving social media tags (#, @)
 ...removing separators 
 ...610,061 unique types
 ...complete, elapsed time: 83.1 seconds.
Finished constructing tokens from 78,646 documents.

   user  system elapsed 
 117.55    8.23   83.09 
```