### PR TITLE
Fix 2350

### DIFF
--- a/R/convert.R
+++ b/R/convert.R
@@ -275,7 +275,7 @@ dtm2lda <- function(x, omit_empty = TRUE) {
     docs <- vector(mode = "list", length = nrow(x))
     names(docs) <- rownames(x)
 
-    docs[slam::row_sums(x) > 0] <- split.matrix(rbind(as.integer(x$j) - 1L,
+    docs[slam::row_sums(x) > 0] <- split_matrix(rbind(as.integer(x$j) - 1L,
                                                       as.integer(x$v)),
                                                 as.integer(x$i))
     if (omit_empty) {
@@ -288,7 +288,7 @@ dtm2lda <- function(x, omit_empty = TRUE) {
 }
 
 # internal function for dtm2lda
-split.matrix <- function(x, f, drop = FALSE, ...) {
+split_matrix <- function(x, f, drop = FALSE, ...) {
     lapply(split(seq_len(ncol(x)),
                  f, drop = drop, ...), function(ind) x[, ind, drop = FALSE])
 }

--- a/R/dfm.R
+++ b/R/dfm.R
@@ -38,11 +38,6 @@ dfm <- function(x,
                 remove_padding = FALSE,
                 verbose = quanteda_options("verbose"),
                 ...) {
-
-    if (is.null(global$object_class)) {
-        global$object_class <- class(x)[1]
-        global$proc_time <- proc.time()   
-    }
     
     # to catch expansion of defunct "remove" to "remove_padding"
     check_defunct_dfm_args(names(as.list(sys.call())[-1]))
@@ -65,7 +60,12 @@ dfm.tokens <- function(x,
                        remove_padding = FALSE,
                        verbose = quanteda_options("verbose"),
                        ...) {
-
+    
+    if (is.null(global$object_class)) {
+        global$object_class <- class(x)[1]
+        global$proc_time <- proc.time()   
+    }
+    
     dfm(as.tokens_xptr(x), tolower = tolower,
         remove_padding = remove_padding, verbose = verbose, ...)
 
@@ -78,7 +78,12 @@ dfm.tokens_xptr <- function(x,
                             remove_padding = FALSE,
                             verbose = quanteda_options("verbose"),
                             ...) {
-
+    
+    if (is.null(global$object_class)) {
+        global$object_class <- class(x)[1]
+        global$proc_time <- proc.time()   
+    }
+    
     check_dots(...)
     if (verbose)
         catm("Creating a dfm from a", global$object_class, "object...\n")
@@ -113,7 +118,12 @@ dfm.dfm <- function(x,
                     remove_padding = FALSE,
                     verbose = quanteda_options("verbose"),
                     ...) {
-
+    
+    if (is.null(global$object_class)) {
+        global$object_class <- class(x)[1]
+        global$proc_time <- proc.time()   
+    }
+    
     check_dots(...)
     x <- as.dfm(x)
 

--- a/R/tokens.R
+++ b/R/tokens.R
@@ -166,32 +166,13 @@ tokens <-  function(x,
                     verbose = quanteda_options("verbose"),
                     ...,
                     xptr = FALSE) {
-    
-    if (is.null(global$object_class)) {
-        global$object_class <- class(x)[1]
-        global$proc_time <- proc.time()   
-    }
     UseMethod("tokens")
 }
 
 #' @rdname tokens
 #' @noRd
 #' @export
-tokens.default <- function(x,
-                           what = "word",
-                           remove_punct = FALSE,
-                           remove_symbols = FALSE,
-                           remove_numbers = FALSE,
-                           remove_url = FALSE,
-                           remove_separators = TRUE,
-                           split_hyphens = FALSE,
-                           split_tags = FALSE,
-                           include_docvars = TRUE,
-                           padding = FALSE,
-                           concatenator = "_",
-                           verbose = quanteda_options("verbose"),
-                           ...,
-                           xptr = FALSE) {
+tokens.default <- function(x, ...) {
     check_class(class(x), "tokens")
 }
 
@@ -212,6 +193,12 @@ tokens.list <- function(x,
                         concatenator = "_",
                         verbose = quanteda_options("verbose"),
                         ...) {
+    
+    if (is.null(global$object_class)) {
+        global$object_class <- class(x)[1]
+        global$proc_time <- proc.time()   
+    }
+    
     tokens(as.tokens(x),
            remove_punct = remove_punct,
            remove_symbols = remove_symbols,
@@ -243,6 +230,12 @@ tokens.character <- function(x,
                              verbose = quanteda_options("verbose"),
                              ...,
                              xptr = FALSE) {
+    
+    if (is.null(global$object_class)) {
+        global$object_class <- class(x)[1]
+        global$proc_time <- proc.time()   
+    }
+    
     tokens.corpus(corpus(x),
            what = what,
            remove_punct = remove_punct,
@@ -280,6 +273,12 @@ tokens.corpus <- function(x,
                           verbose = quanteda_options("verbose"),
                           ...,
                           xptr = FALSE)  {
+    
+    if (is.null(global$object_class)) {
+        global$object_class <- class(x)[1]
+        global$proc_time <- proc.time()   
+    }
+    
     x <- as.corpus(x)
     
     if (verbose) {
@@ -425,6 +424,11 @@ tokens.tokens_xptr <-  function(x,
                            concatenator = "_",
                            verbose = quanteda_options("verbose"),
                            ...) {
+
+    if (is.null(global$object_class)) {
+        global$object_class <- class(x)[1]
+        global$proc_time <- proc.time()   
+    }
     
     remove_punct <- check_logical(remove_punct)
     remove_symbols <- check_logical(remove_symbols)
@@ -492,6 +496,10 @@ tokens.tokens_xptr <-  function(x,
 
 #' @export
 tokens.tokens <- function(x, ...) {
+    if (is.null(global$object_class)) {
+        global$object_class <- class(x)[1]
+        global$proc_time <- proc.time()   
+    }
     as.tokens(tokens(as.tokens_xptr(x), ...))
 }
 

--- a/R/tokens.R
+++ b/R/tokens.R
@@ -177,7 +177,21 @@ tokens <-  function(x,
 #' @rdname tokens
 #' @noRd
 #' @export
-tokens.default <- function(x, ...) {
+tokens.default <- function(x,
+                           what = "word",
+                           remove_punct = FALSE,
+                           remove_symbols = FALSE,
+                           remove_numbers = FALSE,
+                           remove_url = FALSE,
+                           remove_separators = TRUE,
+                           split_hyphens = FALSE,
+                           split_tags = FALSE,
+                           include_docvars = TRUE,
+                           padding = FALSE,
+                           concatenator = "_",
+                           verbose = quanteda_options("verbose"),
+                           ...,
+                           xptr = FALSE) {
     check_class(class(x), "tokens")
 }
 
@@ -739,16 +753,17 @@ types.tokens <- function(x) {
 }
 
 "types<-" <- function(x, value) {
-    UseMethod("types<-")
+    set_types(x) <- value
+    #UseMethod("types<-")
 }
 
-"types<-.tokens" <- function(x, value) {
-    set_types(x) <- value
-}
-
-"types<-.tokens_xptr" <- function(x, value) {
-    set_types(x) <- value
-}
+# "types<-.tokens" <- function(x, value) {
+#     set_types(x) <- value
+# }
+# 
+# "types<-.tokens_xptr" <- function(x, value) {
+#     set_types(x) <- value
+# }
 
 
 # concatenator functions --------------

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -43,7 +43,12 @@ Complete output:
 ```
 
 We have tried to examine the results of `examples_and_tests/tests/testthat.Rout.fail` but that file produces a 404 error. 
-I emailed Uwe Ligges about this a week ago asking for assistance, but received no reply.  We are unsure whether this is a real error or something amiss with the CRAN checks.
+
+I emailed Uwe Ligges about this following a previous submission, and he sought input from Tomas Kalibera, who tested the package and identified the issue as pertaining to a version of the TBB library that is part of RpppParallel specific to the ARM64 platform for windows.
+
+He wrote:
+"please release a new revision with the fixes you have on github."
+
 
 ## Reverse dependency and other package conflicts
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,9 +1,9 @@
 # Submission notes
 
+*  Fixes problems notified by CRAN concerning UseMethod no longer forwarding local variables from the generic.
 *  Major update versus v.3.3.1, with many new features and improvements -- see NEWS.
 *  Numerous bug fixes.
 *  Numerous compatibility enhancements with newer versions of some packages (e.g. Matrix).
-
 
 ## Test environments
 
@@ -15,40 +15,7 @@
 
 ## R CMD check results
 
-All checks are fine, locally and on GitHub's CI for multiple platforms.  But `devtools::check_win_release()` and `devtools::check_win_devel()` shows the following:
-
-```
-* checking tests ... [146s] ERROR
-  Running 'spelling.R' [0s]
-  Running 'testthat.R' [145s]
-Running the tests in 'tests/testthat.R' failed.
-Complete output:
-  > Sys.setenv("R_TESTS" = "")
-  > Sys.setenv("_R_CHECK_LENGTH_1_CONDITION_" = TRUE)
-  > 
-  > library(testthat)
-  > library(quanteda)
-  Package version: 4.0.0
-  Unicode version: 15.1
-  ICU version: 74.1
-  Parallel computing: 2 of 56 threads used.
-  See https://quanteda.io for tutorials and examples.
-  > 
-  > # for strong tests for Matrix deprecations
-  > options(Matrix.warnDeprecatedCoerce = 2)
-  > 
-  > ops <- quanteda_options()
-  > quanteda_options(reset = TRUE)
-  > test_check("quanteda")
-```
-
-We have tried to examine the results of `examples_and_tests/tests/testthat.Rout.fail` but that file produces a 404 error. 
-
-I emailed Uwe Ligges about this following a previous submission, and he sought input from Tomas Kalibera, who tested the package and identified the issue as pertaining to a version of the TBB library that is part of RpppParallel specific to the ARM64 platform for windows.
-
-He wrote:
-"please release a new revision with the fixes you have on github."
-
+All checks are clean, locally and on GitHub's CI for multiple platforms.
 
 ## Reverse dependency and other package conflicts
 

--- a/tests/testthat/test-tokens-word4.R
+++ b/tests/testthat/test-tokens-word4.R
@@ -324,7 +324,7 @@ test_that("tokens arguments works with values from parent frame (#721)", {
 
 test_that("tokens works for strange spaces (#796)", {
     txt <- "space tab\t newline\n non-breakingspace\u00A0, variationselector16 \uFE0F."
-    expect_identical(ntoken(txt, remove_punct = FALSE, remove_separators = TRUE),
+    expect_identical(ntoken(tokens(txt, remove_punct = FALSE, remove_separators = TRUE)),
                      c(text1 = 7L))
     expect_identical(
         as.character(tokens(txt, what = "word", remove_punct = TRUE, remove_separators = TRUE)),
@@ -514,7 +514,8 @@ test_that("tokens verbose = TRUE produces expected messages", {
 test_that("types<- with wrong value generates error", {
     toks <- tokens(c("one two three", "four five."))
     expect_error(
-        quanteda:::`types<-.tokens`(toks, value = 1:6),
+        # quanteda:::`types<-.tokens`(toks, value = 1:6),
+        quanteda:::`types<-`(toks, value = 1:6),
         "replacement value must be character"
     )
 })

--- a/tests/testthat/test-tokens.R
+++ b/tests/testthat/test-tokens.R
@@ -612,7 +612,8 @@ test_that("tokens verbose = TRUE produces expected messages", {
 test_that("types<- with wrong value generates error", {
     toks <- tokens(c("one two three", "four five."))
     expect_error(
-        quanteda:::`types<-.tokens`(toks, value = 1:6),
+        # quanteda:::`types<-.tokens`(toks, value = 1:6),
+        quanteda:::`types<-`(toks, value = 1:6),
         "replacement value must be character"
     )
 })


### PR DESCRIPTION
Don't initialise the global environment `global` in the generics for dfm and tokens functions.

- now initialises the `global` environment in each method, not in the generic
- affects tokens and dfm methods
- a change in CRAN policy required this

Passes the win-devel checks so after this, we should be good to go for CRAN and 4.0.