### PR TITLE
Save tokenizer

### DIFF
--- a/R/meta.R
+++ b/R/meta.R
@@ -264,6 +264,7 @@ make_meta_tokens <- function(inherit = NULL, ...) {
     default <- list(
         "unit" = "documents",
         "what" = "word",
+        "tokenizer" = "tokenizer_word",
         "ngram" = 1L,
         "skip" = 0L,
         "concatenator" = "_",
@@ -280,6 +281,7 @@ make_meta_dfm <- function(inherit = NULL, ...) {
     default <- list(
         "unit" = "documents",
         "what" = "word",
+        "tokenizer" = "tokenizer_word",
         "ngram" = 1L,
         "skip" = 0L,
         "concatenator" = "_",

--- a/R/meta.R
+++ b/R/meta.R
@@ -264,7 +264,7 @@ make_meta_tokens <- function(inherit = NULL, ...) {
     default <- list(
         "unit" = "documents",
         "what" = "word",
-        "tokenizer" = "tokenizer_word",
+        "tokenizer" = "tokenize_word",
         "ngram" = 1L,
         "skip" = 0L,
         "concatenator" = "_",
@@ -281,7 +281,7 @@ make_meta_dfm <- function(inherit = NULL, ...) {
     default <- list(
         "unit" = "documents",
         "what" = "word",
-        "tokenizer" = "tokenizer_word",
+        "tokenizer" = "tokenize_word",
         "ngram" = 1L,
         "skip" = 0L,
         "concatenator" = "_",
@@ -303,6 +303,7 @@ make_meta_fcm <- function(inherit = NULL, ...) {
         "unit" = "documents",
         "concatenator" = "_",
         "what" = "word",
+        "tokenizer" = "tokenize_word",
         "context" = "document", 
         "window" = 5L,
         "count" = "frequency",

--- a/R/tokens-methods.R
+++ b/R/tokens-methods.R
@@ -218,6 +218,7 @@ c.tokens_xptr <- function(...) {
     build_tokens(
         temp, types = NULL,
         what = field_object(attrs[[1]], "what"),
+        tokenizer = field_object(attrs[[1]], "tokenizer"),
         ngram = sort(unique(ngram)),
         skip = sort(unique(skip)),
         concatenator = field_object(attrs[[1]], "concatenator"),

--- a/R/tokens.R
+++ b/R/tokens.R
@@ -333,6 +333,7 @@ tokens.corpus <- function(x,
         result, 
         types = NULL, 
         what = what,
+        tokenizer = tokenizer,
         docvars = select_docvars(attrs[["docvars"]], user = include_docvars, system = TRUE),
         meta = attrs[["meta"]]
     )

--- a/tests/testthat/test-tokens.R
+++ b/tests/testthat/test-tokens.R
@@ -519,6 +519,7 @@ test_that("combined tokens objects have all the attributes", {
     expect_identical(names(attributes(c(toks1, toks4))),
                      names(attributes(toks1)))
     expect_identical(attr(c(toks1, toks4), "meta")$object$what, "word")
+    expect_identical(attr(c(toks1, toks4), "meta")$object$tokenizer, "tokenize_word3")
     expect_identical(attr(c(toks1, toks4), "meta")$object$concatenator, "_")
     expect_identical(attr(c(toks1, toks4), "meta")$object$ngram, c(1L))
     expect_identical(attr(c(toks1, toks4), "meta")$object$skip, c(0L))
@@ -527,6 +528,7 @@ test_that("combined tokens objects have all the attributes", {
     expect_identical(names(attributes(c(toks1, toks5))),
                      names(attributes(toks1)))
     expect_identical(attr(c(toks1, toks5), "meta")$object$what, "word")
+    expect_identical(attr(c(toks1, toks5), "meta")$object$tokenizer, "tokenize_word3")
     expect_identical(attr(c(toks1, toks5), "meta")$object$concatenator, "_")
     expect_identical(attr(c(toks1, toks5), "meta")$object$ngram, 1L)
     expect_identical(attr(c(toks1, toks5), "meta")$object$skip, 0L)


### PR DESCRIPTION
Address #2313. We might want to drop `what` from the object meta fields because it is unreliable and redundant.