### PR TITLE
Test for absence of libtbb in configure.ac

### DIFF
--- a/configure
+++ b/configure
@@ -1569,6 +1569,53 @@ printf "%s\n" "$ac_res" >&6; }
   eval $as_lineno_stack; ${as_lineno_stack:+:} unset as_lineno
 
 } # ac_fn_cxx_check_header_compile
+
+# ac_fn_cxx_try_link LINENO
+# -------------------------
+# Try to link conftest.$ac_ext, and return whether this succeeded.
+ac_fn_cxx_try_link ()
+{
+  as_lineno=${as_lineno-"$1"} as_lineno_stack=as_lineno_stack=$as_lineno_stack
+  rm -f conftest.$ac_objext conftest.beam conftest$ac_exeext
+  if { { ac_try="$ac_link"
+case "(($ac_try" in
+  *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
+  *) ac_try_echo=$ac_try;;
+esac
+eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
+printf "%s\n" "$ac_try_echo"; } >&5
+  (eval "$ac_link") 2>conftest.err
+  ac_status=$?
+  if test -s conftest.err; then
+    grep -v '^ *+' conftest.err >conftest.er1
+    cat conftest.er1 >&5
+    mv -f conftest.er1 conftest.err
+  fi
+  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; } && {
+	 test -z "$ac_cxx_werror_flag" ||
+	 test ! -s conftest.err
+       } && test -s conftest$ac_exeext && {
+	 test "$cross_compiling" = yes ||
+	 test -x conftest$ac_exeext
+       }
+then :
+  ac_retval=0
+else $as_nop
+  printf "%s\n" "$as_me: failed program was:" >&5
+sed 's/^/| /' conftest.$ac_ext >&5
+
+	ac_retval=1
+fi
+  # Delete the IPA/IPO (Inter Procedural Analysis/Optimization) information
+  # created by the PGI compiler (conftest_ipa8_conftest.oo), as it would
+  # interfere with the next link command; also delete a directory that is
+  # left behind by Apple's compiler.  We do this before executing the actions.
+  rm -rf conftest.dSYM conftest_ipa8_conftest.oo
+  eval $as_lineno_stack; ${as_lineno_stack:+:} unset as_lineno
+  as_fn_set_status $ac_retval
+
+} # ac_fn_cxx_try_link
 ac_configure_args_raw=
 for ac_arg
 do
@@ -3017,11 +3064,11 @@ if test x$ac_prog_cxx_stdcxx = xno
 then :
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CXX option to enable C++11 features" >&5
 printf %s "checking for $CXX option to enable C++11 features... " >&6; }
-if test ${ac_cv_prog_cxx_11+y}
+if test ${ac_cv_prog_cxx_cxx11+y}
 then :
   printf %s "(cached) " >&6
 else $as_nop
-  ac_cv_prog_cxx_11=no
+  ac_cv_prog_cxx_cxx11=no
 ac_save_CXX=$CXX
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -3063,11 +3110,11 @@ if test x$ac_prog_cxx_stdcxx = xno
 then :
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CXX option to enable C++98 features" >&5
 printf %s "checking for $CXX option to enable C++98 features... " >&6; }
-if test ${ac_cv_prog_cxx_98+y}
+if test ${ac_cv_prog_cxx_cxx98+y}
 then :
   printf %s "(cached) " >&6
 else $as_nop
-  ac_cv_prog_cxx_98=no
+  ac_cv_prog_cxx_cxx98=no
 ac_save_CXX=$CXX
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -4257,11 +4304,11 @@ if test x$ac_prog_cxx_stdcxx = xno
 then :
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CXX option to enable C++11 features" >&5
 printf %s "checking for $CXX option to enable C++11 features... " >&6; }
-if test ${ac_cv_prog_cxx_11+y}
+if test ${ac_cv_prog_cxx_cxx11+y}
 then :
   printf %s "(cached) " >&6
 else $as_nop
-  ac_cv_prog_cxx_11=no
+  ac_cv_prog_cxx_cxx11=no
 ac_save_CXX=$CXX
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -4303,11 +4350,11 @@ if test x$ac_prog_cxx_stdcxx = xno
 then :
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CXX option to enable C++98 features" >&5
 printf %s "checking for $CXX option to enable C++98 features... " >&6; }
