### PR TITLE
Annotation mode in tokens_lookup()

### DIFF
--- a/R/tokens_lookup.R
+++ b/R/tokens_lookup.R
@@ -105,6 +105,7 @@ tokens_lookup <- function(x, dictionary, levels = 1:5,
                           nomatch = NULL,
                           append_key = FALSE,
                           separator = "/",
+                          annotate = FALSE,
                           concatenator = concat(x),
                           nested_scope = c("key", "dictionary"),
                           apply_if = NULL,
@@ -121,6 +122,7 @@ tokens_lookup.default <- function(x, dictionary, levels = 1:5,
                                  nomatch = NULL,
                                  append_key = FALSE,
                                  separator = "/",
+                                 annotate = FALSE,
                                  concatenator = concat(x),
                                  nested_scope = c("key", "dictionary"),
                                  apply_if = NULL,
@@ -137,6 +139,7 @@ tokens_lookup.tokens_xptr <- function(x, dictionary, levels = 1:5,
                           nomatch = NULL,
                           append_key = FALSE,
                           separator = "/",
+                          annotate = FALSE,
                           concatenator = concat(x),
                           nested_scope = c("key", "dictionary"),
                           apply_if = NULL,
@@ -197,8 +200,13 @@ tokens_lookup.tokens_xptr <- function(x, dictionary, levels = 1:5,
         if (!is.null(nomatch))
             warning("nomatch only applies if exclusive = TRUE")
         id_used <- unique(id_key)
-        result <- cpp_tokens_lookup(x, ids, match(id_key, id_used), key[id_used], overlap, 2,
-                                    !apply_if, get_threads())
+        if (!annotate) { 
+            result <- cpp_tokens_lookup(x, ids, match(id_key, id_used), key[id_used], overlap, 2,
+                                        !apply_if, get_threads())
+        } else {
+            result <- cpp_tokens_lookup(x, ids, match(id_key, id_used), key[id_used], overlap, 3,
+                                        !apply_if, get_threads())
+        }
     }
     if (append_key)
         cpp_recompile(result)

--- a/man/tokens_lookup.Rd
+++ b/man/tokens_lookup.Rd
@@ -15,6 +15,7 @@ tokens_lookup(
   nomatch = NULL,
   append_key = FALSE,
   separator = "/",
+  annotate = FALSE,
   concatenator = concat(x),
   nested_scope = c("key", "dictionary"),
   apply_if = NULL,

--- a/src/tokens_lookup.cpp
+++ b/src/tokens_lookup.cpp
@@ -77,7 +77,7 @@ Text lookup(Text tokens,
             // return tokens with no-match
             Text keys_flat(tokens.size(), id_max); 
             return keys_flat;
-        } else if (nomatch == 2) {
+        } else if (nomatch == 2 || nomatch == 3) {
             // return shifted tokens in exclusive mode
             Text keys_flat(tokens.size());
             for (std::size_t i = 0; i < tokens.size(); i++) {
@@ -99,6 +99,8 @@ Text lookup(Text tokens,
         keys_flat.reserve(match_count);
     }
     for (size_t i = 0; i < keys.size(); i++) {
+        if (nomatch == 3)
+            keys_flat.push_back(id_max + tokens[i]); // keep original token always
         if (flags_match_global[i]) {
             std::vector<unsigned int> key_sub = keys[i];
             if (key_sub.size() > 1) {
@@ -153,7 +155,7 @@ TokensPtr cpp_tokens_lookup(TokensPtr xptr,
     
     std::vector<unsigned int> keys = Rcpp::as< std::vector<unsigned int> >(keys_);
     unsigned int id_max = 0;
-    if (nomatch == 2) {
+    if (nomatch == 2 || nomatch == 3) {
         types.insert(types.end(), xptr->types.begin(), xptr->types.end());
         if (keys_.size() > 0)
             id_max = *max_element(keys.begin(), keys.end());
@@ -198,7 +200,7 @@ TokensPtr cpp_tokens_lookup(TokensPtr xptr,
     xptr->texts = texts;
     xptr->types = types;
     
-    if (nomatch != 2) { // exclusive mode
+    if (nomatch == 0 || nomatch == 1) { // exclusive mode
         // NOTE: values might need to be reset
         xptr->recompiled = true;
     } else {


### PR DESCRIPTION
@kbenoit how about adding something like this? We can achieve this with minimal changes in the C++ code.  

```r
> dict <- dictionary(list("negation" = c("no", "not")))
> toks <- tokens("No! This is not good.")

# annotation mode
> tokens_lookup(toks, dict,  exclusive = FALSE, annotate = TRUE)
Tokens consisting of 1 document.
text1 :
[1] "No"       "NEGATION" "!"        "This"     "is"       "not"      "NEGATION" "good"     "."       

# current non-exclusive mode
> tokens_lookup(toks, dict,  exclusive = FALSE, annotate = FALSE)
Tokens consisting of 1 document.
text1 :
[1] "NEGATION" "!"        "This"     "is"       "NEGATION" "good"     "."  
```

It would be more useful if it is like this for languages without cases.

```r
> tokens_lookup(toks, dict,  exclusive = FALSE, annotate = TRUE)
Tokens consisting of 1 document.
text1 :
[1] "No"       "<NEGATION>" "!"        "This"     "is"       "not"      "<NEGATION>" "good"     "." 
```

I am not sure how about the argument yet. This might be better.

```r
tokens_lookup(x, dictionary, mode = c("exclusive", "non-exclusive", "annotation"))
```
More radially
```r
tokens_annotate(x, dictionary)
```