### PR TITLE
Stop using vector.insert()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # quanteda 4.1.x
 
+## Changes and additions
+
+* Make the `c` operation on `tokens` and `tokens_xptr` objects significantly faster. 
+
 ## Bug fixes and stability enhancements
 
 * Fix a bug in `dfm_lookup()` that leads to wrong feature names when `exclusive = TRUE` (#2424).

--- a/src/tokens_combine.cpp
+++ b/src/tokens_combine.cpp
@@ -14,42 +14,49 @@ TokensPtr cpp_tokens_combine(TokensPtr xptr1,
                              TokensPtr xptr2,
                              const int thread = -1) {
     
+    //dev::Timer timer;
+    //dev::start_timer("Insert", timer);
     Types types;
     types.reserve(xptr1->types.size() + xptr2->types.size());
     types.insert(types.end(), xptr1->types.begin(), xptr1->types.end());
     types.insert(types.end(), xptr2->types.begin(), xptr2->types.end());
+    //dev::stop_timer("Insert", timer);
     
     std::size_t V = xptr1->types.size();
+    std::size_t G = xptr1->texts.size(); 
     std::size_t H = xptr2->texts.size(); 
-    Texts texts = xptr2->texts;
     
+    Texts texts = xptr1->texts;
+    texts.resize(G + H);
+    
+    //dev::start_timer("Shift", timer);
 #if QUANTEDA_USE_TBB
     tbb::task_arena arena(thread);
     arena.execute([&]{
         tbb::parallel_for(tbb::blocked_range<int>(0, H), [&](tbb::blocked_range<int> r) {
             for (int h = r.begin(); h < r.end(); ++h) {
-                for (std::size_t i = 0; i < texts[h].size(); i++) {
-                    if (texts[h][i] != 0)
-                        texts[h][i] += V;
+                Text text = xptr2->texts[h];
+                for (std::size_t i = 0; i < text.size(); i++) {
+                    if (text[i] != 0)
+                        text[i] += V;
                 }
+                texts[G + h] = text;
             }
         });
     });
 #else
     for (std::size_t h = 0; h < H; h++) {
-        for (std::size_t i = 0; i < texts[h].size(); i++) {
-            if (texts[h][i] != 0)
-                texts[h][i] += V;
+        Text text = xptr2->texts[h];
+        for (std::size_t i = 0; i < text.size(); i++) {
+            if (text[i] != 0)
+                text[i] += V;
         }
+        texts[G + h] = text;
     }
 #endif
-
-    Texts temp;
-    temp.reserve(xptr1->texts.size() + texts.size());
-    temp.insert(temp.end(), xptr1->texts.begin(), xptr1->texts.end());
-    temp.insert(temp.end(), texts.begin(), texts.end());
+    //dev::stop_timer("Shift", timer);
     
-    TokensObj *ptr = new TokensObj(temp, types, false);
+    TokensObj *ptr = new TokensObj(texts, types, false);
     return TokensPtr(ptr, true);
 }
 


### PR DESCRIPTION
I noticed that `vector.insert()` is taking long time. This change will make the `c` operation on tokens significantly faster. 