### PR TITLE
Fix/links

### DIFF
--- a/R/wordstem.R
+++ b/R/wordstem.R
@@ -12,7 +12,7 @@
 #'   codes)
 #' @seealso [wordStem][SnowballC::wordStem]
 #'
-#' @references <http://snowball.tartarus.org/>
+#' @references <https://snowballstem.org/>
 #'
 #'   <http://www.iso.org/iso/home/standards/language_codes.htm> for the
 #'   ISO-639 language codes

--- a/man/tokens_wordstem.Rd
+++ b/man/tokens_wordstem.Rd
@@ -63,7 +63,7 @@ dfm_wordstem(origdfm)
 \references{
 \url{http://snowball.tartarus.org/}
 
-\url{http://www.iso.org/iso/home/standards/language_codes.htm} for the
+\url{https://www.iso.org/iso-639-language-code} for the
 ISO-639 language codes
 }
 \seealso{


### PR DESCRIPTION
Just updating two links, the old snowball stem link mentions: 

> This is the old website for the snowball system, preserved for historical reasons (there are many references to it in the published literature), but now no longer maintained. Snowball development continues on [Github](https://github.com/snowballstem), and the new website for snowball is at http://snowballstem.org/. See below for links to the snowball-discuss archives.

Thanks for the great package!