### PR TITLE
Replace remove_unigram with match_pattern

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,9 @@
 
 * Further improve the verbose messages for corpus, tokens, dfm and fcm objects.
 
+* Changes to dfm_select() now include new arguments `match_pattern` and `concatenator`, to control how single-word patterns or multi-word patterns
+  and multi-word patterns matched, as well as controlling the concatenator that binds phrases in the pattern.
+
 # quanteda 4.2.0
 
 ## Changes and additions

--- a/R/char_select.R
+++ b/R/char_select.R
@@ -51,7 +51,8 @@ char_select.character <- function(x, pattern, selection = c("keep", "remove"),
     ids <- object2id(pattern, types = x, 
                      valuetype = valuetype, 
                      case_insensitive = case_insensitive,
-                     concatenator = " ")
+                     concatenator = " ",
+                     match_pattern = "single")
     id <- unlist_integer(ids)
     
     if (selection == "keep") {

--- a/R/dfm_lookup.R
+++ b/R/dfm_lookup.R
@@ -103,7 +103,9 @@ dfm_lookup.dfm <- function(x, dictionary, levels = 1:5,
              if (length(dictionary) > 1L) "s" else "", "\n", sep = "")
 
     ids <- object2id(dictionary, type, valuetype, case_insensitive,
-                     field_object(attrs, "concatenator"), levels)
+                     concatenator = field_object(attrs, "concatenator"), 
+                     levels = levels,
+                     match_pattern = "single")
     
     # flag nested patterns
     if (length(ids)) {

--- a/R/dfm_select.R
+++ b/R/dfm_select.R
@@ -116,7 +116,9 @@ dfm_select.dfm <-  function(x, pattern = NULL,
                 field_object(attrs, "concatenator")
             )
         }
-        ids_pat <- pattern2id(pattern, feat, valuetype, case_insensitive)
+        ids_pat <- object2id(pattern, feat, valuetype, case_insensitive,
+                             concatenator = field_object(attrs, "concatenator"),
+                             match_pattern = "single")
         id_pat <- unlist_integer(ids_pat, unique = TRUE, use.names = FALSE)
         if ("" %in% feat) id_pat[id_pat == 0] <- 1L
     }