-if test ${ac_cv_prog_cxx_98+y}
+if test ${ac_cv_prog_cxx_cxx98+y}
 then :
   printf %s "(cached) " >&6
 else $as_nop
-  ac_cv_prog_cxx_98=no
+  ac_cv_prog_cxx_cxx98=no
 ac_save_CXX=$CXX
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -4354,10 +4401,10 @@ ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
 
 
 # Default to no Intel TBB
-TBBFLAG=
+TBBFLAGS=
 TBBLIBS=
 
-# If tbb.h is found, define TBB
+# If tbb.h and libtbb are found, define TBB and add -ltbb
 ac_header= ac_cache=
 for ac_item in $ac_header_cxx_list
 do
@@ -4390,15 +4437,52 @@ fi
 ac_fn_cxx_check_header_compile "$LINENO" "tbb/tbb.h" "ac_cv_header_tbb_tbb_h" "$ac_includes_default"
 if test "x$ac_cv_header_tbb_tbb_h" = xyes
 then :
-  TBBFLAG=-DTBB;TBBLIBS=-ltbb
+
 else $as_nop
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: parallel computing is disabled because tbb/tbb.h (Intel TBB) is not found" >&5
 printf "%s\n" "$as_me: WARNING: parallel computing is disabled because tbb/tbb.h (Intel TBB) is not found" >&2;}
 fi
 
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking libtbb available for linking" >&5
+printf %s "checking libtbb available for linking... " >&6; }
+ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
 
+SAVED_LDFLAGS=$LDFLAGS
+LDFLAGS="$LDFLAGS -ltbb"
+HAVE_TBB=no
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <tbb/tbb.h>
+int
+main (void)
+{
+major_version()
+  ;
+  return 0;
+}
+    TBBFLAGS=-DTBB;TBBLIBS=-ltbb HAVE_TBB=yes
+_ACEOF
+if ac_fn_cxx_try_link "$LINENO"
+then :
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: parallel computing is disabled because libtbb (Intel TBB devel package) is absent" >&5
+printf "%s\n" "$as_me: WARNING: parallel computing is disabled because libtbb (Intel TBB devel package) is absent" >&2;}
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam \
+    conftest$ac_exeext conftest.$ac_ext
+if test ${HAVE_TBB} = no ; then
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
+else
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+printf "%s\n" "yes" >&6; }
+fi
+LDFLAGS=$SAVED_LDFLAGS
 # Now substitute these variables in src/Makevars.in to create src/Makevars
-TBB_CFLAGS=${TBBFLAG}
+TBB_CFLAGS=${TBBFLAGS}
 
 TBB_LIBS=${TBBLIBS}
 

--- a/configure
+++ b/configure
@@ -1569,53 +1569,6 @@ printf "%s\n" "$ac_res" >&6; }
   eval $as_lineno_stack; ${as_lineno_stack:+:} unset as_lineno
 
 } # ac_fn_cxx_check_header_compile
-
-# ac_fn_cxx_try_link LINENO
-# -------------------------
-# Try to link conftest.$ac_ext, and return whether this succeeded.
-ac_fn_cxx_try_link ()
-{
-  as_lineno=${as_lineno-"$1"} as_lineno_stack=as_lineno_stack=$as_lineno_stack
-  rm -f conftest.$ac_objext conftest.beam conftest$ac_exeext
-  if { { ac_try="$ac_link"
-case "(($ac_try" in
-  *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
-  *) ac_try_echo=$ac_try;;
-esac
-eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
-printf "%s\n" "$ac_try_echo"; } >&5
-  (eval "$ac_link") 2>conftest.err
-  ac_status=$?
-  if test -s conftest.err; then
-    grep -v '^ *+' conftest.err >conftest.er1
-    cat conftest.er1 >&5
-    mv -f conftest.er1 conftest.err
-  fi
-  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
-  test $ac_status = 0; } && {
-	 test -z "$ac_cxx_werror_flag" ||
-	 test ! -s conftest.err
-       } && test -s conftest$ac_exeext && {
-	 test "$cross_compiling" = yes ||
-	 test -x conftest$ac_exeext
-       }
-then :
-  ac_retval=0
-else $as_nop
-  printf "%s\n" "$as_me: failed program was:" >&5
-sed 's/^/| /' conftest.$ac_ext >&5
-
-	ac_retval=1
-fi
-  # Delete the IPA/IPO (Inter Procedural Analysis/Optimization) information
-  # created by the PGI compiler (conftest_ipa8_conftest.oo), as it would
-  # interfere with the next link command; also delete a directory that is
-  # left behind by Apple's compiler.  We do this before executing the actions.
-  rm -rf conftest.dSYM conftest_ipa8_conftest.oo
-  eval $as_lineno_stack; ${as_lineno_stack:+:} unset as_lineno
-  as_fn_set_status $ac_retval
-
-} # ac_fn_cxx_try_link
 ac_configure_args_raw=
 for ac_arg
 do
