### PR TITLE
Add max_n to dfm_trim() and tokens_trim()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,8 @@
 * Added `docvars()` and `docvars<-()` methods for `tokens_xptr` objects,
   allowing document variables to be read and assigned without recompiling the
   tokens. (#2497)
+  
+* Add `max_n` to limit the number of features in dfm and tokens (#2496).
 
 # quanteda 4.4
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,9 @@
 
 * Add the `drop0()` method for dfm and fcm (#2460).
 
+* Added the `max_n` argument to `dfm_trim()` and `tokens_trim()` to keep only
+  the most frequent features, with ties broken by feature order. (#2496)
+
 # quanteda 4.4
 
 ## Changes and additions

--- a/R/corpus_segment.R
+++ b/R/corpus_segment.R
@@ -92,8 +92,7 @@
 #'                            pattern_position = "after", extract_pattern = FALSE)
 #' cbind(corpseg3, docvars(corpseg3))
 #' 
-#' @importFrom stringi stri_trim_both stri_replace_all_fixed stri_locate_last_fixed 
-#'   stri_locate_first_fixed stri_sub
+#' @importFrom stringi stri_trim_both stri_replace_all_fixed stri_locate_last_fixed stri_locate_first_fixed stri_sub
 #' @export
 corpus_segment <- function(x, pattern = "##*",
                            valuetype = c("glob", "regex", "fixed"),

--- a/R/dfm_trim.R
+++ b/R/dfm_trim.R
@@ -32,7 +32,7 @@
 #'   highest document frequencies, and so on; `"quantile"` sets the cutoffs
 #'   according to the quantiles (see [quantile()]) of document
 #'   frequencies.
-#' @param max_n the maximum number of the feature. Features are selected based 
+#' @param max_n the maximum number of features. Features are selected based 
 #'   on their frequencies, but the earlier elements in [featnames] or [types] 
 #'   are chosen when the frequencies are equal.
 #' @param sparsity equivalent to `1 - min_docfreq`, included for comparison

--- a/R/dfm_trim.R
+++ b/R/dfm_trim.R
@@ -32,6 +32,9 @@
 #'   highest document frequencies, and so on; `"quantile"` sets the cutoffs
 #'   according to the quantiles (see [quantile()]) of document
 #'   frequencies.
+#' @param max_n the maximum number of the feature. Features are selected based 
+#'   on their frequencies, but the earlier elements in [featnames] or [types] 
+#'   are chosen when the frequencies are equal.
 #' @param sparsity equivalent to `1 - min_docfreq`, included for comparison
 #'   with \pkg{tm}
 #' @inheritParams messages
@@ -75,6 +78,7 @@ dfm_trim <- function(x,
                      termfreq_type = c("count", "prop", "rank", "quantile"),
                      min_docfreq = NULL, max_docfreq = NULL, 
                      docfreq_type = c("count", "prop", "rank", "quantile"),
+                     max_n = NULL,
                      sparsity = NULL,
                      verbose = quanteda_options("verbose")) {
     UseMethod("dfm_trim")
@@ -86,6 +90,7 @@ dfm_trim.default <- function(x,
                              termfreq_type = c("count", "prop", "rank", "quantile"),
                              min_docfreq = NULL, max_docfreq = NULL,
                              docfreq_type = c("count", "prop", "rank", "quantile"),
+                             max_n = NULL,
                              sparsity = NULL,
                              verbose = quanteda_options("verbose")) {
     check_class(class(x), "dfm_trim")
@@ -97,6 +102,7 @@ dfm_trim.dfm <- function(x,
                          termfreq_type = c("count", "prop", "rank", "quantile"),
                          min_docfreq = NULL, max_docfreq = NULL,
                          docfreq_type = c("count", "prop", "rank", "quantile"),
+                         max_n = NULL,
                          sparsity = NULL,
                          verbose = quanteda_options("verbose")) {
 
@@ -128,7 +134,8 @@ dfm_trim.dfm <- function(x,
     
     f <- trim_features(colSums(x), docfreq(x), ndoc(x),
                        min_termfreq, max_termfreq, termfreq_type, 
-                       min_docfreq, max_docfreq, docfreq_type)
+                       min_docfreq, max_docfreq, docfreq_type, 
+                       max_n)
     
     if (verbose)
         before <- stats_dfm(x)
@@ -141,7 +148,8 @@ dfm_trim.dfm <- function(x,
 
 trim_features <- function(termfreq, docfreq, n,
                           min_termfreq, max_termfreq, termfreq_type, 
-                          min_docfreq, max_docfreq, docfreq_type) {
+                          min_docfreq, max_docfreq, docfreq_type,
+                          max_n) {
     
     s <- sum(termfreq)
     if (termfreq_type == "count") {
@@ -256,5 +264,10 @@ trim_features <- function(termfreq, docfreq, n,
     b4 <- docfreq > max_docfreq
     b <- b1 | b2 | b3 | b4
     
-    return(names(b[!b]))
+    f <- termfreq[!b]
+    if (!is.null(max_n)) {
+        max_n <- check_integer(max_n, min = 0)
+        f <- f[head(order(f, decreasing = TRUE), max_n)]
+    }
+    return(names(f))
 }

--- a/R/dictionaries.R
+++ b/R/dictionaries.R
@@ -938,8 +938,7 @@ nest_dictionary <- function(dict, depth) {
 #' @rdname read_dict_functions
 #' @description `read_dict_liwc` imports LIWC dictionary files in the
 #'   `.dic` format.
-#' @importFrom stringi stri_extract_first_regex stri_extract_last_regex stri_replace_first_regex
-#' stri_read_lines stri_extract_first_regex
+#' @importFrom stringi stri_extract_first_regex stri_extract_last_regex stri_replace_first_regex stri_read_lines
 #' @examples
 #'
 #' dict <- quanteda:::read_dict_liwc(

--- a/R/tokenizers.R
+++ b/R/tokenizers.R
@@ -289,8 +289,7 @@ breakrules_reset <- function(what = c("word", "sentence")) {
 
 #' @rdname tokenize_internal
 #' @inheritParams tokens
-#' @importFrom stringi stri_detect_regex stri_detect_charclass
-#'   stri_replace_all_regex stri_detect_fixed stri_replace_all_fixed
+#' @importFrom stringi stri_replace_all_regex stri_split_boundaries
 #' @export
 tokenize_word1 <- function(x, split_hyphens = FALSE, verbose = quanteda_options("verbose"), ...) {
 
@@ -341,8 +340,7 @@ tokenize_character <- function(x, ...) {
 }
 
 #' @rdname tokenize_internal
-#' @importFrom stringi stri_replace_all_regex stri_replace_all_fixed
-#'   stri_split_boundaries stri_trim_right
+#' @importFrom stringi stri_replace_all_regex stri_split_boundaries stri_trim_right
 #' @export
 tokenize_sentence <- function(x, verbose = FALSE, ...) {
     if (verbose) catm(" ...segmenting into sentences\n")

--- a/R/tokens_trim.R
+++ b/R/tokens_trim.R
@@ -27,6 +27,7 @@ tokens_trim <- function(x,
                      termfreq_type = c("count", "prop", "rank", "quantile"),
                      min_docfreq = NULL, max_docfreq = NULL, 
                      docfreq_type = c("count", "prop", "rank", "quantile"),
+                     max_n = NULL,
                      padding = FALSE,
                      verbose = quanteda_options("verbose")) {
     UseMethod("tokens_trim")
@@ -38,6 +39,7 @@ tokens_trim.default <- function(x,
                              termfreq_type = c("count", "prop", "rank", "quantile"),
                              min_docfreq = NULL, max_docfreq = NULL,
                              docfreq_type = c("count", "prop", "rank", "quantile"),
+                             max_n = NULL,
                              padding = FALSE,
                              verbose = quanteda_options("verbose")) {
     check_class(class(x), "tokens_trim")
@@ -49,6 +51,7 @@ tokens_trim.tokens_xptr <- function(x,
                                     termfreq_type = c("count", "prop", "rank", "quantile"),
                                     min_docfreq = NULL, max_docfreq = NULL,
                                     docfreq_type = c("count", "prop", "rank", "quantile"),
+                                    max_n = NULL,
                                     padding = FALSE,
                                     verbose = quanteda_options("verbose")) {
     
@@ -60,7 +63,8 @@ tokens_trim.tokens_xptr <- function(x,
                        cpp_get_freq(x, no_padding = TRUE, boolean = TRUE),
                        cpp_ndoc(x),
                        min_termfreq, max_termfreq, termfreq_type, 
-                       min_docfreq, max_docfreq, docfreq_type)
+                       min_docfreq, max_docfreq, docfreq_type,
+                       max_n)
 
     result <- tokens_select(x, f, valuetype = "fixed", case_insensitive = FALSE,
                             padding = padding, verbose = FALSE)

--- a/man/dfm-class.Rd
+++ b/man/dfm-class.Rd
@@ -22,13 +22,13 @@
 \usage{
 \S4method{t}{dfm}(x)
 
-\S4method{colSums}{dfm}(x, na.rm = FALSE, dims = 1L, ...)
+\S4method{colSums}{dfm}(x, na.rm = FALSE, dims = 1, ...)
 
-\S4method{rowSums}{dfm}(x, na.rm = FALSE, dims = 1L, ...)
+\S4method{rowSums}{dfm}(x, na.rm = FALSE, dims = 1, ...)
 
-\S4method{colMeans}{dfm}(x, na.rm = FALSE, dims = 1L, ...)
+\S4method{colMeans}{dfm}(x, na.rm = FALSE, dims = 1, ...)
 
-\S4method{rowMeans}{dfm}(x, na.rm = FALSE, dims = 1L, ...)
+\S4method{rowMeans}{dfm}(x, na.rm = FALSE, dims = 1, ...)
 
 \S4method{Arith}{dfm,numeric}(e1, e2)
 

--- a/man/dfm-class.Rd
+++ b/man/dfm-class.Rd
@@ -23,13 +23,13 @@
 \usage{
 \S4method{t}{dfm}(x)
 
-\S4method{colSums}{dfm}(x, na.rm = FALSE, dims = 1, ...)
+\S4method{colSums}{dfm}(x, na.rm = FALSE, dims = 1L, ...)
 
-\S4method{rowSums}{dfm}(x, na.rm = FALSE, dims = 1, ...)
+\S4method{rowSums}{dfm}(x, na.rm = FALSE, dims = 1L, ...)
 
-\S4method{colMeans}{dfm}(x, na.rm = FALSE, dims = 1, ...)
+\S4method{colMeans}{dfm}(x, na.rm = FALSE, dims = 1L, ...)
 
-\S4method{rowMeans}{dfm}(x, na.rm = FALSE, dims = 1, ...)
+\S4method{rowMeans}{dfm}(x, na.rm = FALSE, dims = 1L, ...)
 
 \S4method{Arith}{dfm,numeric}(e1, e2)
 

--- a/man/dfm_trim.Rd
+++ b/man/dfm_trim.Rd
@@ -12,6 +12,7 @@ dfm_trim(
   min_docfreq = NULL,
   max_docfreq = NULL,
   docfreq_type = c("count", "prop", "rank", "quantile"),
+  max_n = NULL,
   sparsity = NULL,
   verbose = quanteda_options("verbose")
 )
@@ -41,6 +42,10 @@ frequency, so that 1, 2, ... are the features with the highest and second
 highest document frequencies, and so on; \code{"quantile"} sets the cutoffs
 according to the quantiles (see \code{\link[=quantile]{quantile()}}) of document
 frequencies.}
+
+\item{max_n}{the maximum number of features. Features are selected based
+on their frequencies, but the earlier elements in \link{featnames} or \link{types}
+are chosen when the frequencies are equal.}
 
 \item{sparsity}{equivalent to \code{1 - min_docfreq}, included for comparison
 with \pkg{tm}}

--- a/man/tokens_trim.Rd
+++ b/man/tokens_trim.Rd
@@ -12,6 +12,7 @@ tokens_trim(
   min_docfreq = NULL,
   max_docfreq = NULL,
   docfreq_type = c("count", "prop", "rank", "quantile"),
+  max_n = NULL,
   padding = FALSE,
   verbose = quanteda_options("verbose")
 )
@@ -41,6 +42,10 @@ frequency, so that 1, 2, ... are the features with the highest and second
 highest document frequencies, and so on; \code{"quantile"} sets the cutoffs
 according to the quantiles (see \code{\link[=quantile]{quantile()}}) of document
 frequencies.}
+
+\item{max_n}{the maximum number of features. Features are selected based
+on their frequencies, but the earlier elements in \link{featnames} or \link{types}
+are chosen when the frequencies are equal.}
 
 \item{padding}{if \code{TRUE}, leave an empty string where the removed tokens
 previously existed.}

--- a/tests/testthat/test-dfm_trim.R
+++ b/tests/testthat/test-dfm_trim.R
@@ -1,38 +1,42 @@
 test_that("dfm_trim works", {
-    mydfm <- dfm(tokens(c(d1 = "a b c d e", d2 = "a a b b e f", d3 = "b c e e f f f")))
-    s <- sum(mydfm)
+    dfmt <- dfm(tokens(c(d1 = "a b c d e", d2 = "a a b b e f", d3 = "b c e e f f f")))
+    s <- sum(dfmt)
     
-    expect_equal(nfeat(dfm_trim(mydfm, min_termfreq = 0.5, termfreq_type = "quantile")), 4)
-    expect_equal(nfeat(dfm_trim(mydfm, min_termfreq = 3 / s, termfreq_type = "prop")), 4)
-    expect_equal(nfeat(dfm_trim(mydfm, min_termfreq = 3)), 4)
+    expect_equal(nfeat(dfm_trim(dfmt, min_termfreq = 0.5, termfreq_type = "quantile")), 4)
+    expect_equal(nfeat(dfm_trim(dfmt, min_termfreq = 3 / s, termfreq_type = "prop")), 4)
+    expect_equal(nfeat(dfm_trim(dfmt, min_termfreq = 3)), 4)
     
-    expect_equal(nfeat(dfm_trim(mydfm, max_termfreq = 0.8, termfreq_type = "quantile")), 6)
-    expect_equal(nfeat(dfm_trim(mydfm, max_termfreq = 4 / s, termfreq_type = "prop")), 6)
-    expect_equal(nfeat(dfm_trim(mydfm, max_termfreq = 4)), 6)
+    expect_equal(nfeat(dfm_trim(dfmt, max_termfreq = 0.8, termfreq_type = "quantile")), 6)
+    expect_equal(nfeat(dfm_trim(dfmt, max_termfreq = 4 / s, termfreq_type = "prop")), 6)
+    expect_equal(nfeat(dfm_trim(dfmt, max_termfreq = 4)), 6)
 
-    expect_equal(nfeat(dfm_trim(mydfm, min_docfreq = 0.5, docfreq_type = "quantile")), 5)
-    expect_equal(nfeat(dfm_trim(mydfm, min_docfreq = 2 / 3, docfreq_type = "prop")), 5)
-    expect_equal(nfeat(dfm_trim(mydfm, min_docfreq = 2)), 5)
+    expect_equal(nfeat(dfm_trim(dfmt, min_docfreq = 0.5, docfreq_type = "quantile")), 5)
+    expect_equal(nfeat(dfm_trim(dfmt, min_docfreq = 2 / 3, docfreq_type = "prop")), 5)
+    expect_equal(nfeat(dfm_trim(dfmt, min_docfreq = 2)), 5)
     
-    expect_equal(nfeat(dfm_trim(mydfm, max_docfreq = 0.5, docfreq_type = "quantile")), 4)
-    expect_equal(nfeat(dfm_trim(mydfm, max_docfreq = 2 / 3, docfreq_type = "prop")), 4)
-    expect_equal(nfeat(dfm_trim(mydfm, max_docfreq = 2)), 4)
+    expect_equal(nfeat(dfm_trim(dfmt, max_docfreq = 0.5, docfreq_type = "quantile")), 4)
+    expect_equal(nfeat(dfm_trim(dfmt, max_docfreq = 2 / 3, docfreq_type = "prop")), 4)
+    expect_equal(nfeat(dfm_trim(dfmt, max_docfreq = 2)), 4)
     
-    expect_equal(nfeat(dfm_trim(mydfm, min_termfreq = 2, termfreq_type = "rank")), 3)
-    expect_equal(nfeat(dfm_trim(mydfm, min_termfreq = 4)), 3)
+    expect_equal(nfeat(dfm_trim(dfmt, min_termfreq = 2, termfreq_type = "rank")), 3)
+    expect_equal(nfeat(dfm_trim(dfmt, min_termfreq = 4)), 3)
     
-    expect_equal(nfeat(dfm_trim(mydfm, max_termfreq = 4, termfreq_type = "rank")), 3)
-    expect_equal(nfeat(dfm_trim(mydfm, max_termfreq = 3)), 3)
+    expect_equal(nfeat(dfm_trim(dfmt, max_termfreq = 4, termfreq_type = "rank")), 3)
+    expect_equal(nfeat(dfm_trim(dfmt, max_termfreq = 3)), 3)
     
-    expect_equal(nfeat(dfm_trim(mydfm, min_docfreq = 1, docfreq_type = "rank")), 2)
-    expect_equal(nfeat(dfm_trim(mydfm, min_docfreq = 3)), 2)
+    expect_equal(nfeat(dfm_trim(dfmt, min_docfreq = 1, docfreq_type = "rank")), 2)
+    expect_equal(nfeat(dfm_trim(dfmt, min_docfreq = 3)), 2)
     
-    expect_equal(nfeat(dfm_trim(mydfm, max_docfreq = 2, docfreq_type = "rank")), 4)
-    expect_equal(nfeat(dfm_trim(mydfm, max_docfreq = 2)), 4)
+    expect_equal(nfeat(dfm_trim(dfmt, max_docfreq = 2, docfreq_type = "rank")), 4)
+    expect_equal(nfeat(dfm_trim(dfmt, max_docfreq = 2)), 4)
     
-    expect_equal(nfeat(dfm_trim(mydfm, sparsity = 0.0)), 2)
-    expect_equal(nfeat(dfm_trim(mydfm, sparsity = 0.5)), 5)
-    expect_equal(nfeat(dfm_trim(mydfm, sparsity = 1.0)), 6)
+    expect_equal(nfeat(dfm_trim(dfmt, sparsity = 0.0)), 2)
+    expect_equal(nfeat(dfm_trim(dfmt, sparsity = 0.5)), 5)
+    expect_equal(nfeat(dfm_trim(dfmt, sparsity = 1.0)), 6)
+    
+    expect_equal(featnames(dfm_trim(dfmt, max_n = 3)), c("b", "e", "f"))
+    expect_equal(nfeat(dfm_trim(dfmt, max_n = 4)), 4)
+    expect_equal(nfeat(dfm_trim(dfmt, max_termfreq = 3, max_n = 4)), 3)
     
 })
 
@@ -62,28 +66,28 @@ test_that("dfm_trim works", {
 # })
 
 test_that("dfm_trim works without trimming arguments #509", {
-    mydfm <- dfm(tokens(c("This is a sentence.", "This is a second sentence.", "Third sentence.")))
-    expect_equal(dim(mydfm[-2, ]), c(2, 7))
-    expect_equal(dim(dfm_trim(mydfm[-2, ], verbose = FALSE)), c(2, 6))
+    dfmt <- dfm(tokens(c("This is a sentence.", "This is a second sentence.", "Third sentence.")))
+    expect_equal(dim(dfmt[-2, ]), c(2, 7))
+    expect_equal(dim(dfm_trim(dfmt[-2, ], verbose = FALSE)), c(2, 6))
 })
 
 test_that("dfm_trim works with duplicated feature names (#829)", {
-    mydfm <- dfm(tokens(c(d1 = "a b c d e", d2 = "a a b b e f", d3 = "b c e e f f f")))
-    colnames(mydfm)[3] <- "b"
+    dfmt <- dfm(tokens(c(d1 = "a b c d e", d2 = "a a b b e f", d3 = "b c e e f f f")))
+    colnames(dfmt)[3] <- "b"
     expect_equal(
-        as.matrix(dfm_trim(mydfm, min_termfreq = 1)),
+        as.matrix(dfm_trim(dfmt, min_termfreq = 1)),
         matrix(c(1,1,1,1,1,0, 2,2,0,0,1,1, 0,1,1,0,2,3), byrow = TRUE, nrow = 3,
                dimnames = list(docs = c("d1", "d2", "d3"), 
                                features = c(letters[c(1,2,2,4:6)])))
     )
     expect_equal(
-        as.matrix(dfm_trim(mydfm, min_termfreq = 2)),
+        as.matrix(dfm_trim(dfmt, min_termfreq = 2)),
         matrix(c(1,1,1,1,0, 2,2,0,1,1, 0,1,1,2,3), byrow = TRUE, nrow = 3,
                dimnames = list(docs = c("d1", "d2", "d3"), 
                                features = c(letters[c(1,2,2,5:6)])))
     )
     # expect_equal(
-    #     as.matrix(dfm_trim(mydfm, min_termfreq = 3)),
+    #     as.matrix(dfm_trim(dfmt, min_termfreq = 3)),
     #     matrix(c(1,1,1,0, 2,2,1,1, 0,1,2,3), byrow = TRUE, nrow = 3,
     #            dimnames = list(docs = c("d1", "d2", "d3"), 
     #                            features = c(letters[c(1,2,5:6)])))
@@ -91,11 +95,11 @@ test_that("dfm_trim works with duplicated feature names (#829)", {
 })
 
 test_that("dfm_trim works with min_termfreq larger than total number (#1181)", {
-    testdfm <- dfm(tokens(c(d1 = "a a a a b b", d2 = "a b b c")))
-    expect_equal(dimnames(dfm_trim(testdfm, min_termfreq = 6)), 
+    dfmt <- dfm(tokens(c(d1 = "a a a a b b", d2 = "a b b c")))
+    expect_equal(dimnames(dfm_trim(dfmt, min_termfreq = 6)), 
                 list(docs = c("d1", "d2"), features = character())
     )
-    expect_equal(dimnames(dfm_trim(testdfm, min_docfreq = 3)), 
+    expect_equal(dimnames(dfm_trim(dfmt, min_docfreq = 3)), 
                  list(docs = c("d1", "d2"), features = character())
     )
 
@@ -204,6 +208,12 @@ test_that("dfm_trim error with invalid input", {
     expect_error(
         dfm_trim(dfmat, max_docfreq = 0, docfreq_type = "rank"),
         "The value of max_docfreq must be between 1 and Inf"
+    )
+    
+    # max_n
+    expect_error(
+        dfm_trim(dfmat, max_n = -1),
+        "The value of max_n must be between 0 and Inf"
     )
 })
 

--- a/tests/testthat/test-dfm_trim.R
+++ b/tests/testthat/test-dfm_trim.R
@@ -37,7 +37,10 @@ test_that("dfm_trim works", {
     expect_equal(featnames(dfm_trim(dfmt, max_n = 3)), c("b", "e", "f"))
     expect_equal(nfeat(dfm_trim(dfmt, max_n = 4)), 4)
     expect_equal(nfeat(dfm_trim(dfmt, max_termfreq = 3, max_n = 4)), 3)
-    
+    # ties (b, e, f all have frequency 4) are broken by feature order
+    expect_equal(featnames(dfm_trim(dfmt, max_n = 2)), c("b", "e"))
+    expect_equal(nfeat(dfm_trim(dfmt, max_n = 0)), 0)
+
 })
 
 # test_that("dfm_trim works as expected", {

--- a/tests/testthat/test-tokens_trim.R
+++ b/tests/testthat/test-tokens_trim.R
@@ -36,7 +36,9 @@ test_that("tokens_trim works", {
     expect_equal(types(tokens_trim(toks, max_n = 3)), c("b", "e", "f"))
     expect_equal(length(types(tokens_trim(toks, max_n = 4))), 4)
     expect_equal(length(types(tokens_trim(toks, max_termfreq = 3, max_n = 4))), 3)
-    
+    # ties (b, e, f all have frequency 4) are broken by type order
+    expect_equal(types(tokens_trim(toks, max_n = 2)), c("b", "e"))
+
 })
 
 test_that("tokens_trim works with padding", {

--- a/tests/testthat/test-tokens_trim.R
+++ b/tests/testthat/test-tokens_trim.R
@@ -33,6 +33,10 @@ test_that("tokens_trim works", {
     expect_equal(length(types(tokens_trim(toks, max_docfreq = 2, docfreq_type = "rank"))), 4)
     expect_equal(length(types(tokens_trim(toks, max_docfreq = 2))), 4)
     
+    expect_equal(types(tokens_trim(toks, max_n = 3)), c("b", "e", "f"))
+    expect_equal(length(types(tokens_trim(toks, max_n = 4))), 4)
+    expect_equal(length(types(tokens_trim(toks, max_termfreq = 3, max_n = 4))), 3)
+    
 })
 
 test_that("tokens_trim works with padding", {


### PR DESCRIPTION
For #2496

```r
> toks
Tokens consisting of 3 documents.
d1 :
[1] "a" "b" "c" "d" "e"

d2 :
[1] "a" "a" "b" "b" "e" "f"

d3 :
[1] "b" "c" "e" "e" "f" "f" "f"

> tokens_trim(toks, max_n = 4)
Tokens consisting of 3 documents.
d1 :
[1] "a" "b" "e"

d2 :
[1] "a" "a" "b" "b" "e" "f"

d3 :
[1] "b" "e" "e" "f" "f" "f"

> tokens_trim(toks, max_n = 3)
Tokens consisting of 3 documents.
d1 :
[1] "b" "e"

d2 :
[1] "b" "b" "e" "f"

d3 :
[1] "b" "e" "e" "f" "f" "f"

> tokens_trim(toks, max_n = 2)
Tokens consisting of 3 documents.
d1 :
[1] "b" "e"

d2 :
[1] "b" "b" "e"

d3 :
[1] "b" "e" "e"

> tokens_trim(toks, max_n = 1)
Tokens consisting of 3 documents.
d1 :
[1] "b"

d2 :
[1] "b" "b"

d3 :
[1] "b"

> tokens_trim(toks, max_n = 1, padding = TRUE)
Tokens consisting of 3 documents.
d1 :
[1] ""  "b" ""  ""  "" 

d2 :
[1] ""  ""  "b" "b" ""  "" 

d3 :
[1] "b" ""  ""  ""  ""  ""  ""
```