--- a/R/index.R
+++ b/R/index.R
@@ -33,8 +33,8 @@ index.tokens_xptr <- function(x, pattern,
     
     attrs <- attributes(x)
     type <- get_types(x)
-    ids <- object2id(pattern, type, valuetype,
-                     case_insensitive, field_object(attrs, "concatenator"))
+    ids <- object2id(pattern, type, valuetype, case_insensitive, 
+                     concatenator = field_object(attrs, "concatenator"))
     result <- cpp_index(x, ids, get_threads())
     result$docname <- docnames(x)[result$docname]
     result$pattern <- factor(names(ids)[result$pattern], levels = unique(names(ids)))

--- a/R/tokens_compound.R
+++ b/R/tokens_compound.R
@@ -112,7 +112,9 @@ tokens_compound.tokens_xptr <- function(x, pattern,
     attrs <- attributes(x)
     type <- get_types(x)
 
-    ids <- object2id(pattern, type, valuetype, case_insensitive, remove_unigram = all(window == 0))
+    ids <- object2id(pattern, type, valuetype, case_insensitive, 
+                     concatenator = field_object(attrs, "concatenator"),
+                     match_pattern = if (all(window == 0)) "multi" else "any")
     if (length(window) == 1) window <- rep(window, 2)
     if (is.null(apply_if))
         apply_if <- rep(TRUE, length.out = ndoc(x))

--- a/R/tokens_lookup.R
+++ b/R/tokens_lookup.R
@@ -160,7 +160,8 @@ tokens_lookup.tokens_xptr <- function(x, dictionary, levels = 1:5,
     attrs <- attributes(x)
     type <- get_types(x)
     ids <- object2id(dictionary, type, valuetype, case_insensitive,
-                     field_object(attrs, "concatenator"), levels)
+                     concatenator = field_object(attrs, "concatenator"), 
+                     levels = levels)
     overlap <- match(nested_scope, c("key", "dictionary"))
     if (is.null(apply_if))
         apply_if <- rep(TRUE, length.out = ndoc(x))

--- a/R/tokens_replace.R
+++ b/R/tokens_replace.R
@@ -73,8 +73,10 @@ tokens_replace.tokens_xptr <- function(x, pattern, replacement, valuetype = "glo
     if (verbose)
         before <- stats_tokens(x)
     
-    ids_pat <- object2id(pattern, type, valuetype, case_insensitive, conc, keep_nomatch = FALSE)
-    ids_rep <- object2id(replacement, type, "fixed", FALSE, conc, keep_nomatch = TRUE)
+    ids_pat <- object2id(pattern, type, valuetype, case_insensitive, 
+                         concatenator = conc, keep_nomatch = FALSE)
+    ids_rep <- object2id(replacement, type, "fixed", FALSE, 
+                         concatenator = conc, keep_nomatch = TRUE)
     set_types(x) <- type
     
     result <- cpp_tokens_replace(x, ids_pat, ids_rep[attr(ids_pat, "pattern")], !apply_if,

--- a/R/tokens_segment.R
+++ b/R/tokens_segment.R
@@ -80,7 +80,7 @@ tokens_segment.tokens_xptr <- function(x, pattern,
     type <- get_types(x)
 
     ids <- object2id(pattern, type, valuetype, case_insensitive,
-                        field_object(attrs, "concatenator"))
+                     concatenator = field_object(attrs, "concatenator"))
     if ("" %in% pattern) ids <- c(ids, list(0)) # append padding index
     
     if (verbose)

--- a/R/tokens_select.R
+++ b/R/tokens_select.R
@@ -161,7 +161,7 @@ tokens_select.tokens_xptr <- function(x, pattern = NULL,
         }
     } else {
         ids <- object2id(pattern, type, valuetype, case_insensitive,
-                         field_object(attrs, "concatenator"))
+                         concatenator = field_object(attrs, "concatenator"))
     }
 
     # selection by nchar

--- a/man/object2id.Rd
+++ b/man/object2id.Rd
@@ -12,7 +12,7 @@ object2id(
   case_insensitive = TRUE,
   concatenator = "_",
   levels = 1,
-  remove_unigram = FALSE,
+  match_only = NULL,
   keep_nomatch = FALSE
 )
 
@@ -23,7 +23,7 @@ object2fixed(
   case_insensitive = TRUE,
   concatenator = "_",
   levels = 1,
-  remove_unigram = FALSE,
+  match_only = NULL,
   keep_nomatch = FALSE
 )
 }
@@ -49,7 +49,8 @@ levels are not contiguous, e.g. \code{levels = c(1:3)} will collapse the second
 level into the first, but record the third level (if present) collapsed
 below the first (see examples).}
 
-\item{remove_unigram}{if \code{TRUE}, ignores single-word patterns}
+\item{match_only}{select only unigrams ("unigrams") or n-grams ("ngrams")
+should be matched. If \code{NULL}, it matches both unigrams and n-grams.}
 
 \item{keep_nomatch}{keep patterns that did not match}
 }
@@ -71,7 +72,8 @@ dict <- dictionary(list(A = c("a", "aa"),
                         B = c("BB", "B B"),
                         C = c("C", "C-C")))
 object2fixed(dict, types)
-object2fixed(dict, types, remove_unigram = TRUE)
+object2fixed(dict, types, match_only = "unigrams")
+object2fixed(dict, types, match_only = "ngrams")
 
 # phrase
 pats <- phrase(c("a", "aa", "zz", "bb", "b b"))

--- a/man/object2id.Rd
+++ b/man/object2id.Rd
@@ -12,7 +12,7 @@ object2id(
   case_insensitive = TRUE,
   concatenator = "_",
   levels = 1,
-  match_only = NULL,
+  match_pattern = c("any", "single", "multi"),
   keep_nomatch = FALSE
 )
 
@@ -23,7 +23,7 @@ object2fixed(
   case_insensitive = TRUE,
   concatenator = "_",
   levels = 1,
-  match_only = NULL,
+  match_pattern = c("any", "single", "multi"),
   keep_nomatch = FALSE
 )
 }
@@ -49,8 +49,8 @@ levels are not contiguous, e.g. \code{levels = c(1:3)} will collapse the second
 level into the first, but record the third level (if present) collapsed
 below the first (see examples).}
 