@@ -4443,48 +4396,45 @@ else $as_nop
 printf "%s\n" "$as_me: WARNING: parallel computing is disabled because tbb/tbb.h (Intel TBB) is not found" >&2;}
 fi
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking libtbb available for linking" >&5
-printf %s "checking libtbb available for linking... " >&6; }
-ac_ext=cpp
-ac_cpp='$CXXCPP $CPPFLAGS'
-ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
-ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
-ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
-
-SAVED_LDFLAGS=$LDFLAGS
-LDFLAGS="$LDFLAGS -ltbb"
-HAVE_TBB=no
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking libtbb available for linking:" >&5
+printf %s "checking libtbb available for linking:... " >&6; }
+# https://link.springer.com/chapter/10.1007/978-1-4842-4398-5_1 fig 1.4
+cat > libtbb_test.cpp <<_EOCONF
+#include <iostream>
 #include <tbb/tbb.h>
-int
-main (void)
-{
-major_version()
-  ;
+
+int main() {
+  tbb::parallel_invoke(
+    []() { std::cout << " Hello " << std::endl; },
+    []() { std::cout << " TBB! " << std::endl; }
+  );
   return 0;
 }
-    TBBFLAGS=-DTBB;TBBLIBS=-ltbb HAVE_TBB=yes
-_ACEOF
-if ac_fn_cxx_try_link "$LINENO"
-then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: parallel computing is disabled because libtbb (Intel TBB devel package) is absent" >&5
-printf "%s\n" "$as_me: WARNING: parallel computing is disabled because libtbb (Intel TBB devel package) is absent" >&2;}
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
-    conftest$ac_exeext conftest.$ac_ext
-if test ${HAVE_TBB} = no ; then
+_EOCONF
+  ${CXX} ${CXXFLAGS} -o libtbb_test libtbb_test.cpp -ltbb 2> errors.txt
+
+if test `echo $?` -ne 0 ; then
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
 printf "%s\n" "no" >&6; }
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: parallel computing is disabled because libtbb (Intel TBB devel package) is absent" >&5
+printf "%s\n" "$as_me: WARNING: parallel computing is disabled because libtbb (Intel TBB devel package) is absent" >&2;}
 else
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 printf "%s\n" "yes" >&6; }
+    TBBFLAGS=-DTBB
+    TBBLIBS=-ltbb
 fi
-LDFLAGS=$SAVED_LDFLAGS
+rm -f libtbb_test.cpp libtbb_test errors.txt
 # Now substitute these variables in src/Makevars.in to create src/Makevars
 TBB_CFLAGS=${TBBFLAGS}
 
 TBB_LIBS=${TBBLIBS}
+
+
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: Package CPP flags: ${TBB_CFLAGS}" >&5
+printf "%s\n" "$as_me: Package CPP flags: ${TBB_CFLAGS}" >&6;}
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: Package LIBS: ${TBB_LIBS}" >&5
+printf "%s\n" "$as_me: Package LIBS: ${TBB_LIBS}" >&6;}
 
 ac_config_files="$ac_config_files src/Makevars"
 

--- a/configure.ac
+++ b/configure.ac
@@ -26,24 +26,37 @@ TBBLIBS=
 # If tbb.h and libtbb are found, define TBB and add -ltbb
 AC_CHECK_HEADER([tbb/tbb.h],,
     [AC_MSG_WARN([parallel computing is disabled because tbb/tbb.h (Intel TBB) is not found])])
