### PR TITLE
Fix tokens restore

### DIFF
--- a/R/tokens_restore.R
+++ b/R/tokens_restore.R
@@ -18,8 +18,13 @@ tokens_restore.default <- function(x) {
 tokens_restore.tokens_xptr <- function(x) {
     type <- get_types(x)
     attrs <- attributes(x)
-    result <- cpp_tokens_restore(x, list(match("\uE001", type)), list(match("\uE002", type)), 
-                                 "", get_threads())
+    
+    left <- pattern2id("\uE001", type, valuetype = "fixed")
+    right <- pattern2id("\uE002", type, valuetype = "fixed")
+    if (!length(left) || !length(right)) 
+        return(x)
+    
+    result <- cpp_tokens_restore(x, left, right, "", get_threads())
     rebuild_tokens(result, attrs)
 }
 

--- a/src/tokens_compound.cpp
+++ b/src/tokens_compound.cpp
@@ -167,7 +167,7 @@ TokensPtr cpp_tokens_compound(TokensPtr xptr,
 
     Ngrams comps = Rcpp::as<Ngrams>(compounds_);
     std::vector<std::size_t> spans(comps.size());
-    for (size_t g = 0; g < comps.size(); g++) {
+    for (std::size_t g = 0; g < comps.size(); g++) {
         Ngram comp = comps[g];
         // ignore patterns with paddings
         if (std::find(comp.begin(), comp.end(), 0) == comp.end()) {

--- a/src/tokens_restore.cpp
+++ b/src/tokens_restore.cpp
@@ -91,13 +91,13 @@ TokensPtr cpp_tokens_restore(TokensPtr xptr,
     map_comps.max_load_factor(GLOBAL_NGRAMS_MAX_LOAD_FACTOR);
 
     Ngrams marks_left = Rcpp::as<Ngrams>(marks_left_);
-    for (size_t g = 0; g < marks_left.size(); g++) {
+    for (std::size_t g = 0; g < marks_left.size(); g++) {
         Ngram value = marks_left[g];
         unsigned int key = 1; // 1 for left
         map_marks.insert(std::pair<Ngram, unsigned int>(value, key));
     }
     Ngrams marks_right = Rcpp::as<Ngrams>(marks_right_);
-    for (size_t g = 0; g < marks_right.size(); g++) {
+    for (std::size_t g = 0; g < marks_right.size(); g++) {
         Ngram value = marks_right[g];
         unsigned int key = 2; // 2 for right
         map_marks.insert(std::pair<Ngram, unsigned int>(value, key));


### PR DESCRIPTION
`match("\uE001", letters)` returns `NA` when the special character is not found. This leads to error in conversion to `unsingned int` in C++.