-\item{match_only}{select only unigrams ("unigrams") or n-grams ("ngrams")
-should be matched. If \code{NULL}, it matches both unigrams and n-grams.}
+\item{match_pattern}{select only single-word patterns or multi-word patterns
+should be matched. If "any", it matches both single-word and multi-word patterns.}
 
 \item{keep_nomatch}{keep patterns that did not match}
 }
@@ -72,8 +72,8 @@ dict <- dictionary(list(A = c("a", "aa"),
                         B = c("BB", "B B"),
                         C = c("C", "C-C")))
 object2fixed(dict, types)
-object2fixed(dict, types, match_only = "unigrams")
-object2fixed(dict, types, match_only = "ngrams")
+object2fixed(dict, types, match_pattern = "single")
+object2fixed(dict, types, match_pattern = "multi")
 
 # phrase
 pats <- phrase(c("a", "aa", "zz", "bb", "b b"))

--- a/tests/testthat/test-dfm_select.R
+++ b/tests/testthat/test-dfm_select.R
@@ -187,27 +187,31 @@ test_that("dfm_remove works even when it does not remove anything, issue 711", {
 
 test_that("dfm_select errors when dictionary has multi-word features, issue 775", {
     dfmt <- dfm(tokens(data_corpus_inaugural[50:58]))
+    
+    # with the default separator
     testdict1 <- dictionary(list(eco = c("compan*", "factory worker*"),
                                  pol = c("political part*", "election*")),
                             separator = " ")
-    testdict2 <- dictionary(list(eco = c("compan*", "factory_worker"),
-                                 pol = c("political_part*", "election*")),
-                            separator = "_")
     expect_equal(
         featnames(dfm_select(dfmt, pattern = testdict1, valuetype = "glob")),
         c("election", "elections", "company", "companies")
     )
     expect_equal(
         featnames(dfm_select(dfmt, pattern = phrase(testdict1), valuetype = "glob")),
-        c("political", "election", "part", "parties", "elections", "partisan", "company", "participation", "party", "partisanship", "partial", "companies")
+        c("election", "elections", "company", "companies")
     )
+    
+    # with a different separator
+    testdict2 <- dictionary(list(eco = c("compan*", "factory_worker"),
+                                 pol = c("political_part*", "election*")),
+                            separator = "_")
     expect_equal(
         featnames(dfm_select(dfmt, pattern = testdict2, valuetype = "glob")),
         c("election", "elections", "company", "companies")
     )
     expect_equal(
         featnames(dfm_select(dfmt, pattern = phrase(testdict2), valuetype = "glob")),
-        c("political", "election", "part", "parties", "elections", "partisan", "company", "participation", "party", "partisanship", "partial", "companies")
+        c("election", "elections", "company", "companies")
     )
 })
 

--- a/tests/testthat/test-object2fixed.R
+++ b/tests/testthat/test-object2fixed.R
@@ -22,6 +22,28 @@ test_that("object2id is working with a list", {
     attr(lis3, "pattern") <- c(1, 2, 3, 4, 5)
     expect_equal(ids3, lis3)
     
+    ids4 <- quanteda:::object2id(phrase(pat), types = letters, 
+                                 valuetype = 'fixed', case_insensitive = TRUE,
+                                 match_pattern = "single")
+    lis4 <- list("A" = 1)
+    attr(lis4, "pattern") <- c(1)
+    expect_equal(ids4, lis4)
+    
+    ids5 <- quanteda:::object2id(phrase(pat), types = letters, 
+                                 valuetype = 'fixed', case_insensitive = TRUE,
+                                 match_pattern = "multi")
+    lis5 <- list("a b" = c(1, 2), "C D" = c(3, 4),
+                 "e f g" = c(5, 6, 7))
+    attr(lis5, "pattern") <- c(1, 2, 3)
+    expect_equal(ids5, lis5)
+    
+    expect_error(
+        quanteda:::object2id(phrase(pat), types = letters, 
+                             match_pattern = "bigrams"),
+        '\'arg\' should be one of "any", "single", "multi"',
+        fixed = TRUE
+    )
+    
 })
 
 test_that("object2id is working with a list", {


### PR DESCRIPTION
Address #2400. This slightly changes the behaviour of `dfm_select()` when `phrase()` is applied to `pattern`. I think the new behaviour is more correct.