### PR TITLE
Fix UBSAN issue

### DIFF
--- a/src/tokens_xptr.cpp
+++ b/src/tokens_xptr.cpp
@@ -32,7 +32,7 @@ List cpp_get_attributes(TokensPtr xptr) {
 // [[Rcpp::export]]
 List cpp_as_list(TokensPtr xptr) {
     xptr->recompile();
-    Tokens texts_ = as_list(xptr->texts);
+    List texts_ = as_list(xptr->texts);
     texts_.attr("types") = encode(xptr->types);
     texts_.attr("class") = "tokens";
     return texts_;

--- a/src/tokens_xptr.cpp
+++ b/src/tokens_xptr.cpp
@@ -33,7 +33,7 @@ List cpp_get_attributes(TokensPtr xptr) {
 List cpp_as_list(TokensPtr xptr) {
     xptr->recompile();
     Tokens texts_ = as_list(xptr->texts);
-    texts_.attr("types") = encode(xptr->types);;
+    texts_.attr("types") = encode(xptr->types);
     texts_.attr("class") = "tokens";
     return texts_;
 }


### PR DESCRIPTION
Closes #2406. I still think that this is a sanitizer issue, but if we can avoid confusing it, you don't have to argue with CRAN. 

Here `ListOf` (`Tokens`) is a very particular class. But given that `as_list` returns a `List` in the first place, there is no gain in transforming it into a `ListOf`. So keeping everything as a `List` seems to content UBSAN. Using the `rocker/r-devel-ubsan-clang` container, I see:

```bash
$ ASAN_OPTIONS=detect_leaks=0 RDscript -e 'remotes::install_github("Enchufa2/quanteda", ref="test")'
$ RDscript -e 'quanteda::as.tokens(list("test"))'
Tokens consisting of 1 document.
text1 :
[1] "test"
```