### PR TITLE
Remove RcppArmadillo

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,7 +37,7 @@ Imports:
     stringi,
     xml2,
     yaml
-LinkingTo: Rcpp, RcppArmadillo (>= 0.7.600.1.0)
+LinkingTo: Rcpp
 SystemRequirements: Intel TBB: tbb-devel (Fedora, CentOS, RHEL), libtbb-dev (Debian, Ubuntu, etc) or tbb (Mac).
 NeedsCompilation: yes
 Suggests:

--- a/inst/include/lib.h
+++ b/inst/include/lib.h
@@ -5,7 +5,7 @@
 #define ARMA_64BIT_WORD
 #endif
 
-#include <RcppArmadillo.h>
+#include <Rcpp.h>
 #include <unordered_map>
 #include <unordered_set>
 #include <limits>

--- a/inst/include/tokens.h
+++ b/inst/include/tokens.h
@@ -1,4 +1,4 @@
-#include <RcppArmadillo.h>
+#include <Rcpp.h>
 // [[Rcpp::plugins(cpp11)]]
 using namespace Rcpp;
 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -2,7 +2,6 @@
 // Generator token: 10BE3573-1514-4C36-9D1C-5A225CD40393
 
 #include "quanteda_types.h"
-#include <RcppArmadillo.h>
 #include <Rcpp.h>
 
 using namespace Rcpp;

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -1,6 +1,5 @@
 #include "lib.h"
 using namespace quanteda;
-using namespace arma;
 
 /* 
  * This function removes a string from of a list of string vectors.


### PR DESCRIPTION
RcppArmadillo is not used in **quanteda** (only used in **quanteda.textmodels**).