-AC_MSG_CHECKING([libtbb available for linking])
-AC_LANG(C++)
-SAVED_LDFLAGS=$LDFLAGS
-LDFLAGS="$LDFLAGS -ltbb"
-HAVE_TBB=no
-AC_LINK_IFELSE(
-    [AC_LANG_PROGRAM([#include <tbb/tbb.h>],
-      [major_version()])]
-    [TBBFLAGS=-DTBB;TBBLIBS=-ltbb] [HAVE_TBB=yes],
-    [AC_MSG_WARN([parallel computing is disabled because libtbb (Intel TBB devel package) is absent])])
-if test ${HAVE_TBB} = no ; then
+AC_MSG_CHECKING([libtbb available for linking:])
+# https://link.springer.com/chapter/10.1007/978-1-4842-4398-5_1 fig 1.4
+[cat > libtbb_test.cpp <<_EOCONF
+#include <iostream>
+#include <tbb/tbb.h>
+
+int main() { 
+  tbb::parallel_invoke(
+    []() { std::cout << " Hello " << std::endl; },
+    []() { std::cout << " TBB! " << std::endl; }
+  );
+  return 0;
+}
+_EOCONF]
+  ${CXX} ${CXXFLAGS} -o libtbb_test libtbb_test.cpp -ltbb 2> errors.txt
+
+if test `echo $?` -ne 0 ; then
     AC_MSG_RESULT(no)
+    AC_MSG_WARN([parallel computing is disabled because libtbb (Intel TBB devel package) is absent])
 else
     AC_MSG_RESULT(yes)
+    TBBFLAGS=-DTBB
+    TBBLIBS=-ltbb
 fi
-LDFLAGS=$SAVED_LDFLAGS
+rm -f libtbb_test.cpp libtbb_test errors.txt
 # Now substitute these variables in src/Makevars.in to create src/Makevars
 AC_SUBST(TBB_CFLAGS, ${TBBFLAGS})
 AC_SUBST(TBB_LIBS, ${TBBLIBS})
+
+AC_MSG_NOTICE([Package CPP flags: ${TBB_CFLAGS}])
+AC_MSG_NOTICE([Package LIBS: ${TBB_LIBS}])
+
 AC_CONFIG_FILES([src/Makevars])
 AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -23,11 +23,25 @@ AC_PROG_CXX
 TBBFLAGS=
 TBBLIBS=
 
-# If tbb.h is found, define TBB
-AC_CHECK_HEADER([tbb/tbb.h],
-   [TBBFLAG=-DTBB;TBBLIBS=-ltbb],
-   [AC_MSG_WARN([parallel computing is disabled because tbb/tbb.h (Intel TBB) is not found])])
-
+# If tbb.h and libtbb are found, define TBB and add -ltbb
+AC_CHECK_HEADER([tbb/tbb.h],,
+    [AC_MSG_WARN([parallel computing is disabled because tbb/tbb.h (Intel TBB) is not found])])
+AC_MSG_CHECKING([libtbb available for linking])
+AC_LANG(C++)
+SAVED_LDFLAGS=$LDFLAGS
+LDFLAGS="$LDFLAGS -ltbb"
+HAVE_TBB=no
+AC_LINK_IFELSE(
+    [AC_LANG_PROGRAM([#include <tbb/tbb.h>],
+      [major_version()])]
+    [TBBFLAGS=-DTBB;TBBLIBS=-ltbb] [HAVE_TBB=yes],
+    [AC_MSG_WARN([parallel computing is disabled because libtbb (Intel TBB devel package) is absent])])
+if test ${HAVE_TBB} = no ; then
+    AC_MSG_RESULT(no)
+else
+    AC_MSG_RESULT(yes)
+fi
+LDFLAGS=$SAVED_LDFLAGS
 # Now substitute these variables in src/Makevars.in to create src/Makevars
 AC_SUBST(TBB_CFLAGS, ${TBBFLAGS})
 AC_SUBST(TBB_LIBS, ${TBBLIBS})


### PR DESCRIPTION
This seems to work when tbb-devel is present or absent, setting or not setting the Makvars variables.