### PR TITLE
Issue 2331

### DIFF
--- a/R/corpus_trim.R
+++ b/R/corpus_trim.R
@@ -6,7 +6,9 @@
 #' @param what units of trimming, `"sentences"` or `"paragraphs"`, or
 #'   `"documents"`
 #' @param min_ntoken,max_ntoken minimum and maximum lengths in word tokens
-#'   (excluding punctuation)
+#'   (excluding punctuation).  Note that these are approximate numbers of tokens
+#'   based on checking for word boundaries, rather than on-the-fly full
+#'   tokenisation.
 #' @param exclude_pattern a \pkg{stringi} regular expression whose match (at the
 #'   sentence level) will be used to exclude sentences
 #' @return a [corpus] or character vector equal in length to the input.  If

--- a/R/corpus_trim.R
+++ b/R/corpus_trim.R
@@ -41,6 +41,8 @@ corpus_trim.corpus <- function(x, what = c("sentences", "paragraphs", "documents
     x <- as.corpus(x)
     what <- match.arg(what)
     min_ntoken <- check_integer(min_ntoken, min = 0)
+    max_ntoken <- check_integer(max_ntoken, allow_null = TRUE)
+    exclude_pattern <- check_character(exclude_pattern, allow_null = TRUE)
 
     # segment corpus
     temp <- corpus_reshape(x, to = what)
@@ -49,17 +51,13 @@ corpus_trim.corpus <- function(x, what = c("sentences", "paragraphs", "documents
         return(x)
     
     # exclude based on lengths
-    len <- ntoken(tokens(temp, remove_punct = TRUE))
-    if (!is.null(max_ntoken)) {
-        max_ntoken <- check_integer(max_ntoken)
-    } else {
+    len <- stringi::stri_count_boundaries(temp, type = "word", skip_word_none = TRUE)
+    if (is.null(max_ntoken))
         max_ntoken <- max(len)
-    }
     result <- corpus_subset(temp, len >= min_ntoken & len <= max_ntoken)
 
     # exclude based on regular expression match
     if (!is.null(exclude_pattern)) {
-        exclude_pattern <- check_character(exclude_pattern)
         is_pattern <- stri_detect_regex(result, exclude_pattern)
         result <- corpus_subset(result, !is_pattern)
     }

--- a/R/tokens_ngrams.R
+++ b/R/tokens_ngrams.R
@@ -66,7 +66,7 @@ char_ngrams.default <- function(x, n = 2L, skip = 0L, concatenator = "_") {
 char_ngrams.character <- function(x, n = 2L, skip = 0L, concatenator = "_") {
     lifecycle::deprecate_soft("4.0.0", 
                               I('char_ngrams()'), 
-                              I('tokens_ngram(tokens(x))'))
+                              I('`tokens_ngram(tokens(x))`'))
     if (any(stringi::stri_detect_charclass(x, "\\p{Z}")) & concatenator != " ")
         warning("whitespace detected: you may need to run tokens() first")
     x <- as.tokens(list(x))

--- a/R/tokens_ngrams.R
+++ b/R/tokens_ngrams.R
@@ -64,6 +64,9 @@ char_ngrams.default <- function(x, n = 2L, skip = 0L, concatenator = "_") {
 
 #' @export
 char_ngrams.character <- function(x, n = 2L, skip = 0L, concatenator = "_") {
+    lifecycle::deprecate_soft("4.0.0", 
+                              I('char_ngrams()'), 
+                              I('tokens_ngram(tokens(x))'))
     if (any(stringi::stri_detect_charclass(x, "\\p{Z}")) & concatenator != " ")
         warning("whitespace detected: you may need to run tokens() first")
     x <- as.tokens(list(x))

--- a/man/corpus_trim.Rd
+++ b/man/corpus_trim.Rd
@@ -28,7 +28,9 @@ char_trim(
 \code{"documents"}}
 
 \item{min_ntoken, max_ntoken}{minimum and maximum lengths in word tokens
-(excluding punctuation)}
+(excluding punctuation).  Note that these are approximate numbers of tokens
+based on checking for word boundaries, rather than on-the-fly full
+tokenisation.}
 
 \item{exclude_pattern}{a \pkg{stringi} regular expression whose match (at the
 sentence level) will be used to exclude sentences}

--- a/tests/testthat/test-lifecycle-changes.R
+++ b/tests/testthat/test-lifecycle-changes.R
@@ -81,7 +81,7 @@ test_that("char_ngrams produces a deprecated message", {
     txt <- c('insurgents','killed', 'in', 'ongoing', 'fighting')
     expect_warning(
         char_ngrams(txt),
-        "`char_ngrams()` was deprecated in quanteda 4.0",
+        "char_ngrams() was deprecated in quanteda 4.0",
         fixed = TRUE
     )
 })

--- a/tests/testthat/test-lifecycle-changes.R
+++ b/tests/testthat/test-lifecycle-changes.R
@@ -77,6 +77,15 @@ test_that("texts produces a defunct message", {
     )
 })
 
+test_that("char_ngrams produces a deprecated message", {
+    txt <- c('insurgents','killed', 'in', 'ongoing', 'fighting')
+    expect_warning(
+        char_ngrams(txt),
+        "`char_ngrams()` was deprecated in quanteda 4.0",
+        fixed = TRUE
+    )
+})
+
 test_that("nsentence produces a deprecated message", {
     skip_if_not_installed("rlang")
     rlang::local_options(lifecycle_verbosity = "warning")

--- a/tests/testthat/test-lifecycle-changes.R
+++ b/tests/testthat/test-lifecycle-changes.R
@@ -79,7 +79,7 @@ test_that("texts produces a defunct message", {
 
 test_that("char_ngrams produces a deprecated message", {
     txt <- c('insurgents','killed', 'in', 'ongoing', 'fighting')
-    expect_warning(
+    lifecycle::expect_deprecated(
         char_ngrams(txt),
         "char_ngrams() was deprecated in quanteda 4.0",
         fixed = TRUE
@@ -89,7 +89,7 @@ test_that("char_ngrams produces a deprecated message", {
 test_that("nsentence produces a deprecated message", {
     skip_if_not_installed("rlang")
     rlang::local_options(lifecycle_verbosity = "warning")
-    expect_warning(
+    lifecycle::expect_deprecated(
         nsentence("This is one.  And two."),
         "`nsentence()` was deprecated in quanteda 4.0",
         fixed = TRUE

--- a/tests/testthat/test-tokens_ngrams.R
+++ b/tests/testthat/test-tokens_ngrams.R
@@ -52,7 +52,6 @@ test_that("char_ngrams works", {
         c('insurgents_killed', 'killed_in', 'in_ongoing', 'ongoing_fighting')
     )
     
-
     expect_warning(char_ngrams(c('insurgents killed', 'in', 'ongoing', 'fighting')), 
                  "whitespace detected: you may need to run tokens\\(\\) first")
 })

--- a/tests/testthat/test-tokens_recompile.R
+++ b/tests/testthat/test-tokens_recompile.R
@@ -73,31 +73,6 @@ test_that("tokens_recompile: preserves encoding", {
     )
 })
 
-test_that("tokens_recompile: ngrams", {
-    toks <- tokens(c(one = "a b c"))
-
-    expect_equal(
-        as.list(tokens_ngrams(toks, 2:3)),
-        list(one = c("a_b", "b_c", "a_b_c"))
-    )
-
-    expect_equal(
-        attributes(tokens_ngrams(toks, 2:3, concatenator = " "))$meta$object$concatenator,
-        " "
-    )
-
-    expect_equal(
-        attributes(tokens_ngrams(toks, 2:3, concatenator = " "))$meta$object$ngram,
-        2L:3L
-    )
-
-    attr(toks, "types") <- char_ngrams(attr(toks, "types"), 2:3)
-    expect_equal(
-        quanteda:::tokens_recompile(toks, method = "R"),
-        quanteda:::tokens_recompile(toks, method = "C++")
-    )
-})
-
 test_that("tokens_recompile: [ works for tokens", {
     toks <- tokens(c(one = "a b c d",
                      two = "x y z",


### PR DESCRIPTION
Deprecated `char_ngrams()` and remove `tokens()` from `corpus_trim()` for #2331.