### PR TITLE
Add remove_padding to ntoken()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,8 @@
 
 * Added new arguments `append_key`, `separator` and `concatenator` to `tokens_lookup()`. These allow tokens matched by dictionary values to be retained with their keys appended to them, separated by `separator`.  The addition of the `concatenator` argument allows additional control at the lookup stage for tokens that will be concatenated from having matched multi-word dictionary values. (#2324)
 
+* Added a new argument `remove_padding` to `ntoken()` that allows for not counting padding that might have been left over from `tokens_remove(x, padding = TRUE`). (#2336)
+
 ## Removals
 
 * `bootstrap_dfm()` was removed for character and corpus objects.  The correct way to bootstrap sentences is not to tokenize them as sentences and then bootstrap them from the dfm.  This is consistent with requiring the user to tokenise objects prior to forming dfms or other "downstream" objects.

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -89,8 +89,8 @@ cpp_ndoc <- function(xptr) {
     .Call(`_quanteda_cpp_ndoc`, xptr)
 }
 
-cpp_ntoken <- function(xptr) {
-    .Call(`_quanteda_cpp_ntoken`, xptr)
+cpp_ntoken <- function(xptr, padding = TRUE) {
+    .Call(`_quanteda_cpp_ntoken`, xptr, padding)
 }
 
 cpp_ntype <- function(xptr) {

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -93,8 +93,8 @@ cpp_ntoken <- function(xptr, padding = TRUE) {
     .Call(`_quanteda_cpp_ntoken`, xptr, padding)
 }
 
-cpp_ntype <- function(xptr) {
-    .Call(`_quanteda_cpp_ntype`, xptr)
+cpp_ntype <- function(xptr, padding = TRUE) {
+    .Call(`_quanteda_cpp_ntype`, xptr, padding)
 }
 
 cpp_get_types <- function(xptr, recompile = FALSE) {

--- a/R/nfunctions.R
+++ b/R/nfunctions.R
@@ -130,8 +130,7 @@ ntoken.character <- function(x, ...) {
 
 #' @export
 ntoken.tokens <- function(x, remove_padding = FALSE, ...) {
-    check_dots(...)
-    ntoken(as.tokens_xptr(x), remove_padding)
+    ntoken(as.tokens_xptr(x), remove_padding, ...)
 }
 
 #' @export

--- a/R/nfunctions.R
+++ b/R/nfunctions.R
@@ -72,7 +72,7 @@ nfeat.dfm <- function(x) {
 #'
 #' Get the count of tokens (total features) or types (unique tokens).
 #' @param x a \pkg{quanteda} [tokens] or [dfm] object
-#' @param ... not used
+#' @param ... additional arguments passed to `tokens()`
 #' @returns `ntoken()` returns a named integer vector of the counts of the total
 #'   tokens
 #' @examples
@@ -98,21 +98,6 @@ ntoken <- function(x, ...) {
 #' @export
 ntoken.default <- function(x, ...) {
     check_class(class(x), "ntoken")
-}
-
-#' @rdname ntoken
-#' @returns
-#' `ntypes()` returns a named integer vector of the counts of the types (unique
-#' tokens) per document.  For [dfm] objects, `ntype()` will only return the
-#' count of features that occur more than zero times in the dfm.
-#' @export
-ntype <- function(x, ...) {
-    UseMethod("ntype")
-}
-
-#' @export
-ntype.default <- function(x, ...) {
-    check_class(class(x), "ntype")
 }
 
 #' @export
@@ -144,6 +129,21 @@ ntoken.dfm <- function(x, ...) {
     result
 }
 
+#' @rdname ntoken
+#' @returns
+#' `ntypes()` returns a named integer vector of the counts of the types (unique
+#' tokens) per document.  For [dfm] objects, `ntype()` will only return the
+#' count of features that occur more than zero times in the dfm.
+#' @export
+ntype <- function(x, ...) {
+    UseMethod("ntype")
+}
+
+#' @export
+ntype.default <- function(x, ...) {
+    check_class(class(x), "ntype")
+}
+
 #' @export
 ntype.character <- function(x, ...) {
     lifecycle::deprecate_soft("4.0.0", 
@@ -173,10 +173,8 @@ ntype.dfm <- function(x, ...) {
 }
 
 #' @export
-ntype.tokens <- function(x, ...) {
-    if (length(list(...)))
-        x <- tokens(x, ...)
-    vapply(unclass(x), function(y) length(unique(y[y > 0])), integer(1))
+ntype.tokens <- function(x, remove_padding = FALSE, ...) {
+    ntype(as.tokens_xptr(x), remove_padding, ...)
 }
 
 

--- a/R/nfunctions.R
+++ b/R/nfunctions.R
@@ -129,13 +129,9 @@ ntoken.character <- function(x, ...) {
 }
 
 #' @export
-ntoken.tokens <- function(x, ...) {
-    x <- as.tokens(x)
-    if (length(list(...))) {
-        lengths(tokens(x, ...))
-    } else {
-        lengths(x)
-    }
+ntoken.tokens <- function(x, remove_padding = FALSE, ...) {
+    check_dots(...)
+    ntoken(as.tokens_xptr(x), remove_padding)
 }
 
 #' @export

--- a/R/tokens_xptr.R
+++ b/R/tokens_xptr.R
@@ -98,9 +98,10 @@ ntype.tokens_xptr <- function(x, ...) {
 }
 
 #' @export
-ntoken.tokens_xptr <- function(x, ...) {
+ntoken.tokens_xptr <- function(x, remove_padding = FALSE, ...) {
     check_dots(...)
-    structure(cpp_ntoken(x), names = docnames(x))
+    remove_padding <- check_logical(remove_padding)
+    structure(cpp_ntoken(x, !remove_padding), names = docnames(x))
 }
 
 # #' @export

--- a/R/tokens_xptr.R
+++ b/R/tokens_xptr.R
@@ -99,8 +99,9 @@ ntype.tokens_xptr <- function(x, ...) {
 
 #' @export
 ntoken.tokens_xptr <- function(x, remove_padding = FALSE, ...) {
-    check_dots(...)
     remove_padding <- check_logical(remove_padding)
+    if (length(list(...))) # TODO: deprecate ...
+        x <- tokens(as.tokens_xptr(x), ...) 
     structure(cpp_ntoken(x, !remove_padding), names = docnames(x))
 }
 

--- a/R/tokens_xptr.R
+++ b/R/tokens_xptr.R
@@ -92,15 +92,17 @@ concat.tokens_xptr <- function(x) {
 }
 
 #' @export
-ntype.tokens_xptr <- function(x, ...) {
-    check_dots(...)
-    structure(cpp_ntype(x), names = docnames(x))
+ntype.tokens_xptr <- function(x, remove_padding = FALSE, ...) {
+    remove_padding <- check_logical(remove_padding)
+    if (length(list(...)))
+        x <- tokens(as.tokens_xptr(x), ...) 
+    structure(cpp_ntype(x, !remove_padding), names = docnames(x))
 }
 
 #' @export
 ntoken.tokens_xptr <- function(x, remove_padding = FALSE, ...) {
     remove_padding <- check_logical(remove_padding)
-    if (length(list(...))) # TODO: deprecate ...
+    if (length(list(...)))
         x <- tokens(as.tokens_xptr(x), ...) 
     structure(cpp_ntoken(x, !remove_padding), names = docnames(x))
 }

--- a/man/head.dfm.Rd
+++ b/man/head.dfm.Rd
@@ -13,8 +13,7 @@
 \item{x}{a \link{dfm} object}
 
 \item{n}{an integer vector of length up to \code{dim(x)} (or 1,
-    for non-dimensioned objects).  A \code{logical} is silently coerced to
-    integer.  Values specify the indices to be
+    for non-dimensioned objects). Values specify the indices to be
     selected in the corresponding dimension (or along the length) of the
     object. A positive value of \code{n[i]} includes the first/last
     \code{n[i]} indices in that dimension, while a negative value

--- a/man/ntoken.Rd
+++ b/man/ntoken.Rd
@@ -12,7 +12,7 @@ ntype(x, ...)
 \arguments{
 \item{x}{a \pkg{quanteda} \link{tokens} or \link{dfm} object}
 
-\item{...}{not used}
+\item{...}{additional arguments passed to \code{tokens()}}
 }
 \value{
 \code{ntoken()} returns a named integer vector of the counts of the total

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -317,13 +317,14 @@ BEGIN_RCPP
 END_RCPP
 }
 // cpp_ntoken
-IntegerVector cpp_ntoken(TokensPtr xptr);
-RcppExport SEXP _quanteda_cpp_ntoken(SEXP xptrSEXP) {
+IntegerVector cpp_ntoken(TokensPtr xptr, bool padding);
+RcppExport SEXP _quanteda_cpp_ntoken(SEXP xptrSEXP, SEXP paddingSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< TokensPtr >::type xptr(xptrSEXP);
-    rcpp_result_gen = Rcpp::wrap(cpp_ntoken(xptr));
+    Rcpp::traits::input_parameter< bool >::type padding(paddingSEXP);
+    rcpp_result_gen = Rcpp::wrap(cpp_ntoken(xptr, padding));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -484,7 +485,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_quanteda_cpp_as_list", (DL_FUNC) &_quanteda_cpp_as_list, 1},
     {"_quanteda_cpp_subset", (DL_FUNC) &_quanteda_cpp_subset, 2},
     {"_quanteda_cpp_ndoc", (DL_FUNC) &_quanteda_cpp_ndoc, 1},
-    {"_quanteda_cpp_ntoken", (DL_FUNC) &_quanteda_cpp_ntoken, 1},
+    {"_quanteda_cpp_ntoken", (DL_FUNC) &_quanteda_cpp_ntoken, 2},
     {"_quanteda_cpp_ntype", (DL_FUNC) &_quanteda_cpp_ntype, 1},
     {"_quanteda_cpp_get_types", (DL_FUNC) &_quanteda_cpp_get_types, 2},
     {"_quanteda_cpp_set_types", (DL_FUNC) &_quanteda_cpp_set_types, 2},

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -329,13 +329,14 @@ BEGIN_RCPP
 END_RCPP
 }
 // cpp_ntype
-IntegerVector cpp_ntype(TokensPtr xptr);
-RcppExport SEXP _quanteda_cpp_ntype(SEXP xptrSEXP) {
+IntegerVector cpp_ntype(TokensPtr xptr, bool padding);
+RcppExport SEXP _quanteda_cpp_ntype(SEXP xptrSEXP, SEXP paddingSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< TokensPtr >::type xptr(xptrSEXP);
-    rcpp_result_gen = Rcpp::wrap(cpp_ntype(xptr));
+    Rcpp::traits::input_parameter< bool >::type padding(paddingSEXP);
+    rcpp_result_gen = Rcpp::wrap(cpp_ntype(xptr, padding));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -486,7 +487,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_quanteda_cpp_subset", (DL_FUNC) &_quanteda_cpp_subset, 2},
     {"_quanteda_cpp_ndoc", (DL_FUNC) &_quanteda_cpp_ndoc, 1},
     {"_quanteda_cpp_ntoken", (DL_FUNC) &_quanteda_cpp_ntoken, 2},
-    {"_quanteda_cpp_ntype", (DL_FUNC) &_quanteda_cpp_ntype, 1},
+    {"_quanteda_cpp_ntype", (DL_FUNC) &_quanteda_cpp_ntype, 2},
     {"_quanteda_cpp_get_types", (DL_FUNC) &_quanteda_cpp_get_types, 2},
     {"_quanteda_cpp_set_types", (DL_FUNC) &_quanteda_cpp_set_types, 2},
     {"_quanteda_cpp_recompile", (DL_FUNC) &_quanteda_cpp_recompile, 1},

--- a/src/tokens_xptr.cpp
+++ b/src/tokens_xptr.cpp
@@ -55,13 +55,23 @@ int cpp_ndoc(TokensPtr xptr) {
 
 
 // [[Rcpp::export]]
-IntegerVector cpp_ntoken(TokensPtr xptr) {
-    //Rcout << "cpp_ntoken()\n";
+IntegerVector cpp_ntoken(TokensPtr xptr, bool padding = true) {
     xptr->recompile();
     std::size_t H = xptr->texts.size();
-    IntegerVector ls_(H);
-    for (std::size_t h = 0; h < H; h++) {
-        ls_[h] = xptr->texts[h].size();
+    IntegerVector ls_(H, 0);
+    if (padding) { 
+        for (std::size_t h = 0; h < H; h++) {
+            ls_[h] = xptr->texts[h].size();
+        }
+    } else {
+        for (std::size_t h = 0; h < H; h++) {
+            std::size_t I = xptr->texts[h].size();
+            for (std::size_t i = 0; i < I; i++) {
+                // ignore paddings
+                if (xptr->texts[h][i] > 0)
+                    ls_[h]++;
+            }    
+        }
     }
     return ls_;
 }

--- a/src/tokens_xptr.cpp
+++ b/src/tokens_xptr.cpp
@@ -77,7 +77,7 @@ IntegerVector cpp_ntoken(TokensPtr xptr, bool padding = true) {
 }
 
 // [[Rcpp::export]]
-IntegerVector cpp_ntype(TokensPtr xptr) {
+IntegerVector cpp_ntype(TokensPtr xptr, bool padding = true) {
     xptr->recompile();
     std::size_t H = xptr->texts.size();
     IntegerVector ns_(H);
@@ -86,7 +86,7 @@ IntegerVector cpp_ntype(TokensPtr xptr) {
         std::sort(text.begin(), text.end());
         text.erase(unique(text.begin(), text.end()), text.end());
         int n = text.size();
-        if (text[0] == 0)
+        if (text[0] == 0 && !padding)
             n--;    
         ns_[h] = n;
     }

--- a/tests/testthat/test-nfunctions.R
+++ b/tests/testthat/test-nfunctions.R
@@ -57,23 +57,23 @@ test_that("test ntype tokens", {
     expect_identical(ntype(toks2), c(d1 = 2L, d2 = 4L))
 })
 
-# test_that("dots are applied in ntokens.tokens, ntype.tokens", {
-#     txt <- c(d1 = "3 wonderful tokens of the tokens function.")
-#     toks <- tokens(txt)
-#     
-#     expect_identical(ntoken(toks), c(d1 = 8L))
-#     expect_identical(ntoken(toks, remove_punct = TRUE), c(d1 = 7L))
-#     expect_identical(ntoken(toks, remove_punct = TRUE, remove_numbers = TRUE), c(d1 = 6L))
-#     expect_warning(ntoken(toks, notarg = TRUE), "^notarg argument is not used")
-#     
-#     expect_identical(ntype(toks), c(d1 = 7L))
-#     expect_identical(ntype(toks, remove_punct = TRUE), c(d1 = 6L))
-#     expect_identical(ntype(toks, remove_punct = TRUE, remove_numbers = TRUE), c(d1 = 5L))
-#     expect_warning(ntype(toks, notarg = TRUE), "^notarg argument is not used")
-#     
-#     suppressWarnings(expect_identical(ntype(txt, remove_punct = TRUE), c(d1 = 6L)))
-#     expect_identical(ntype(txt), c(d1 = 7L))
-# })
+test_that("dots are applied in ntokens.tokens, ntype.tokens", {
+    txt <- c(d1 = "3 wonderful tokens of the tokens function.")
+    toks <- tokens(txt)
+
+    expect_identical(ntoken(toks), c(d1 = 8L))
+    expect_identical(ntoken(toks, remove_punct = TRUE), c(d1 = 7L))
+    expect_identical(ntoken(toks, remove_punct = TRUE, remove_numbers = TRUE), c(d1 = 6L))
+    expect_warning(ntoken(toks, notarg = TRUE), "^notarg argument is not used")
+
+    expect_identical(ntype(toks), c(d1 = 7L))
+    expect_identical(ntype(toks, remove_punct = TRUE), c(d1 = 6L))
+    expect_identical(ntype(toks, remove_punct = TRUE, remove_numbers = TRUE), c(d1 = 5L))
+    expect_warning(ntype(toks, notarg = TRUE), "^notarg argument is not used")
+
+    suppressWarnings(expect_identical(ntype(txt, remove_punct = TRUE), c(d1 = 6L)))
+    expect_identical(ntype(txt), c(d1 = 7L))
+})
 
 test_that("test nsentence", {
     txt <- c(doc1 = "This is Mr. Smith.  He is married to Mrs. Jones.",

--- a/tests/testthat/test-nfunctions.R
+++ b/tests/testthat/test-nfunctions.R
@@ -32,9 +32,17 @@ test_that("test ntype with dfm (#748)", {
 test_that("test ntoken tokens", {
     txt <- c(d1 = "a b c a b c", 
              d2 = "a b c d e")
-    crp <- corpus(txt)
-    suppressWarnings(expect_identical(ntoken(txt), c(d1 = 6L, d2 = 5L)))
-    expect_identical(ntoken(crp), c(d1 = 6L, d2 = 5L))
+    corp <- corpus(txt)
+    toks <- tokens(corp)
+    toks2 <- tokens_remove(toks, "a", padding = TRUE)
+    
+    expect_identical(ntoken(toks), c(d1 = 6L, d2 = 5L))
+    expect_identical(ntoken(toks, remove_padding = TRUE), c(d1 = 6L, d2 = 5L))
+    expect_identical(ntoken(toks2, remove_padding = TRUE), c(d1 = 4L, d2 = 4L))
+    expect_error(
+        ntoken(toks2, remove_padding = c(TRUE, FALSE)),
+        "The length of remove_padding must be 1"
+    )
 })
 
 test_that("test ntype tokens", {
@@ -49,23 +57,23 @@ test_that("test ntype tokens", {
     expect_identical(ntype(toks2), c(d1 = 2L, d2 = 4L))
 })
 
-test_that("dots are applied in ntokens.tokens, ntype.tokens", {
-    txt <- c(d1 = "3 wonderful tokens of the tokens function.")
-    toks <- tokens(txt)
-    
-    expect_identical(ntoken(toks), c(d1 = 8L))
-    expect_identical(ntoken(toks, remove_punct = TRUE), c(d1 = 7L))
-    expect_identical(ntoken(toks, remove_punct = TRUE, remove_numbers = TRUE), c(d1 = 6L))
-    expect_warning(ntoken(toks, notarg = TRUE), "^notarg argument is not used")
-    
-    expect_identical(ntype(toks), c(d1 = 7L))
-    expect_identical(ntype(toks, remove_punct = TRUE), c(d1 = 6L))
-    expect_identical(ntype(toks, remove_punct = TRUE, remove_numbers = TRUE), c(d1 = 5L))
-    expect_warning(ntype(toks, notarg = TRUE), "^notarg argument is not used")
-    
-    suppressWarnings(expect_identical(ntype(txt, remove_punct = TRUE), c(d1 = 6L)))
-    expect_identical(ntype(txt), c(d1 = 7L))
-})
+# test_that("dots are applied in ntokens.tokens, ntype.tokens", {
+#     txt <- c(d1 = "3 wonderful tokens of the tokens function.")
+#     toks <- tokens(txt)
+#     
+#     expect_identical(ntoken(toks), c(d1 = 8L))
+#     expect_identical(ntoken(toks, remove_punct = TRUE), c(d1 = 7L))
+#     expect_identical(ntoken(toks, remove_punct = TRUE, remove_numbers = TRUE), c(d1 = 6L))
+#     expect_warning(ntoken(toks, notarg = TRUE), "^notarg argument is not used")
+#     
+#     expect_identical(ntype(toks), c(d1 = 7L))
+#     expect_identical(ntype(toks, remove_punct = TRUE), c(d1 = 6L))
+#     expect_identical(ntype(toks, remove_punct = TRUE, remove_numbers = TRUE), c(d1 = 5L))
+#     expect_warning(ntype(toks, notarg = TRUE), "^notarg argument is not used")
+#     
+#     suppressWarnings(expect_identical(ntype(txt, remove_punct = TRUE), c(d1 = 6L)))
+#     expect_identical(ntype(txt), c(d1 = 7L))
+# })
 
 test_that("test nsentence", {
     txt <- c(doc1 = "This is Mr. Smith.  He is married to Mrs. Jones.",

--- a/tests/testthat/test-nfunctions.R
+++ b/tests/testthat/test-nfunctions.R
@@ -29,7 +29,7 @@ test_that("test ntype with dfm (#748)", {
 #     )
 # })
 
-test_that("test ntoken tokens", {
+test_that("test ntoken.tokens", {
     txt <- c(d1 = "a b c a b c", 
              d2 = "a b c d e")
     corp <- corpus(txt)
@@ -45,16 +45,20 @@ test_that("test ntoken tokens", {
     )
 })
 
-test_that("test ntype tokens", {
+test_that("test ntype.tokens", {
     txt <- c(d1 = "a b c a b c", 
              d2 = "a b c d e")
-    toks <- tokens(txt)
-    expect_identical(ntype(toks), c(d1 = 3L, d2 = 5L))
-    expect_identical(ntype(toks), c(d1 = 3L, d2 = 5L))
+    corp <- corpus(txt)
+    toks <- tokens(corp)
+    toks2 <- tokens_remove(toks, "a", padding = TRUE)
     
-    toks2 <- tokens_remove(toks, 'a', padding = TRUE)
-    expect_identical(ntype(toks2), c(d1 = 2L, d2 = 4L))
-    expect_identical(ntype(toks2), c(d1 = 2L, d2 = 4L))
+    expect_identical(ntype(toks), c(d1 = 3L, d2 = 5L))
+    expect_identical(ntype(toks, remove_padding = TRUE), c(d1 = 3L, d2 = 5L))
+    expect_identical(ntype(toks2, remove_padding = TRUE), c(d1 = 2L, d2 = 4L))
+    expect_error(
+        ntype(toks2, remove_padding = c(TRUE, FALSE)),
+        "The length of remove_padding must be 1"
+    )
 })
 
 test_that("dots are applied in ntokens.tokens, ntype.tokens", {

--- a/tests/testthat/test-tokens_xptr.R
+++ b/tests/testthat/test-tokens_xptr.R
@@ -16,23 +16,21 @@ test_that("Basic functions work", {
     
     expect_identical(ndoc(xtoks), ndoc(toks))
     expect_identical(ntoken(xtoks), ntoken(toks))
+
     expect_identical(types(xtoks), types(toks))
     expect_identical(concatenator(xtoks), concatenator(toks))
     expect_identical(concat(xtoks), concat(toks))
     expect_identical(ntype(xtoks), ntype(toks))
     expect_warning(
-        ntoken(xtoks, remove_padding = TRUE),
-        "remove_padding argument is not used"
+        ntoken(xtoks, xxx = TRUE),
+        "xxx argument is not used"
     )
-    expect_warning(
-        ntype(xtoks, remove_padding = TRUE),
-        "remove_padding argument is not used"
-    )
-    
     xtoks2 <- tokens_remove(as.tokens_xptr(xtoks), 
                             min_nchar = 2, padding = TRUE)
     toks2 <- tokens_remove(toks, min_nchar = 2, padding = TRUE)
     expect_identical(ntype(xtoks2), ntype(toks2))
+    expect_identical(ntoken(xtoks2, remove_padding = TRUE), 
+                     ntoken(tokens_remove(toks2, "")))
 })
 
 test_that("attributes are the same", {
@@ -73,7 +71,7 @@ test_that("deep copy xtokens", {
     )
 })
 
-test_that("c words on xtokens", {
+test_that("c works on xtokens", {
     xtoks_pad <- tokens_remove(as.tokens_xptr(toks), stopwords(), padding = TRUE)
     xtoks1 <- as.tokens_xptr(xtoks_pad)[1:10]
     xtoks2 <- as.tokens_xptr(xtoks_pad)[11:20]


### PR DESCRIPTION
If `ntoken(x, remove_padding = TRUE)`, it returns the number of tokens ignoring paddings. The results are the same as `ntoken(tokens_remove(x, pattern = ""))` but much more efficient. This will be useful in showing the number of tokens removed in verbose messagess (#2329).

I kept `...` in `ntoken()` but I think the argument should be deprecated as it does not work in `ntoken.dfm()`. User should just run `ntoken(tokens(x))` if necessary. The documentation also says "... not used".