### PR TITLE
Issue 2399

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: quanteda
-Version: 4.0.2
+Version: 4.0.3
 Title: Quantitative Analysis of Textual Data
 Description: A fast, flexible, and comprehensive framework for 
     quantitative text analysis in R.  Provides functionality for corpus management,
@@ -66,7 +66,7 @@ BugReports: https://github.com/quanteda/quanteda/issues
 LazyData: TRUE
 VignetteBuilder: knitr
 Language: en-GB
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2
 Roxygen: list(markdown = TRUE)
 Collate: 
     'RcppExports.R'

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# quanteda 4.0.3
+
+## Bug fixes and stability enhancements
+
+## Changes and additions
+
+* Added `keep_unigrams` argument to `tokens_compound()`, to keep in the returned object the unigrams that are to be compounded. (#2399)
+
 # quanteda 4.0.2
 
 ## Bug fixes and stability enhancements

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -33,8 +33,8 @@ cpp_tokens_combine <- function(xptr1, xptr2, thread = -1L) {
     .Call(`_quanteda_cpp_tokens_combine`, xptr1, xptr2, thread)
 }
 
-cpp_tokens_compound <- function(xptr, compounds_, delim_, join, window_left, window_right, bypass_, thread = -1L) {
-    .Call(`_quanteda_cpp_tokens_compound`, xptr, compounds_, delim_, join, window_left, window_right, bypass_, thread)
+cpp_tokens_compound <- function(xptr, compounds_, delim_, join, keep, window_left, window_right, bypass_, thread = -1L) {
+    .Call(`_quanteda_cpp_tokens_compound`, xptr, compounds_, delim_, join, keep, window_left, window_right, bypass_, thread)
 }
 
 cpp_tokens_group <- function(xptr, groups_, thread = -1L) {

--- a/R/tokens_compound.R
+++ b/R/tokens_compound.R
@@ -9,8 +9,9 @@
 #' @inheritParams pattern
 #' @inheritParams tokens
 #' @inheritParams valuetype
-#' @param join logical; if `TRUE`, join overlapping compounds into a single
+#' @param join if `TRUE`, join overlapping compounds into a single
 #'   compound; otherwise, form these separately.  See examples.
+#' @param keep_unigrams if `TRUE`, keep the original tokens.
 #' @param window integer; a vector of length 1 or 2 that specifies size of the
 #'   window of tokens adjacent to `pattern` that will be compounded with matches
 #'   to `pattern`.  The window can be asymmetric if two elements are specified,
@@ -65,7 +66,9 @@ tokens_compound <- function(x, pattern,
                             valuetype = c("glob", "regex", "fixed"),
                             concatenator = concat(x),
                             window = 0L,
-                            case_insensitive = TRUE, join = TRUE,
+                            case_insensitive = TRUE, 
+                            join = TRUE,
+                            keep_unigrams = FALSE,
                             apply_if = NULL) {
     UseMethod("tokens_compound")
 }
@@ -75,7 +78,9 @@ tokens_compound.default <- function(x, pattern,
                                     valuetype = c("glob", "regex", "fixed"),
                                     concatenator = concat(x),
                                     window = 0L,
-                                    case_insensitive = TRUE, join = TRUE,
+                                    case_insensitive = TRUE, 
+                                    join = TRUE,
+                                    keep_unigrams = FALSE,
                                     apply_if = NULL) {
     check_class(class(x), "tokens_compound")
 }
@@ -85,7 +90,9 @@ tokens_compound.tokens_xptr <- function(x, pattern,
                                         valuetype = c("glob", "regex", "fixed"),
                                         concatenator = concat(x),
                                         window = 0L,
-                                        case_insensitive = TRUE, join = TRUE,
+                                        case_insensitive = TRUE, 
+                                        join = TRUE,
+                                        keep_unigrams = FALSE,
                                         apply_if = NULL) {
 
     valuetype <- match.arg(valuetype)
@@ -94,6 +101,7 @@ tokens_compound.tokens_xptr <- function(x, pattern,
     join <- check_logical(join)
     apply_if <- check_logical(apply_if, min_len = ndoc(x), max_len = ndoc(x),
                                allow_null = TRUE, allow_na = TRUE)
+    keep_unigrams <- check_logical(keep_unigrams)
 
     attrs <- attributes(x)
     type <- get_types(x)
@@ -102,8 +110,8 @@ tokens_compound.tokens_xptr <- function(x, pattern,
     if (length(window) == 1) window <- rep(window, 2)
     if (is.null(apply_if))
         apply_if <- rep(TRUE, length.out = ndoc(x))
-    result <- cpp_tokens_compound(x, ids, concatenator, join, window[1], window[2], !apply_if,
-                                  get_threads())
+    result <- cpp_tokens_compound(x, ids, concatenator, join, keep_unigrams,
+                                  window[1], window[2], !apply_if, get_threads())
     field_object(attrs, "concatenator") <- concatenator
     rebuild_tokens(result, attrs)
 }

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -256,6 +256,8 @@ twitteR
 uXXXX
 underdispersion
 unescaped
+unigram
+unigrams
 valuetype
 vocab
 vol

--- a/man/tokens_compound.Rd
+++ b/man/tokens_compound.Rd
@@ -12,6 +12,7 @@ tokens_compound(
   window = 0L,
   case_insensitive = TRUE,
   join = TRUE,
+  keep_unigrams = FALSE,
   apply_if = NULL
 )
 }
@@ -38,8 +39,10 @@ be shrunk to exclude them.}
 \item{case_insensitive}{logical; if \code{TRUE}, ignore case when matching a
 \code{pattern} or \link{dictionary} values}
 
-\item{join}{logical; if \code{TRUE}, join overlapping compounds into a single
+\item{join}{if \code{TRUE}, join overlapping compounds into a single
 compound; otherwise, form these separately.  See examples.}
+
+\item{keep_unigrams}{if \code{TRUE}, keep the original tokens.}
 
 \item{apply_if}{logical vector of length \code{ndoc(x)}; documents are modified
 only when corresponding values are \code{TRUE}, others are left unchanged.}

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -124,8 +124,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // cpp_tokens_compound
-TokensPtr cpp_tokens_compound(TokensPtr xptr, const List& compounds_, const String& delim_, const bool& join, int window_left, int window_right, const LogicalVector bypass_, const int thread);
-RcppExport SEXP _quanteda_cpp_tokens_compound(SEXP xptrSEXP, SEXP compounds_SEXP, SEXP delim_SEXP, SEXP joinSEXP, SEXP window_leftSEXP, SEXP window_rightSEXP, SEXP bypass_SEXP, SEXP threadSEXP) {
+TokensPtr cpp_tokens_compound(TokensPtr xptr, const List& compounds_, const String& delim_, const bool& join, const bool& keep, int window_left, int window_right, const LogicalVector bypass_, const int thread);
+RcppExport SEXP _quanteda_cpp_tokens_compound(SEXP xptrSEXP, SEXP compounds_SEXP, SEXP delim_SEXP, SEXP joinSEXP, SEXP keepSEXP, SEXP window_leftSEXP, SEXP window_rightSEXP, SEXP bypass_SEXP, SEXP threadSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -133,11 +133,12 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const List& >::type compounds_(compounds_SEXP);
     Rcpp::traits::input_parameter< const String& >::type delim_(delim_SEXP);
     Rcpp::traits::input_parameter< const bool& >::type join(joinSEXP);
+    Rcpp::traits::input_parameter< const bool& >::type keep(keepSEXP);
     Rcpp::traits::input_parameter< int >::type window_left(window_leftSEXP);
     Rcpp::traits::input_parameter< int >::type window_right(window_rightSEXP);
     Rcpp::traits::input_parameter< const LogicalVector >::type bypass_(bypass_SEXP);
     Rcpp::traits::input_parameter< const int >::type thread(threadSEXP);
-    rcpp_result_gen = Rcpp::wrap(cpp_tokens_compound(xptr, compounds_, delim_, join, window_left, window_right, bypass_, thread));
+    rcpp_result_gen = Rcpp::wrap(cpp_tokens_compound(xptr, compounds_, delim_, join, keep, window_left, window_right, bypass_, thread));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -476,7 +477,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_quanteda_cpp_serialize_add", (DL_FUNC) &_quanteda_cpp_serialize_add, 3},
     {"_quanteda_cpp_tokens_chunk", (DL_FUNC) &_quanteda_cpp_tokens_chunk, 4},
     {"_quanteda_cpp_tokens_combine", (DL_FUNC) &_quanteda_cpp_tokens_combine, 3},
-    {"_quanteda_cpp_tokens_compound", (DL_FUNC) &_quanteda_cpp_tokens_compound, 8},
+    {"_quanteda_cpp_tokens_compound", (DL_FUNC) &_quanteda_cpp_tokens_compound, 9},
     {"_quanteda_cpp_tokens_group", (DL_FUNC) &_quanteda_cpp_tokens_group, 3},
     {"_quanteda_cpp_tokens_lookup", (DL_FUNC) &_quanteda_cpp_tokens_lookup, 8},
     {"_quanteda_cpp_tokens_ngrams", (DL_FUNC) &_quanteda_cpp_tokens_ngrams, 5},

--- a/src/tokens_compound.cpp
+++ b/src/tokens_compound.cpp
@@ -18,6 +18,7 @@ Text join_comp(Text tokens,
                const SetNgrams &set_comps,
                MapNgrams &map_comps,
                IdNgram &id_comp,
+               const bool &keep,
                const std::pair<int, int> &window){
     
     if (tokens.empty()) return {}; // return empty vector for empty text
@@ -54,7 +55,9 @@ Text join_comp(Text tokens,
     for (std::size_t i = 0; i < len; i++) {
         //Rcout << "Flag "<< i << ":" << flags_link[i] << "\n";
         if (flags_link[i]) {
-                tokens_seq.push_back(tokens[i]);
+            tokens_seq.push_back(tokens[i]);
+            //if (keep)
+            //    tokens_flat.push_back(tokens[i]);
         } else {
             if (tokens_seq.empty()) {
                 tokens_flat.push_back(tokens[i]);
@@ -74,6 +77,7 @@ Text match_comp(Text tokens,
                 const SetNgrams &set_comps,
                 MapNgrams &map_comps,
                 IdNgram &id_comp,
+                const bool &keep,
                 const std::pair<int, int> &window){
     
     if (tokens.empty()) return {}; // return empty vector for empty text
@@ -129,6 +133,7 @@ Text match_comp(Text tokens,
  * @param compounds_ list of patterns to substitute
  * @param delim_ character to concatenate types
  * @param join join overlapped features if true
+ * @param keep original unigrams if true
  * @param window_left numbers tokens on the left-hand side of pattern
  * @param window_right numbers tokens on the right-hand side of pattern
  * @param bypass_ select documents to modify: TRUE=modify, FALSE=don't modify
@@ -139,6 +144,7 @@ TokensPtr cpp_tokens_compound(TokensPtr xptr,
                               const List &compounds_,
                               const String &delim_,
                               const bool &join,
+                              const bool &keep,
                               int window_left,
                               int window_right,
                               const LogicalVector bypass_,
@@ -190,9 +196,11 @@ TokensPtr cpp_tokens_compound(TokensPtr xptr,
                 if (bypass[h])
                     continue;
                 if (join) {
-                    texts[h] = join_comp(texts[h], spans, set_comps, map_comps, id_comp, window);
+                    texts[h] = join_comp(texts[h], spans, set_comps, map_comps, id_comp, 
+                                         keep, window);
                 } else {
-                    texts[h] = match_comp(texts[h], spans, set_comps, map_comps, id_comp, window);
+                    texts[h] = match_comp(texts[h], spans, set_comps, map_comps, id_comp, 
+                                          keep, window);
                 }
             }    
         });
@@ -202,9 +210,9 @@ TokensPtr cpp_tokens_compound(TokensPtr xptr,
         if (bypass[h])
             continue;
         if (join) {
-            texts[h] = join_comp(texts[h], spans, set_comps, map_comps, id_comp, window);
+            texts[h] = join_comp(texts[h], spans, set_comps, map_comps, id_comp, keep, window);
         } else {
-            texts[h] = match_comp(texts[h], spans, set_comps, map_comps, id_comp, window);
+            texts[h] = match_comp(texts[h], spans, set_comps, map_comps, id_comp, keep, window);
         }
     }
 #endif

--- a/src/tokens_compound.cpp
+++ b/src/tokens_compound.cpp
@@ -56,8 +56,6 @@ Text join_comp(Text tokens,
         //Rcout << "Flag "<< i << ":" << flags_link[i] << "\n";
         if (flags_link[i]) {
             tokens_seq.push_back(tokens[i]);
-            //if (keep)
-            //    tokens_flat.push_back(tokens[i]);
         } else {
             if (tokens_seq.empty()) {
                 tokens_flat.push_back(tokens[i]);

--- a/src/tokens_replace.cpp
+++ b/src/tokens_replace.cpp
@@ -10,7 +10,7 @@ Text replace(Text tokens,
     
     if (tokens.empty()) return {}; // return empty vector for empty text
     
-    std::vector< std::vector<unsigned int> > tokens_multi(tokens.size()); 
+    std::vector< Text > tokens_multi(tokens.size()); 
     std::vector< bool > flags_match(tokens.size(), false); // flag matched tokens
     std::size_t match = 0;
     bool none = true;

--- a/src/tokens_restore.cpp
+++ b/src/tokens_restore.cpp
@@ -10,7 +10,7 @@ Text join_mark(Text tokens,
     
     if (tokens.empty()) return {}; // return empty vector for empty text
     
-    std::vector< std::vector<unsigned int> > tokens_multi(tokens.size()); 
+    std::vector< Text > tokens_multi(tokens.size()); 
     std::vector< bool > flags_match(tokens.size(), false); // flag matched tokens
     std::size_t match = 0;
 

--- a/tests/testthat/test-tokens_compound.R
+++ b/tests/testthat/test-tokens_compound.R
@@ -69,6 +69,12 @@ test_that("tokens_compound join a sequences of sequences", {
                       list(text1 = c("we", "like", "high_quality_sound")))
     expect_equal(as.list(tokens_compound(tokens(txts), seqs, join = FALSE)),
                       list(text1 = c("we", "like", "high_quality", "quality_sound")))
+    expect_equal(as.list(tokens_compound(tokens(txts), seqs, join = TRUE, keep_unigrams = TRUE)),
+                 list(text1 = c("we", "like", "high", "quality", "sound",
+                                "high_quality_sound")))
+    expect_equal(as.list(tokens_compound(tokens(txts), seqs, join = FALSE, keep_unigrams = TRUE)),
+                 list(text1 = c("we", "like", "high", "quality", "high_quality", 
+                                "quality", "sound", "quality_sound")))
 
 })
 

--- a/tests/testthat/test-tokens_compound.R
+++ b/tests/testthat/test-tokens_compound.R
@@ -63,18 +63,19 @@ test_that("tokens_compound join a sequences of sequences", {
              text2 = c("A_B", "B_C_D", "E_F", "F_G"))
     )
 
-    txts <- "we like high quality sound"
+    txt2 <- "we like high quality sound"
+    toks2 <- tokens(txt2)
     seqs <- phrase(c("high quality", "quality sound"))
-    expect_equal(as.list(tokens_compound(tokens(txts), seqs, join = TRUE)),
+    expect_equal(as.list(tokens_compound(toks2, seqs, join = TRUE)),
                       list(text1 = c("we", "like", "high_quality_sound")))
-    expect_equal(as.list(tokens_compound(tokens(txts), seqs, join = FALSE)),
+    expect_equal(as.list(tokens_compound(toks2, seqs, join = FALSE)),
                       list(text1 = c("we", "like", "high_quality", "quality_sound")))
-    expect_equal(as.list(tokens_compound(tokens(txts), seqs, join = TRUE, keep_unigrams = TRUE)),
+    expect_equal(as.list(tokens_compound(toks2, seqs, join = TRUE, keep_unigrams = TRUE)),
                  list(text1 = c("we", "like", "high", "quality", "sound",
                                 "high_quality_sound")))
-    expect_equal(as.list(tokens_compound(tokens(txts), seqs, join = FALSE, keep_unigrams = TRUE)),
-                 list(text1 = c("we", "like", "high", "quality", "high_quality", 
-                                "quality", "sound", "quality_sound")))
+    expect_equal(as.list(tokens_compound(toks2, seqs, join = FALSE, keep_unigrams = TRUE)),
+                 list(text1 = c("we", "like", "high", "high_quality", "quality",
+                                "quality_sound", "sound")))
 
 })
 

--- a/tests/testthat/test-tokens_compound.R
+++ b/tests/testthat/test-tokens_compound.R
@@ -62,20 +62,30 @@ test_that("tokens_compound join a sequences of sequences", {
         list(text1 = c("a_b", "b_c_d", "e_f", "f_g"),
              text2 = c("A_B", "B_C_D", "E_F", "F_G"))
     )
-
+    
     txt2 <- "we like high quality sound"
     toks2 <- tokens(txt2)
-    seqs <- phrase(c("high quality", "quality sound"))
-    expect_equal(as.list(tokens_compound(toks2, seqs, join = TRUE)),
+    seqs2 <- phrase(c("high quality", "quality sound"))
+    expect_equal(as.list(tokens_compound(toks2, seqs2, join = TRUE)),
                       list(text1 = c("we", "like", "high_quality_sound")))
-    expect_equal(as.list(tokens_compound(toks2, seqs, join = FALSE)),
+    expect_equal(as.list(tokens_compound(toks2, seqs2, join = FALSE)),
                       list(text1 = c("we", "like", "high_quality", "quality_sound")))
-    expect_equal(as.list(tokens_compound(toks2, seqs, join = TRUE, keep_unigrams = TRUE)),
+    expect_equal(as.list(tokens_compound(toks2, seqs2, join = TRUE, keep_unigrams = TRUE)),
                  list(text1 = c("we", "like", "high", "quality", "sound",
                                 "high_quality_sound")))
-    expect_equal(as.list(tokens_compound(toks2, seqs, join = FALSE, keep_unigrams = TRUE)),
+    expect_equal(as.list(tokens_compound(toks2, seqs2, join = FALSE, keep_unigrams = TRUE)),
                  list(text1 = c("we", "like", "high", "high_quality", "quality",
                                 "quality_sound", "sound")))
+    
+    expect_error(
+        tokens_compound(toks, seqs, join = c(TRUE, FALSE)),
+        "The length of join must be 1"
+    )
+    
+    expect_error(
+        tokens_compound(toks, seqs, keep_unigrams = c(TRUE, FALSE)),
+        "The length of keep_unigrams must be 1"
+    )
 
 })
 

--- a/tests/testthat/test-tokens_xptr.R
+++ b/tests/testthat/test-tokens_xptr.R
@@ -383,7 +383,7 @@ test_that("test low-level validation", {
     )
     expect_error(
         quanteda:::cpp_tokens_compound(as.tokens_xptr(xtoks), 
-                                     dict, "-", TRUE, 0, 0, c(FALSE, TRUE)),
+                                      dict, "-", TRUE, FALSE, 0, 0, c(FALSE, TRUE)),
         "Invalid bypass"
     )
     expect_error(


### PR DESCRIPTION
Add `keep_unigrams` as discussed in #2399. Compared to other arguments of the function like `join` the name is rather long, so it could be just `keep`.